### PR TITLE
Add awesome-ai-startups to Related projects (zh-TW / zh-CN / en)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -205,6 +205,7 @@ Other lists in the same space — useful to browse alongside this repo when hunt
 - [`wong2/awesome-mcp-servers`](https://github.com/wong2/awesome-mcp-servers) — categorized MCP server catalog
 - [`punkpeye/awesome-mcp-servers`](https://github.com/punkpeye/awesome-mcp-servers) — another MCP server catalog
 - [`hesreallyhim/awesome-claude-code`](https://github.com/hesreallyhim/awesome-claude-code) — Claude Code tools & plugins list
+- [`nowork-studio/awesome-ai-startups`](https://github.com/nowork-studio/awesome-ai-startups) — curated list of bootstrapped, pre-seed, and angel-funded AI products built by independent founders
 
 These are pure catalogs (browse and pick). This repo is different in that it has a **learning order from Stage 0 all the way to production**.
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ PR 流程跟 style 規範請看 [CONTRIBUTING.md](CONTRIBUTING.md) 跟 [resource
 - [`wong2/awesome-mcp-servers`](https://github.com/wong2/awesome-mcp-servers) — MCP server 清單，按分類整理
 - [`punkpeye/awesome-mcp-servers`](https://github.com/punkpeye/awesome-mcp-servers) — 另一份 MCP server 清單
 - [`hesreallyhim/awesome-claude-code`](https://github.com/hesreallyhim/awesome-claude-code) — Claude Code 相關工具與 plugin 清單
+- [`nowork-studio/awesome-ai-startups`](https://github.com/nowork-studio/awesome-ai-startups) — 獨立開發者打造的 bootstrapped、pre-seed 與天使輪 AI 產品精選清單
 
 這些是純清單形式（看到再挑），本 repo 的不同點是有「**從 Stage 0 一路走到 production 的學習順序**」。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -248,6 +248,7 @@ PR 流程跟 style 规范请看 [CONTRIBUTING.md](CONTRIBUTING.md) 和 [resource
 - [`hesreallyhim/awesome-claude-code`](https://github.com/hesreallyhim/awesome-claude-code) — Claude Code 相关工具与 plugin 清单（整理中）
 - [`travisvn/awesome-claude-skills`](https://github.com/travisvn/awesome-claude-skills) — Claude Skills 清单
 - [`anthropics/claude-plugins-official`](https://github.com/anthropics/claude-plugins-official) — Anthropic 官方 plugin 模板，要打包自己的 plugin 从这份开始
+- [`nowork-studio/awesome-ai-startups`](https://github.com/nowork-studio/awesome-ai-startups) — 独立开发者打造的 bootstrapped、pre-seed 与天使轮 AI 产品精选清单
 
 这些是纯清单形式（看到再挑），本 repo 的不同点是有“从 Stage 0 一路走到 production 的学习顺序”。
 


### PR DESCRIPTION
新增一份相關清單到三份 README 的「Related projects / 其他相關專案 / 其他相关项目」區塊：

- [`nowork-studio/awesome-ai-startups`](https://github.com/nowork-studio/awesome-ai-startups) — 獨立開發者打造的 bootstrapped、pre-seed 與天使輪 AI 產品精選清單

格式跟現有條目一致（簡單 bullet + 短描述），三份語系版本同步更新。

Adds one curated list to the parallel "Related projects" sections in the zh-TW, zh-CN, and English READMEs. Format matches existing entries (simple bullet + short description).