### PR TITLE
catalog: add whale (DeepSeek terminal assistant) + a-stock-data (A-share toolkit) to Chinese ecosystem

### DIFF
--- a/resources/mcp-skills-catalog.en.md
+++ b/resources/mcp-skills-catalog.en.md
@@ -31,7 +31,7 @@
 8. [Design (Figma / Excalidraw)](#8-design-figma--excalidraw) (3)
 9. [Monitoring / Observability](#9-monitoring--observability) (3)
 10. [Media / Streaming (YouTube / Spotify)](#10-media--streaming-youtube--spotify) (3)
-11. [Chinese-language Ecosystem](#11-chinese-language-ecosystem) (7)
+11. [Chinese-language Ecosystem](#11-chinese-language-ecosystem) (9)
 12. [Other Common (Cloudflare / Stripe…)](#12-other-common-cloudflare--stripe) (2)
 13. [Research Workflow Skills](#13-research-workflow-skills-academic--paper--lit) (4)
 14. [Multi-LLM Delegation Skills](#14-multi-llm-delegation-skills) (3)
@@ -715,6 +715,30 @@
 **What it does**: LangChain-based open-source knowledge-base QA system — local deployment, supports multiple vector stores, end-to-end RAG example.
 **Audience**: Chinese teams who want RAG without building it from scratch; scenarios requiring local-only deployment (no cloud LLM).
 **Notes**: ★ 37k makes it the most popular RAG implementation in the Chinese ecosystem; maintenance has slowed (last commit 2025-11). For new projects, fork and evaluate as a reference, not a turnkey base.
+
+### [usewhale/whale](https://github.com/usewhale/whale) ⭐⭐⭐
+
+| Field | Value |
+|---|---|
+| Stars | ★ 114 |
+| License | MIT |
+| Rating | ⭐⭐⭐ |
+
+**What it does**: Terminal AI coding assistant optimized for DeepSeek models — supports MCP server integration, Claude-style Skills, conversation caching, written in Go.
+**Audience**: Chinese developers who use DeepSeek as their primary LLM; those who want a terminal tool without the full Claude Code stack.
+**Notes**: One of the few open-source tools with DeepSeek-specific optimization; MCP + Skills dual support allows incremental capability expansion.
+
+### [simonlin1212/a-stock-data](https://github.com/simonlin1212/a-stock-data) ⭐⭐⭐⭐
+
+| Field | Value |
+|---|---|
+| Stars | ★ 445 |
+| License | Apache-2.0 |
+| Rating | ⭐⭐⭐⭐ |
+
+**What it does**: China A-share market data toolkit — a single SKILL.md file wrapping 8 data sources (mootdx, EastMoney, akshare, iwencai, etc.) with 21 endpoints, directly usable by AI coding assistants.
+**Audience**: Chinese developers using Claude Code / Codex / OpenClaw for investment research or quantitative analysis; those who don't want to build data-fetching logic from scratch.
+**Notes**: Installable with a single `curl` + `pip install`; highest-starred community Skill for Chinese A-share data. Compatible with Claude Code, Codex, and OpenClaw.
 
 > Looking for WeChat / DingTalk integrations? Today the mainstream is chatbot frameworks (e.g., zhayujie/CowAgent), not pure MCP servers. Will add when proper MCPs emerge.
 

--- a/resources/mcp-skills-catalog.md
+++ b/resources/mcp-skills-catalog.md
@@ -31,7 +31,7 @@
 8. [設計（Figma / Excalidraw）](#8-設計figma--excalidraw)（3）
 9. [監控 / Observability](#9-監控--observability)（3）
 10. [媒體 / 串流（YouTube / Spotify）](#10-媒體--串流youtube--spotify)（3）
-11. [中文圈專用](#11-中文圈專用)（7）
+11. [中文圈專用](#11-中文圈專用)（9）
 12. [其他常用（Cloudflare / Stripe…）](#12-其他常用cloudflare--stripe)（2）
 13. [研究工作流 Skills（學術 / paper / 文獻）](#13-研究工作流-skills學術--paper--文獻)（4）
 14. [Multi-LLM Delegation Skills](#14-multi-llm-delegation-skills)（3）
@@ -715,6 +715,30 @@
 **教什麼**：基於 LangChain 的開源知識庫問答系統——本地化部署、支援多種向量資料庫、RAG 端到端範例。
 **適合誰**：想做 RAG 又不想全部自己刻的中文團隊；要本地部署（不能用雲端 LLM）的場景。
 **備註**：★ 37k 是中文圈最熱門的 RAG 實作之一；維護節奏放緩（last commit 2025-11）。新專案建議先 fork 後評估，當參考實作用。
+
+### [usewhale/whale](https://github.com/usewhale/whale) ⭐⭐⭐
+
+| 欄位 | 內容 |
+|---|---|
+| Stars | ★ 114 |
+| License | MIT |
+| 推薦度 | ⭐⭐⭐ |
+
+**教什麼**：專為 DeepSeek 模型優化的終端 AI 編碼助手——支援 MCP server 接入、Claude-style Skills、對話快取優化，Go 實作。
+**適合誰**：以 DeepSeek 為主力 LLM 的中文開發者；想用終端工具但不需要 Claude Code 全家桶的人。
+**備註**：開源同類中少見的 DeepSeek 專屬優化；MCP + Skills 雙支援讓它可以逐步擴充能力。
+
+### [simonlin1212/a-stock-data](https://github.com/simonlin1212/a-stock-data) ⭐⭐⭐⭐
+
+| 欄位 | 內容 |
+|---|---|
+| Stars | ★ 445 |
+| License | Apache-2.0 |
+| 推薦度 | ⭐⭐⭐⭐ |
+
+**教什麼**：A 股全棧資料工具包——單一 SKILL.md 檔案封裝 8 個資料源（mootdx、東財、akshare、iwencai 等）21 個端點，AI 編碼助手直接可用。
+**適合誰**：用 Claude Code / Codex / OpenClaw 做投研或量化分析的中文開發者；不想自己刻資料抓取邏輯的人。
+**備註**：一條 `curl` + `pip install` 即可啟用；中國 A 股資料類 Skill 中星星數最高的社群實作。相容 Claude Code、Codex、OpenClaw。
 
 > 想找微信 / 釘釘整合？目前主流是用 chat bot framework（如 zhayujie/CowAgent）而不是純 MCP server。等正規 MCP 出現再加進來。
 

--- a/resources/mcp-skills-catalog.zh-Hans.md
+++ b/resources/mcp-skills-catalog.zh-Hans.md
@@ -31,7 +31,7 @@
 8. [设计（Figma / Excalidraw）](#8-设计figma--excalidraw)（3）
 9. [监控 / Observability](#9-监控--observability)（3）
 10. [媒体 / 串流（YouTube / Spotify）](#10-媒体--串流youtube--spotify)（3）
-11. [中文圈专属](#11-中文圈专属)（7）
+11. [中文圈专属](#11-中文圈专属)（9）
 12. [其他常用（Cloudflare / Stripe…）](#12-其他常用cloudflare--stripe)（2）
 13. [研究工作流 Skills（学术 / paper / 文献）](#13-研究工作流-skills学术--paper--文献)（4）
 14. [Multi-LLM Delegation Skills](#14-multi-llm-delegation-skills)（3）
@@ -719,6 +719,30 @@
 **教什么**：基于 LangChain 的开源知识库问答系统——本地化部署、支持多种向量数据库、RAG 端到端范例。
 **适合谁**：想做 RAG 又不想全部自己刻的中文团队；要本地部署（不能用云端 LLM）的场景。
 **备注**：★ 37k 是中文圈最热门的 RAG 实现之一；维护节奏放缓（last commit 2025-11）。新项目建议先 fork 后评估，当参考实现用。
+
+### [usewhale/whale](https://github.com/usewhale/whale) ⭐⭐⭐
+
+| 栏位 | 内容 |
+|---|---|
+| Stars | ★ 114 |
+| License | MIT |
+| 推荐度 | ⭐⭐⭐ |
+
+**教什么**：专为 DeepSeek 模型优化的终端 AI 编码助手——支持 MCP server 接入、Claude-style Skills、对话缓存优化，Go 实现。
+**适合谁**：以 DeepSeek 为主力 LLM 的中文开发者；想用终端工具但不需要 Claude Code 全家桶的人。
+**备注**：开源同类中少见的 DeepSeek 专属优化；MCP + Skills 双支持让它可以逐步扩充能力。
+
+### [simonlin1212/a-stock-data](https://github.com/simonlin1212/a-stock-data) ⭐⭐⭐⭐
+
+| 栏位 | 内容 |
+|---|---|
+| Stars | ★ 445 |
+| License | Apache-2.0 |
+| 推荐度 | ⭐⭐⭐⭐ |
+
+**教什么**：A 股全栈数据工具包——单一 SKILL.md 文件封装 8 个数据源（mootdx、东财、akshare、iwencai 等）21 个端点，AI 编码助手直接可用。
+**适合谁**：用 Claude Code / Codex / OpenClaw 做投研或量化分析的中文开发者；不想自己刻数据抓取逻辑的人。
+**备注**：一条 `curl` + `pip install` 即可启用；中国 A 股数据类 Skill 中星星数最高的社群实现。兼容 Claude Code、Codex、OpenClaw。
 
 > 想找微信 / 钉钉集成？目前主流是用 chat bot framework（如 zhayujie/CowAgent）而不是纯 MCP server。等正規 MCP 出现再加进来。
 


### PR DESCRIPTION
## Summary

Add two Chinese-ecosystem tools to the MCP/Skills catalog (Section 11):

### 1. [usewhale/whale](https://github.com/usewhale/whale) ★114
- **What**: Terminal AI coding assistant optimized for DeepSeek models
- **Why it fits**: One of the few open-source tools with DeepSeek-specific optimization; MCP + Skills dual support; active development (last commit 2026-05-13)
- **License**: MIT ✅

### 2. [simonlin1212/a-stock-data](https://github.com/simonlin1212/a-stock-data) ★445
- **What**: China A-share market data toolkit as a single SKILL.md file
- **Why it fits**: Highest-starred community Skill for Chinese A-share data; clean single-file architecture; compatible with Claude Code / Codex / OpenClaw; active development (created 2026-05-11, 445 stars in 2 days)
- **License**: Apache-2.0 ✅

Both meet the ★100+ community repo threshold.

## Changes
- Updated TOC count from (7) to (9) in all three language versions
- Added entries to zh-TW, zh-Hans, and en versions of `mcp-skills-catalog.md`
- Followed existing entry format (table + 教什麼/適合誰/備註)

## Checklist
- [x] All three language files updated (zh-TW, zh-Hans, en)
- [x] Star counts verified via API
- [x] Licenses verified
- [x] Not archived, actively maintained
- [x] Follows existing catalog format