### PR TITLE
[Track B] fix(stage-3): 修復工具紀錄只顯示一筆與 lookup_fact 經常找不到 key 的問題

### DIFF
--- a/examples/stage-3/03-react-from-scratch/starter.py
+++ b/examples/stage-3/03-react-from-scratch/starter.py
@@ -147,13 +147,13 @@ def react_loop(question: str, max_iter: int = 6, client: Any = None) -> dict:
                 "content": obs,
             })
 
-        trace.append({
-            "step": step,
-            "thought": thought_text,
-            "tool": tool_calls[0].function.name,
-            "tool_input": json.loads(tool_calls[0].function.arguments),
-            "obs": last_obs,
-        })
+            trace.append({
+                "step": step,
+                "thought": thought_text,
+                "tool": tc.function.name,
+                "tool_input": json.loads(tc.function.arguments),  
+                "obs": last_obs,
+            })
 
     return {"final": None, "trace": trace, "steps": max_iter, "truncated": True}
 
@@ -161,7 +161,7 @@ def react_loop(question: str, max_iter: int = 6, client: Any = None) -> dict:
 # === 3. 自我驗證 ===
 
 if __name__ == "__main__":
-    question = "台北人口除以紐約人口、答案保留 4 位小數。"
+    question = "'台北人口' 除以 '紐約人口'、答案保留 4 位小數。"
     print(f"❓ 問題：{question}（using Ollama {MODEL}）")
     print("-" * 60)
 


### PR DESCRIPTION


## PR 類型 / Type
<!-- 勾選 -->
- [ ] 🆕 新增 project（Add new project entry）
- [x] 🔧 修正錯誤（Fix error: stale link / wrong info）
- [ ] 🌏 翻譯（Translation: zh + en companion）
- [x] 📝 內容改善（Content improvement）
- [ ] 🎨 風格 / 結構（Style / structure）
- [ ] 其他 / Other

## 影響範圍 / Affected files
<!-- 例如：stages/05-claude-code-ecosystem.md + stages/05-claude-code-ecosystem.en.md -->
examples/stage-3/03-react-from-scratch/starter.py

## 摘要 / Summary
<!-- 1-3 句說明做了什麼 + 為什麼 -->
1. 修正了question的寫法，在 question 中為「'台北人口'」與「'紐約人口'」加上單引號標註。若無明確強調，LLM 容易將參數轉譯（例如變成 "台北 population"），導致 tool_lookup_fact 比對不到內部定義的 key 而報錯，甚至引發模型自行捏造估算人數的幻覺。
2. 修正 react_loop 函式中 trace 紀錄 tool_calls 的邏輯。原程式碼將 trace.append 置於迴圈外，導致 LLM 在單一 step 內同時呼叫兩次查詢工具時，終端機（console）僅會印出第一筆紀錄。現已將 trace.append 移入 for tc in tool_calls: 迴圈內，以確保完整呈現所有工具的使用軌跡。

## 如果是翻譯 / 文字修正：style-guide check
- [x] 沒有 zh-Hans 用詞（教程 / 視頻 / 軟件 / 用戶 / 網絡 / 接口 / 默認 / 函数 / 算法）
- [x] 沒有 overclaim（the best / production-grade / 首選 / 全世界最好）
- [x] License 標註符合 [慣例](../resources/style-guide.md#5-license-標註慣例)
- [x] zh + en companion 兩邊都有更新（如果只動到一邊請說明為什麼）（本次修改僅涉及 Python 範例程式碼，不影響 .md 文件 

## 額外說明 / Additional notes
<!-- 任何 reviewer 應該知道的 context -->
這是我第一次參與貢獻，如果有任何疏忽或遺漏格式請不吝告知

關於摘要的第一點，原本以為可能是本地的qwen2.5:3b模型參數量較小導致的推論偏移，但經由替換串接其他 API 進行交叉測試後(例如gemini-3-flash-preview)交叉測試後，發現參數提取不精準的狀況依然會發生。因此決定直接從提問字串（Prompt）著手強化邊界標記。

再煩請Reviewer審核，如有任何錯誤再麻煩糾正，謝謝。

