### PR TITLE
Add YIELD INTELLIGENCE MCP server — Finance MCP in Section 12

### DIFF
--- a/resources/mcp-skills-catalog.en.md
+++ b/resources/mcp-skills-catalog.en.md
@@ -795,6 +795,17 @@
 **Audience**: developers wiring payment / billing into agent flows.
 **Notes**: ⚠️ this is real money. Test thoroughly in sandbox before going to production.
 
+### YIELD INTELLIGENCE MCP (Hosted Remote Server)
+
+| Field | Value |
+|---|---|
+| Type | hosted MCP server |
+| Rating | ⭐⭐⭐ (finance analysis tool; practical example of hosted vs self-hosted MCP architecture) |
+
+**What it does**: YIELD INTELLIGENCE hosted remote MCP server — live US Treasury yield rates, dividend ETF / REIT / preferred stock analysis, and passive income portfolio optimization. Two tools: `analyze_yield_opportunities` (scans passive income options) + `optimize_income_portfolio` (builds a portfolio toward a target monthly income). Listed in the Anthropic official MCP Registry (`io.github.thebrierfox/intuitek-ace`, since 2026-05-10).
+**Audience**: people doing personal finance analysis in Claude Code / Claude Desktop who want AI to surface passive income opportunities. Good hands-on example of a hosted remote MCP server — plug the URL in, zero install, useful for Stage 5 learners exploring the hosted vs self-hosted difference.
+**Notes**: Live endpoint `https://api.intuitek.ai/yield/mcp` (no auth, no API key required). x402 micropayment $1 USDC/call on Base (agent-to-agent scenarios); free for regular users. Analysis-only, no trading. GitHub: [thebrierfox/intuitek-ace](https://github.com/thebrierfox/intuitek-ace) (MIT License).
+
 ---
 
 ## 13. Research Workflow Skills (academic / paper / lit)

--- a/resources/mcp-skills-catalog.en.md
+++ b/resources/mcp-skills-catalog.en.md
@@ -32,7 +32,7 @@
 9. [Monitoring / Observability](#9-monitoring--observability) (3)
 10. [Media / Streaming (YouTube / Spotify)](#10-media--streaming-youtube--spotify) (3)
 11. [Chinese-language Ecosystem](#11-chinese-language-ecosystem) (9)
-12. [Other Common (Cloudflare / Stripe…)](#12-other-common-cloudflare--stripe) (2)
+12. [Other Common (Cloudflare / Stripe…)](#12-other-common-cloudflare--stripe) (3)
 13. [Research Workflow Skills](#13-research-workflow-skills-academic--paper--lit) (4)
 14. [Multi-LLM Delegation Skills](#14-multi-llm-delegation-skills) (3)
 15. [Finance / Trading Agents](#15-finance--trading-agents) (2)

--- a/resources/mcp-skills-catalog.md
+++ b/resources/mcp-skills-catalog.md
@@ -32,7 +32,7 @@
 9. [監控 / Observability](#9-監控--observability)（3）
 10. [媒體 / 串流（YouTube / Spotify）](#10-媒體--串流youtube--spotify)（3）
 11. [中文圈專用](#11-中文圈專用)（9）
-12. [其他常用（Cloudflare / Stripe…）](#12-其他常用cloudflare--stripe)（2）
+12. [其他常用（Cloudflare / Stripe…）](#12-其他常用cloudflare--stripe)（3）
 13. [研究工作流 Skills（學術 / paper / 文獻）](#13-研究工作流-skills學術--paper--文獻)（4）
 14. [Multi-LLM Delegation Skills](#14-multi-llm-delegation-skills)（3）
 15. [金融 / 交易 Agents](#15-金融--交易-agents)（2）
@@ -794,6 +794,19 @@
 **教什麼**：Stripe 官方 AI agent toolkit，含 MCP server，操作付款、訂閱、退款、客戶。
 **適合誰**：要在 agent 內處理付款 / billing 的開發者。
 **備註**：⚠️ 涉及金流，務必用 sandbox 測試夠了再接 production。
+
+
+### [thebrierfox/intuitek-ace](https://github.com/thebrierfox/intuitek-ace) ⭐⭐⭐
+
+| 欄位 | 內容 |
+|---|---|
+| Stars | ★ 官方 MCP Registry: `io.github.thebrierfox/intuitek-ace` |
+| License | MIT |
+| 推薦度 | ⭐⭐⭐（Finance MCP 中唯一聚焦美國國債殖利率 + 被動收入的 server） |
+
+**教什麼**：YIELD INTELLIGENCE hosted remote MCP server——即時美國國債殖利率 + 股息 ETF / REIT / 特別股分析 + 被動收入投資組合優化。2 個工具：`analyze_yield_opportunities`（掃描被動收入機會）+ `optimize_income_portfolio`（目標月收入建立投資組合）。已列入 Anthropic 官方 MCP Registry（`io.github.thebrierfox/intuitek-ace`，since 2026-05-10）。
+**適合誰**：用 Claude Code / Claude Desktop 做個人理財分析、想讓 AI 找出被動收入機會的人。Stage 5 / Track A MCP 接法示範首選——hosted remote server，直接 plug URL，0 安裝。
+**備註**：Live endpoint `https://api.intuitek.ai/yield/mcp`（no auth、no API key）。x402 micropayment $1 USDC/call on Base（agent-to-agent 場景）；一般使用者免費。非交易型，純分析工具。
 
 ---
 

--- a/resources/mcp-skills-catalog.md
+++ b/resources/mcp-skills-catalog.md
@@ -796,17 +796,16 @@
 **備註**：⚠️ 涉及金流，務必用 sandbox 測試夠了再接 production。
 
 
-### [thebrierfox/intuitek-ace](https://github.com/thebrierfox/intuitek-ace) ⭐⭐⭐
+### YIELD INTELLIGENCE MCP（Hosted Remote Server）
 
 | 欄位 | 內容 |
 |---|---|
-| Stars | ★ 官方 MCP Registry: `io.github.thebrierfox/intuitek-ace` |
-| License | MIT |
-| 推薦度 | ⭐⭐⭐（Finance MCP 中唯一聚焦美國國債殖利率 + 被動收入的 server） |
+| 形式 | hosted MCP server |
+| 推薦度 | ⭐⭐⭐（Finance 分析工具；了解 hosted vs self-hosted MCP 實作差異的實例） |
 
 **教什麼**：YIELD INTELLIGENCE hosted remote MCP server——即時美國國債殖利率 + 股息 ETF / REIT / 特別股分析 + 被動收入投資組合優化。2 個工具：`analyze_yield_opportunities`（掃描被動收入機會）+ `optimize_income_portfolio`（目標月收入建立投資組合）。已列入 Anthropic 官方 MCP Registry（`io.github.thebrierfox/intuitek-ace`，since 2026-05-10）。
-**適合誰**：用 Claude Code / Claude Desktop 做個人理財分析、想讓 AI 找出被動收入機會的人。Stage 5 / Track A MCP 接法示範首選——hosted remote server，直接 plug URL，0 安裝。
-**備註**：Live endpoint `https://api.intuitek.ai/yield/mcp`（no auth、no API key）。x402 micropayment $1 USDC/call on Base（agent-to-agent 場景）；一般使用者免費。非交易型，純分析工具。
+**適合誰**：用 Claude Code / Claude Desktop 做個人理財分析、想讓 AI 找出被動收入機會的人。hosted remote MCP server 範例——直接 plug URL、0 安裝、適合 Stage 5 學完 MCP 概念後拿來實驗 hosted vs self-hosted 差異。
+**備註**：Live endpoint `https://api.intuitek.ai/yield/mcp`（no auth、no API key）。x402 micropayment $1 USDC/call on Base（agent-to-agent 場景）；一般使用者免費。非交易型，純分析工具。GitHub：[thebrierfox/intuitek-ace](https://github.com/thebrierfox/intuitek-ace)（MIT License）。
 
 ---
 

--- a/resources/mcp-skills-catalog.zh-Hans.md
+++ b/resources/mcp-skills-catalog.zh-Hans.md
@@ -32,7 +32,7 @@
 9. [监控 / Observability](#9-监控--observability)（3）
 10. [媒体 / 串流（YouTube / Spotify）](#10-媒体--串流youtube--spotify)（3）
 11. [中文圈专属](#11-中文圈专属)（9）
-12. [其他常用（Cloudflare / Stripe…）](#12-其他常用cloudflare--stripe)（2）
+12. [其他常用（Cloudflare / Stripe…）](#12-其他常用cloudflare--stripe)（3）
 13. [研究工作流 Skills（学术 / paper / 文献）](#13-研究工作流-skills学术--paper--文献)（4）
 14. [Multi-LLM Delegation Skills](#14-multi-llm-delegation-skills)（3）
 15. [金融 / 交易 Agents](#15-金融--交易-agents)（2）

--- a/resources/mcp-skills-catalog.zh-Hans.md
+++ b/resources/mcp-skills-catalog.zh-Hans.md
@@ -799,6 +799,17 @@
 **适合谁**：要在 agent 内处理付款 / billing 的开发者。
 **备注**：⚠️ 涉及金流，务必用 sandbox 测试够了再接 production。
 
+### YIELD INTELLIGENCE MCP（Hosted Remote Server）
+
+| 栏位 | 内容 |
+|---|---|
+| 形式 | hosted MCP server |
+| 推荐度 | ⭐⭐⭐（金融分析工具；了解 hosted vs self-hosted MCP 实现差异的实例） |
+
+**教什么**：YIELD INTELLIGENCE hosted remote MCP server——即时美国国债收益率 + 股息 ETF / REIT / 优先股分析 + 被动收入投资组合优化。2 个工具：`analyze_yield_opportunities`（扫描被动收入机会）+ `optimize_income_portfolio`（面向目标月收入建立投资组合）。已收录于 Anthropic 官方 MCP Registry（`io.github.thebrierfox/intuitek-ace`，since 2026-05-10）。
+**适合谁**：用 Claude Code / Claude Desktop 做个人理财分析、想让 AI 找出被动收入机会的人。hosted remote MCP server 范例——直接 plug URL、0 安装、适合 Stage 5 学完 MCP 概念后用来体验 hosted vs self-hosted 差异。
+**备注**：Live endpoint `https://api.intuitek.ai/yield/mcp`（no auth、no API key）。x402 micropayment $1 USDC/call on Base（agent-to-agent 场景）；一般用户免费。纯分析工具，不涉及交易。GitHub：[thebrierfox/intuitek-ace](https://github.com/thebrierfox/intuitek-ace)（MIT License）。
+
 ---
 
 ## 13. 研究工作流 Skills（学术 / paper / 文献）


### PR DESCRIPTION
Adding YIELD INTELLIGENCE to the Finance section.

What it does: Passive income opportunity analysis with live US Treasury rates, portfolio yield calculator, and AI-powered income optimization.

Live MCP endpoint: https://api.intuitek.ai/yield/mcp (open, no auth required)

Tools: analyze_yield_opportunities, optimize_income_portfolio

Category fit: Finance — financial data and yield analysis.
