### PR TITLE
Add Hephaestus

### DIFF
--- a/RESOURCES.en.md
+++ b/RESOURCES.en.md
@@ -79,6 +79,7 @@ This repo **doesn't replace** flat awesome lists. When you already know which to
 ### Claude Code / Skills / Plugins-related
 
 - [**hesreallyhim/awesome-claude-code**](https://github.com/hesreallyhim/awesome-claude-code) — Claude Code resources (currently restructuring)
+- [**agentlas-ai/Hephaestus**](https://github.com/agentlas-ai/Hephaestus) — Open Agent OS for Claude Code, Codex, and Cursor with local-first agent/skill packaging, routing, memory, security gates, and Hephaestus Network MCP
 - [**travisvn/awesome-claude-skills**](https://github.com/travisvn/awesome-claude-skills) — Claude Skills catalog
 - [**anthropics/claude-plugins-official**](https://github.com/anthropics/claude-plugins-official) — Anthropic's official plugin marketplace template; start here when packaging your own plugin
 

--- a/RESOURCES.md
+++ b/RESOURCES.md
@@ -81,6 +81,7 @@
 ### Claude Code / Skills / Plugins 相關
 
 - [**hesreallyhim/awesome-claude-code**](https://github.com/hesreallyhim/awesome-claude-code) — Claude Code 相關資源清單（整理中）
+- [**agentlas-ai/Hephaestus**](https://github.com/agentlas-ai/Hephaestus) — Open Agent OS for Claude Code / Codex / Cursor，含 local-first agent/skill packaging、routing、memory、安全 gates 與 Hephaestus Network MCP
 - [**travisvn/awesome-claude-skills**](https://github.com/travisvn/awesome-claude-skills) — Claude Skills 清單
 - [**anthropics/claude-plugins-official**](https://github.com/anthropics/claude-plugins-official) — Anthropic 官方 plugin 範本，要打包自己的 plugin 從這份開始
 

--- a/RESOURCES.zh-Hans.md
+++ b/RESOURCES.zh-Hans.md
@@ -79,6 +79,7 @@
 ### Claude Code / Skills / Plugins 相关
 
 - [**hesreallyhim/awesome-claude-code**](https://github.com/hesreallyhim/awesome-claude-code) — Claude Code 相关资源清单（整理中）
+- [**agentlas-ai/Hephaestus**](https://github.com/agentlas-ai/Hephaestus) — Open Agent OS for Claude Code / Codex / Cursor，包含 local-first agent/skill packaging、routing、memory、安全 gates 与 Hephaestus Network MCP
 - [**travisvn/awesome-claude-skills**](https://github.com/travisvn/awesome-claude-skills) — Claude Skills 清单
 - [**anthropics/claude-plugins-official**](https://github.com/anthropics/claude-plugins-official) — Anthropic 官方 plugin 范本，要打包自己的 plugin 从这份开始
 


### PR DESCRIPTION
## Summary
- Adds Hephaestus to the Claude Code / Skills / Plugins resources section.
- Updates the Traditional Chinese, English, and Simplified Chinese resource files together.
- Describes Hephaestus as an open Agent OS for Claude Code, Codex, and Cursor with local-first agent/skill packaging, routing, memory, security gates, and Hephaestus Network MCP.

## Checks
- Confirmed there was no existing Hephaestus entry in this clone before adding it.
- Verified the public Hephaestus repository: https://github.com/agentlas-ai/Hephaestus