### PR TITLE
docs: add Skill Hub to related resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ PR 流程跟 style 規範請看 [CONTRIBUTING.md](CONTRIBUTING.md) 跟 [resource
 - [`wong2/awesome-mcp-servers`](https://github.com/wong2/awesome-mcp-servers) — MCP server 清單，按分類整理
 - [`punkpeye/awesome-mcp-servers`](https://github.com/punkpeye/awesome-mcp-servers) — 另一份 MCP server 清單
 - [`hesreallyhim/awesome-claude-code`](https://github.com/hesreallyhim/awesome-claude-code) — Claude Code 相關工具與 plugin 清單
+- [Skill Hub - AI Agent Skills Navigator](https://skill.442595.xyz/) — 5,000+ 個 AI Agent 技能，涵蓋 20+ 類別，可搜尋、篩選與收藏；適用各階段的技能查閱
 
 這些是純清單形式（看到再挑），本 repo 的不同點是有「**從 Stage 0 一路走到 production 的學習順序**」。
 


### PR DESCRIPTION
Added [Skill Hub](https://skill.442595.xyz/) — AI Agent Skills Navigator with 5,000+ curated skills across 20+ categories.