### PR TITLE
fix: suppress noisy EXPECTED warnings for foundational stages 01-04

### DIFF
--- a/scripts/check-stage-template.py
+++ b/scripts/check-stage-template.py
@@ -65,6 +65,15 @@ EXPECTED_PATTERNS = [
 #     to other stages, not a hands-on stage. Has 自我檢查 only.
 SKIP_STAGES = ['00-', '05-', '07.5-']
 
+# Foundational stages (01-04) use chapter-natural section names rather
+# than the template strings in EXPECTED_PATTERNS (e.g. "主流 LLM 家族對比"
+# instead of "🎯 LLM 是什麼（先定位）"). Their positioning and tool-
+# recommendation sections are substantively present — just named more
+# precisely. Renaming would degrade quality. These stages pass all
+# REQUIRED checks; only the EXPECTED pattern match fails. Suppress the
+# ⚠ EXPECTED warnings for them to keep the script output signal-only.
+EXPECTED_EXEMPT_STAGES = ['01-', '02-', '03-', '04-']
+
 H2_RE = re.compile(r'^## (.+?)\s*$', re.MULTILINE)
 
 
@@ -90,6 +99,15 @@ def should_skip(path: Path) -> bool:
     if name.endswith('.en.md') or name.endswith('.zh-Hans.md'):
         return True
     for prefix in SKIP_STAGES:
+        if name.startswith(prefix):
+            return True
+    return False
+
+
+def should_skip_expected(path: Path) -> bool:
+    """Return True for stages whose EXPECTED sections are intentionally named differently."""
+    name = path.name
+    for prefix in EXPECTED_EXEMPT_STAGES:
         if name.startswith(prefix):
             return True
     return False
@@ -132,7 +150,7 @@ def main() -> int:
                 print(f'   - {label}')
             has_required_issue = True
 
-        if missing_exp:
+        if missing_exp and not should_skip_expected(stage):
             warn_prefix = '❌' if args.strict_expected else '⚠'
             print(f'{warn_prefix} {rel}: missing EXPECTED H2 section(s):')
             for label in missing_exp:


### PR DESCRIPTION
## Summary

Fixes the warning noise reported in #55 where `scripts/check-stage-template.py` emits ⚠ warnings for stages 01–04 even though those stages are intentionally correct.

**Root cause:** Stages 01-04 use chapter-natural H2 section names (e.g. `主流 LLM 家族對比`) rather than the generic EXPECTED template strings (`🎯 [topic] 是什麼（先定位）`). The positioning and tool-recommendation content exists — just under more precise titles. The script's own comments already explained this but still printed the warnings.

**Fix:**
- Add `EXPECTED_EXEMPT_STAGES = ['01-', '02-', '03-', '04-']` constant
- Add `should_skip_expected(path)` helper function  
- Skip the EXPECTED section warning output for those stages
- REQUIRED checks are **unaffected** — those still run for all non-skipped stages
- `--strict-expected` mode is also **unaffected** for stages 05+

**Before:**
```
⚠ stages/01-llm-basics.md: missing EXPECTED H2 section(s):
   - 🎯 [topic] 是什麼（先定位）
   - 🎯 常用工具推薦（按用途）
⚠ stages/02-prompt-engineering.md: missing EXPECTED H2 section(s):
...
```

**After:**
```
✓ All stages have REQUIRED template sections.
```

## Related Issue

Closes #55