### PR TITLE
Add nika to the dev-collaboration MCP/skills catalog (3 language twins)

### DIFF
--- a/resources/mcp-skills-catalog.en.md
+++ b/resources/mcp-skills-catalog.en.md
@@ -394,6 +394,18 @@
 **Audience**: people running coding agents on large or unfamiliar repos who want fast orientation and lower token use.
 **Notes**: re-index after big edits, since the graph can go stale; treat its answers as a fast first pass and verify load-bearing claims (who-calls-X / is-this-dead) against the actual code.
 
+### [supernovae-st/nika](https://github.com/supernovae-st/nika) ⭐⭐⭐⭐
+
+| Field | Value |
+|---|---|
+| Form | CLI engine + MCP client/server |
+| License | AGPL-3.0 |
+| Rating | ⭐⭐⭐⭐ (verifiable agent workflows; a both-sides MCP example) |
+
+**What it does**: open-source Rust workflow engine — repeatable AI tasks live as declarative .nika.yaml DAGs (four verbs: infer/exec/invoke/agent), statically checked before execution (schema / default-deny permits / cost floor) and leaving a hash-chained tamper-evident trace after (`nika trace verify`). It is both an MCP client (invoke tasks call any MCP server's tools) and a read-only MCP server (`nika mcp` — agents validate workflows without executing).
+**Audience**: anyone who wants Claude Code / Codex automations to be auditable, replayable and CI-ready; also a working example of MCP client vs server.
+**Notes**: local-first — the mock and Ollama / llama.cpp / vLLM paths need zero API keys; the core discipline is that nothing ships unless `nika check` exits 0. Author self-submission (first-party).
+
 ---
 
 ## 6. Databases

--- a/resources/mcp-skills-catalog.md
+++ b/resources/mcp-skills-catalog.md
@@ -394,6 +394,18 @@
 **適合誰**：在大型或不熟的 repo 上跑 coding agent、想快速定位又想省 token 的人。
 **備註**：大改後要重新索引（graph 會 stale）；把它的回答當「快速第一手」、load-bearing 的結論（誰呼叫 X / 這段是不是死碼）再用實際程式碼驗證。
 
+### [supernovae-st/nika](https://github.com/supernovae-st/nika) ⭐⭐⭐⭐
+
+| 欄位 | 內容 |
+|---|---|
+| 形式 | CLI 引擎 + MCP client/server |
+| License | AGPL-3.0 |
+| 推薦度 | ⭐⭐⭐⭐（可驗證的 agent 工作流；MCP 雙向實例） |
+
+**教什麼**：Rust 開源工作流引擎——把重複的 AI 任務固化成 .nika.yaml 宣告式 DAG（infer/exec/invoke/agent 四個動詞），執行前靜態檢查（schema / 權限 default-deny / 成本下限），執行後產生 hash-chain 防篡改 trace（`nika trace verify`）。同時是 MCP client（invoke 任務可呼叫任何 MCP server 的工具）與唯讀 MCP server（`nika mcp`——agent 可驗證工作流而不執行）。
+**適合誰**：想讓 Claude Code / Codex 產出的自動化「可審計、可重跑、可進 CI」的人；學 MCP client vs server 差異的實例。
+**備註**：本地優先——mock 與 Ollama / llama.cpp / vLLM 路徑零 API key；`nika check` exit 0 才交付是它的核心紀律。作者自薦（first-party）。
+
 ---
 
 ## 6. 資料庫

--- a/resources/mcp-skills-catalog.zh-Hans.md
+++ b/resources/mcp-skills-catalog.zh-Hans.md
@@ -396,6 +396,18 @@
 **适合谁**：在大型或不熟的 repo 上跑 coding agent、想快速定位又想省 token 的人。
 **备注**：大改后要重新索引（graph 会 stale）；把它的回答当“快速第一手”、load-bearing 的结论（谁调用 X / 这段是不是死码）再用实际代码验证。
 
+### [supernovae-st/nika](https://github.com/supernovae-st/nika) ⭐⭐⭐⭐
+
+| 栏位 | 内容 |
+|---|---|
+| 形式 | CLI 引擎 + MCP client/server |
+| License | AGPL-3.0 |
+| 推荐度 | ⭐⭐⭐⭐（可验证的 agent 工作流；MCP 双向实例） |
+
+**教什么**：Rust 开源工作流引擎——把重复的 AI 任务固化成 .nika.yaml 声明式 DAG（infer/exec/invoke/agent 四个动词），执行前静态检查（schema / 权限 default-deny / 成本下限），执行后生成 hash-chain 防篡改 trace（`nika trace verify`）。同时是 MCP client（invoke 任务可调用任何 MCP server 的工具）与只读 MCP server（`nika mcp`——agent 可验证工作流而不执行）。
+**适合谁**：想让 Claude Code / Codex 产出的自动化“可审计、可重跑、可进 CI”的人；学 MCP client vs server 差异的实例。
+**备注**：本地优先——mock 与 Ollama / llama.cpp / vLLM 路径零 API key；`nika check` exit 0 才交付是它的核心纪律。作者自荐（first-party）。
+
 ---
 
 ## 6. 数据库


### PR DESCRIPTION
全三個語言檔同步更新（zh-Hant 底本 + .en + .zh-Hans，沿用 YIELD INTELLIGENCE 先例的完整格式：欄位表 + 教什麼/適合誰/備註）。nika 是 Rust 開源（AGPL）工作流引擎，放在第 5 區（開發協作）codebase-memory 之後：.nika.yaml 宣告式 DAG，執行前靜態檢查、執行後防篡改 trace；同時是 MCP client 與唯讀 MCP server——正好是目錄裡「client vs server 雙向」的教學實例。本地優先，mock/Ollama 路徑零 API key。Disclosure: I am the nika author (first-party submission · 利益相關：作者自薦)。