### PR TITLE
新增 awesome-agent-architecture 到中文社群必看（三語同步）

### DIFF
--- a/RESOURCES.en.md
+++ b/RESOURCES.en.md
@@ -87,6 +87,7 @@ This repo **doesn't replace** flat awesome lists. When you already know which to
 - [**datawhalechina/hello-agents**](https://github.com/datawhalechina/hello-agents) — Datawhale systematic agent tutorial (zh-Hans)
 - [**WangRongsheng/awesome-LLM-resources**](https://github.com/WangRongsheng/awesome-LLM-resources) — comprehensive zh-Hans LLM resources (8k+ stars)
 - [**AiHubCN/Awesome-Chinese-LLM**](https://github.com/AiHubCN/Awesome-Chinese-LLM) — open-source Chinese LLM catalog
+- [**hardness1020/awesome-agent-architecture**](https://github.com/hardness1020/awesome-agent-architecture) — section-by-section teardown of modern agent harnesses (loop engineering, tools, permissions, context, memory, evaluation) studied through systems such as Claude Code and Hermes Agent, with a runnable Python demo per section (trilingual: EN / zh-TW / zh-Hans)
 
 ### Online courses / MOOCs (certificate comparison)
 

--- a/RESOURCES.md
+++ b/RESOURCES.md
@@ -89,6 +89,7 @@
 - [**datawhalechina/hello-agents**](https://github.com/datawhalechina/hello-agents) — Datawhale 系統性 agent 教學（zh-Hans）
 - [**WangRongsheng/awesome-LLM-resources**](https://github.com/WangRongsheng/awesome-LLM-resources) — 完整的中文 LLM 資源整理（8k+ stars）
 - [**AiHubCN/Awesome-Chinese-LLM**](https://github.com/AiHubCN/Awesome-Chinese-LLM) — 中文開源大模型整理
+- [**hardness1020/awesome-agent-architecture**](https://github.com/hardness1020/awesome-agent-architecture) — 逐節拆解現代 agent harness（loop engineering、tools、permissions、context、memory、evaluation），以 Claude Code、Hermes Agent 等系統為案例（持續新增），每節附可執行 Python demo（繁中/简中/英文三語）
 
 ### 線上課程 / MOOC（帶證書對照）
 

--- a/RESOURCES.zh-Hans.md
+++ b/RESOURCES.zh-Hans.md
@@ -87,6 +87,7 @@
 - [**datawhalechina/hello-agents**](https://github.com/datawhalechina/hello-agents) — Datawhale 系统性 agent 教学（zh-Hans）
 - [**WangRongsheng/awesome-LLM-resources**](https://github.com/WangRongsheng/awesome-LLM-resources) — 完整的中文 LLM 资源整理（8k+ stars）
 - [**AiHubCN/Awesome-Chinese-LLM**](https://github.com/AiHubCN/Awesome-Chinese-LLM) — 中文开源大模型整理
+- [**hardness1020/awesome-agent-architecture**](https://github.com/hardness1020/awesome-agent-architecture) — 逐节拆解现代 agent harness（loop engineering、tools、permissions、context、memory、evaluation），以 Claude Code、Hermes Agent 等系统为案例（持续新增），每节附可运行 Python demo（繁中/简中/英文三语）
 
 ### 线上课程 / MOOC（带证书对照）
 


### PR DESCRIPTION
## 動了什麼

`RESOURCES.md` / `RESOURCES.en.md` / `RESOURCES.zh-Hans.md` 三語同步，在「中文社群必看」各加一條：[hardness1020/awesome-agent-architecture](https://github.com/hardness1020/awesome-agent-architecture)。

## 軌道與適合對象

**Track B（Agent Builder）**。讀者到了要理解 harness 內部怎麼構成的階段時，這份是逐節拆解（loop engineering、tools、permissions、context、memory、evaluation），以 Claude Code、Hermes Agent 等系統為案例（持續新增），每節附可執行 Python demo。

## 為什麼放「中文社群必看」

原生繁中/简中/英文三語內容（不是機翻 README），對本 repo 的中文讀者可直接銜接。MIT 協議。

聲明：我是該 repo 的維護者。
