### PR TITLE
[throwaway] smoke-test pr-link-audit bot — do not merge

### DIFF
--- a/pr-bot-smoke-test.md
+++ b/pr-bot-smoke-test.md
@@ -8,3 +8,4 @@ Test links (a healthy repo + an archived one, to exercise both paths):
 
 - Active, permissive license: [pallets/flask](https://github.com/pallets/flask)
 - Archived, should be flagged: [langchain-ai/langserve](https://github.com/langchain-ai/langserve)
+- Old / unmaintained, should be stale-flagged: [openai/gpt-2](https://github.com/openai/gpt-2)

--- a/pr-bot-smoke-test.md
+++ b/pr-bot-smoke-test.md
@@ -1,0 +1,10 @@
+# PR link-audit bot — smoke test (throwaway, do NOT merge)
+
+This file exists only to trigger `.github/workflows/pr-link-audit.yml` on a real
+PR, so we can confirm the Action fires and comments correctly. The PR will be
+closed and this branch deleted right after.
+
+Test links (a healthy repo + an archived one, to exercise both paths):
+
+- Active, permissive license: [pallets/flask](https://github.com/pallets/flask)
+- Archived, should be flagged: [langchain-ai/langserve](https://github.com/langchain-ai/langserve)


### PR DESCRIPTION
Throwaway PR to confirm the new `pr-link-audit` GitHub Action fires on a real PR and posts its advisory comment. Adds one healthy repo link (pallets/flask) and one archived one (langchain-ai/langserve) to exercise both the OK and flagged paths. Will be closed and the branch deleted once verified. No content merges.