### PR TITLE
fix(freshness): close mirror-locale + DeepSeek space-form coverage holes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -198,3 +198,25 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  freshness-tests:
+    name: Freshness gate unit tests
+    runs-on: ubuntu-latest
+    # Runs on every PR that triggers this workflow (any **.md / scripts/** /
+    # resources/** change — no schedule-only guard) so the freshness-gate
+    # coverage can't silently regress the way it did in 2026-07.
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install PyYAML
+        run: pip install pyyaml
+
+      - name: Run freshness gate regression tests
+        # Pins the 2026-07 coverage fixes: mirror-locale scanning +
+        # DeepSeek space-form regex (scripts/test_freshness.py).
+        run: python scripts/test_freshness.py

--- a/resources/setup-guide.en.md
+++ b/resources/setup-guide.en.md
@@ -100,7 +100,7 @@ Want to script with Python, run batch jobs, integrate LLMs into your own app/aut
 - **Google AI Studio**: https://aistudio.google.com/
   Useful for trying the Gemini API. Free quota depends on region and account state.
 - **NVIDIA NIM**: https://build.nvidia.com/
-  **Hosts many open-source models (Llama / Mistral / DeepSeek-R1 / Qwen / Gemma etc.), OpenAI-compatible API, new accounts get 1000 free credits**. Great when you want to try several open models without local GPU. `base_url=https://integrate.api.nvidia.com/v1`.
+  **Hosts many open-source models (Llama / Mistral / DeepSeek-R1 + R2 lineage / Qwen / Gemma etc.), OpenAI-compatible API, new accounts get 1000 free credits**. Great when you want to try several open models without local GPU. `base_url=https://integrate.api.nvidia.com/v1`.
 
 #### Chinese / Chinese-language cloud (region-friendly, very cheap)
 

--- a/resources/setup-guide.zh-Hans.md
+++ b/resources/setup-guide.zh-Hans.md
@@ -100,7 +100,7 @@
 - **Google AI Studio**：https://aistudio.google.com/
   适合先试 Gemini API，免费额度会依地区和账号状态不同。
 - **NVIDIA NIM**：https://build.nvidia.com/
-  **托管多个开源 model（Llama / Mistral / DeepSeek-R1 / Qwen / Gemma 等）、OpenAI-compatible API、新账号送 1000 credits**。适合“想试多个 open-source model 但没 GPU”的情境。`base_url=https://integrate.api.nvidia.com/v1`。
+  **托管多个开源 model（Llama / Mistral / DeepSeek-R1 + R2 lineage / Qwen / Gemma 等）、OpenAI-compatible API、新账号送 1000 credits**。适合“想试多个 open-source model 但没 GPU”的情境。`base_url=https://integrate.api.nvidia.com/v1`。
 
 #### 中国 / 中文场景（地区友善、价格极便宜）
 

--- a/scripts/check-2026-freshness.py
+++ b/scripts/check-2026-freshness.py
@@ -35,7 +35,7 @@ except ImportError:
 
 
 EXCLUDE_DIRS = {'.ai', 'book', 'node_modules', '.git', 'archives', '.coord'}
-EXCLUDE_MIRROR_SUFFIXES = ['.en.md', '.zh-Hans.md']  # focus on zh-TW canonical
+MIRROR_SUFFIXES = ('.en.md', '.zh-Hans.md')  # trilingual mirror locales (zh-TW is canonical)
 
 
 def load_config(repo_root: Path) -> dict:
@@ -44,12 +44,26 @@ def load_config(repo_root: Path) -> dict:
         return yaml.safe_load(f)
 
 
+def canonical_rel(rel: str) -> str:
+    """Map a mirror-locale rel path to its zh-TW canonical form for config matching.
+
+    'stages/06-memory-rag.en.md' -> 'stages/06-memory-rag.md'. Mirror locales are
+    now scanned (not skipped), so per-file overrides and exclude_files written for
+    the canonical file must also apply to its .en.md / .zh-Hans.md siblings.
+    """
+    for suffix in MIRROR_SUFFIXES:
+        if rel.endswith(suffix):
+            return rel[: -len(suffix)] + '.md'
+    return rel
+
+
 def matches_exclude(path: Path, repo_root: Path, exclude_patterns: list[str]) -> bool:
-    """Check if file path matches any exclude glob pattern."""
+    """Check if a file path (or its canonical mirror form) matches any exclude glob."""
     rel = path.relative_to(repo_root).as_posix()
-    for pat in exclude_patterns:
-        if fnmatch(rel, pat) or fnmatch(rel + '/', pat):
-            return True
+    for candidate in {rel, canonical_rel(rel)}:
+        for pat in exclude_patterns:
+            if fnmatch(candidate, pat) or fnmatch(candidate + '/', pat):
+                return True
     return False
 
 
@@ -79,10 +93,12 @@ def scan_file(
 
     window = cfg.get('qualifier_context_lines', 2)
 
-    # Check per-file context override
+    # Check per-file context override (mirror locales inherit the canonical file's override)
     rel = path.relative_to(repo_root).as_posix()
+    canon = canonical_rel(rel)
     for override in cfg.get('exclude_files_pattern_specific', []):
-        if fnmatch(rel, override.get('file', '')):
+        pat = override.get('file', '')
+        if fnmatch(rel, pat) or fnmatch(canon, pat):
             # Accept both new (qualifier_window) and legacy (skip_patterns_with_context)
             # field names for backward compat
             window = override.get(
@@ -130,9 +146,8 @@ def scan_file(
 def should_skip(path: Path, repo_root: Path, cfg: dict) -> bool:
     if any(part in EXCLUDE_DIRS for part in path.parts):
         return True
-    for suffix in EXCLUDE_MIRROR_SUFFIXES:
-        if path.name.endswith(suffix):
-            return True
+    # Mirror locales (.en.md / .zh-Hans.md) are NO LONGER skipped: stale facts drift
+    # into them when canonical is fixed but the mirror is left behind (2026-07 gap).
     exclude_files = cfg.get('exclude_files', [])
     return matches_exclude(path, repo_root, exclude_files)
 

--- a/scripts/freshness-models.yml
+++ b/scripts/freshness-models.yml
@@ -34,41 +34,45 @@ current_frontier_models:
     - "QvQ-72B"
 
 # Stale patterns — 偵測過時 model name without proper historical qualifier
+# NOTE: qualifier_terms include both English ('baseline') and the localized CJK
+# forms ('基線' / '基线') because mirror locales (.en.md / .zh-Hans.md) are now
+# scanned — a qualifier written as "baseline" in zh-TW/en often becomes "基线" in
+# the zh-Hans mirror, and the gate must recognize all three (2026-07 gap).
 stale_patterns:
   - pattern: 'Claude 3\.5 Sonnet'
-    qualifier_terms: ['前身', '歷史', 'lineage', '舊版', '原始', 'baseline', 'predecessor', 'history']
+    qualifier_terms: ['前身', '歷史', 'lineage', '舊版', '原始', 'baseline', '基線', '基线', 'predecessor', 'history']
     note: 'Pre-2026 Claude version (Claude 3.5 Sonnet was current circa 2024-Q4)'
 
   - pattern: 'Claude 3 Opus'
-    qualifier_terms: ['前身', '歷史', 'lineage', '舊版', '原始', 'baseline']
+    qualifier_terms: ['前身', '歷史', 'lineage', '舊版', '原始', 'baseline', '基線', '基线']
     note: 'Pre-2025 Claude version'
 
   - pattern: 'gpt-4o|GPT-4o'
-    qualifier_terms: ['前身', '歷史', 'lineage', '舊版', '原始', 'baseline', '對照', 'predecessor']
+    qualifier_terms: ['前身', '歷史', 'lineage', '舊版', '原始', 'baseline', '基線', '基线', '對照', 'predecessor']
     note: 'Pre-GPT-5 OpenAI flagship (GPT-4o was current 2024-mid through 2025-summer)'
 
   - pattern: 'GPT-4(?!\.|o|\-|\d)'
-    qualifier_terms: ['前身', '歷史', 'lineage', '舊版', '原始', 'baseline']
+    qualifier_terms: ['前身', '歷史', 'lineage', '舊版', '原始', 'baseline', '基線', '基线']
     note: 'Plain GPT-4 reference, likely stale'
 
   - pattern: 'Gemini 1\.5|Gemini 2\.0|Gemini 2\.5(?! Thinking)'
-    qualifier_terms: ['前身', '歷史', 'lineage', '舊版', 'baseline']
+    qualifier_terms: ['前身', '歷史', 'lineage', '舊版', 'baseline', '基線', '基线']
     note: 'Pre-Gemini 3 Google flagship'
 
-  - pattern: 'DeepSeek-R1(?!-Distill)'
-    qualifier_terms: ['前身', '歷史', 'lineage', '原始', 'baseline', 'paper', 'method']
+  - pattern: 'DeepSeek[- ]R1(?!-Distill)'  # [- ] catches both 'DeepSeek-R1' and space-form 'DeepSeek R1'
+    qualifier_terms: ['前身', '歷史', 'lineage', '原始', 'baseline', '基線', '基线', 'paper', 'method']
     note: '2025-01 DeepSeek reasoning model (superseded by R2 in 2026-03)'
 
   - pattern: 'DeepSeek-V3(?!\.)'
-    qualifier_terms: ['前身', '歷史', 'lineage', '舊版']
+    qualifier_terms: ['前身', '歷史', 'lineage', '舊版', 'baseline', '基線', '基线']
     note: 'Pre-V4 DeepSeek base model'
 
   - pattern: 'o1-preview|o1-mini'
-    qualifier_terms: ['前身', '歷史', 'lineage', '原始', 'baseline']
+    qualifier_terms: ['前身', '歷史', 'lineage', '原始', 'baseline', '基線', '基线']
     note: 'Early OpenAI reasoning preview (Sep 2024)'
 
   - pattern: 'Opus 4\.7'
-    qualifier_terms: ['前身', '歷史', 'lineage', '舊版', '原始', 'baseline', 'predecessor', 'history']
+    qualifier_terms: ['前身', '歷史', 'lineage', '舊版', '原始', 'baseline', '基線', '基线', 'predecessor', 'history']
     note: 'Opus 4.8 (May 2026) supersedes 4.7'
 
 # Stale date-bound framing — 時間性過時用詞

--- a/scripts/test_freshness.py
+++ b/scripts/test_freshness.py
@@ -1,0 +1,172 @@
+"""Regression tests for scripts/check-2026-freshness.py freshness-gate coverage.
+
+Run: python scripts/test_freshness.py   (plain asserts, no pytest needed)
+ or: pytest scripts/test_freshness.py
+
+Pins the two 2026-07 coverage holes a code review surfaced:
+  1. The DeepSeek regex required a literal hyphen ('DeepSeek-R1'), so the
+     space-form 'DeepSeek R1' (stages/01 picker rows) slipped through. Now
+     'DeepSeek[- ]R1(?!-Distill)' catches both, still exempting -Distill variants.
+  2. Mirror locales (.en.md / .zh-Hans.md) were hard-skipped, so a fact fixed in
+     the zh-TW canonical but left stale in a mirror (e.g. agent-paradigms shipping
+     a stale 'DeepSeek-R1') was never scanned. Mirrors are now scanned, per-file
+     overrides + exclude_files follow the mirror to its canonical form, and the
+     localized 'baseline' qualifier ('基線' / '基线') is recognized.
+"""
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "check_2026_freshness", Path(__file__).with_name("check-2026-freshness.py")
+)
+fr = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(fr)
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_REAL_CFG = fr.load_config(_REPO_ROOT)
+
+# A minimal, self-contained R1 config so pattern tests don't drift with the real yml.
+_R1_CFG = {
+    'stale_patterns': [{
+        'pattern': r'DeepSeek[- ]R1(?!-Distill)',
+        'qualifier_terms': ['lineage', 'baseline', '基線', '基线'],
+        'note': 'test-r1',
+    }],
+    'qualifier_context_lines': 2,
+}
+
+
+def _scan(text: str, cfg: dict, rel: str = "probe.md"):
+    """Write `text` to a temp file at `rel` and return scan_file findings."""
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        p = root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(text, encoding="utf-8")
+        return fr.scan_file(p, cfg, root)
+
+
+def _skip(rel: str, cfg: dict | None = None) -> bool:
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        p = root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("placeholder\n", encoding="utf-8")
+        return fr.should_skip(p, root, cfg or {})
+
+
+# ── Hole #1: DeepSeek regex space-form ────────────────────────────────────────
+
+def test_space_form_deepseek_r1_is_flagged():
+    # The exact hole: 'DeepSeek R1' (space) used to be missed entirely.
+    findings = _scan("Hunyuan 可比 DeepSeek R1 推理、中文\n", _R1_CFG)
+    assert len(findings) == 1
+    assert findings[0][2] == "DeepSeek R1"
+
+
+def test_hyphen_form_deepseek_r1_still_flagged():
+    findings = _scan("NVIDIA NIM hosts DeepSeek-R1 / Qwen\n", _R1_CFG)
+    assert len(findings) == 1
+    assert findings[0][2] == "DeepSeek-R1"
+
+
+def test_distill_variants_still_exempt_both_forms():
+    # -Distill sub-models are separate small models, not the superseded flagship.
+    assert _scan("uses DeepSeek-R1-Distill-Qwen-7B\n", _R1_CFG) == []
+    assert _scan("uses DeepSeek R1-Distill-Qwen-7B\n", _R1_CFG) == []
+
+
+def test_qualifier_suppresses_r1_both_english_and_cjk():
+    assert _scan("DeepSeek-R1 + R2 lineage / Qwen\n", _R1_CFG) == []          # english
+    assert _scan("可比 DeepSeek R1 推理 baseline、中文\n", _R1_CFG) == []       # loanword
+    # localized baseline: qualifier one line away, still within ±2 window
+    assert _scan("可比 DeepSeek R1 推理\n（對照 Opus 4.6 基线）\n", _R1_CFG) == []
+
+
+# ── Hole #2: mirror locales are scanned ───────────────────────────────────────
+
+def test_mirror_locales_are_not_skipped():
+    # The core of hole #2: .en.md / .zh-Hans.md used to be hard-skipped.
+    assert _skip("resources/agent-paradigms.en.md") is False
+    assert _skip("resources/agent-paradigms.zh-Hans.md") is False
+    assert _skip("resources/agent-paradigms.md") is False
+
+
+def test_excluded_file_still_skipped_including_its_mirror():
+    cfg = {'exclude_files': ['CHANGELOG.md']}
+    assert _skip("CHANGELOG.md", cfg) is True
+    # a mirror of an excluded canonical file is excluded too (canonical_rel)
+    assert _skip("CHANGELOG.en.md", cfg) is True
+    assert _skip("CHANGELOG.zh-Hans.md", cfg) is True
+
+
+def test_excluded_dir_still_skipped():
+    assert _skip(".ai/2026/notes.md") is True
+
+
+def test_stale_ref_in_a_mirror_is_actually_caught():
+    # End-to-end: an unqualified stale ref living in a .en.md mirror is reported.
+    findings = _scan("Hosts DeepSeek-R1 / Qwen\n", _R1_CFG, rel="resources/x.en.md")
+    assert len(findings) == 1
+
+
+# ── canonical_rel + per-file override inheritance ─────────────────────────────
+
+def test_canonical_rel_strips_mirror_suffix():
+    assert fr.canonical_rel("stages/06-memory-rag.en.md") == "stages/06-memory-rag.md"
+    assert fr.canonical_rel("stages/06-memory-rag.zh-Hans.md") == "stages/06-memory-rag.md"
+    assert fr.canonical_rel("stages/06-memory-rag.md") == "stages/06-memory-rag.md"
+    assert fr.canonical_rel("README.md") == "README.md"
+
+
+def test_per_file_window_override_follows_mirror_to_canonical():
+    # A qualifier 4 lines below the ref is out of the default ±2 window but inside
+    # the ±5 override written for the *canonical* file — the mirror must inherit it.
+    cfg = {
+        'stale_patterns': [{
+            'pattern': r'DeepSeek[- ]R1(?!-Distill)',
+            'qualifier_terms': ['lineage'],
+            'note': 't',
+        }],
+        'exclude_files_pattern_specific': [{'file': 'stages/wide.md', 'qualifier_window': 5}],
+        'qualifier_context_lines': 2,
+    }
+    text = "title DeepSeek-R1 here\n\n\n\nrefer to release dates for lineage\n"
+    # mirror inherits the canonical file's widened window -> qualifier reached -> clean
+    assert _scan(text, cfg, rel="stages/wide.en.md") == []
+    # a file WITHOUT the override uses ±2 -> qualifier out of reach -> flagged
+    # (proves the widened window, not some other effect, is what suppresses it)
+    assert len(_scan(text, cfg, rel="stages/narrow.en.md")) == 1
+
+
+# ── Ties to the REAL config (breaks if someone reverts the fixes) ─────────────
+
+def test_real_config_recognizes_localized_baseline_for_opus_47():
+    # The exact stages/08 zh-Hans false positive: current line, qualified by 基线.
+    clean = "**72.7%**（Opus 4.6 基线，接近人类；Opus 4.7 / 4.8 数据未公布）\n"
+    assert _scan(clean, _REAL_CFG) == []
+    # but a genuinely stale, unqualified Opus 4.7 is still caught
+    assert len(_scan("旗艦模型改用 Opus 4.7 可用\n", _REAL_CFG)) == 1
+
+
+def test_real_config_space_form_r1_hole_closed():
+    assert len(_scan("Hunyuan 可比 DeepSeek R1 推理、中文\n", _REAL_CFG)) == 1
+    assert _scan("Hunyuan 可比 DeepSeek R1 推理 baseline、中文\n", _REAL_CFG) == []
+
+
+if __name__ == "__main__":
+    import sys
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for fn in tests:
+        try:
+            fn()
+            print(f"  PASS  {fn.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"  FAIL  {fn.__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    sys.exit(1 if failed else 0)

--- a/stages/01-llm-basics.en.md
+++ b/stages/01-llm-basics.en.md
@@ -62,7 +62,7 @@ These are the main choices for Chinese-language work, in two groups: **API-only*
 |---|---|---|---|---|---|
 | **DeepSeek** | V4-Flash (`deepseek-v4-flash`) / V4-Pro (`deepseek-v4-pro`) | 1M | reasoning / coding / **lowest cost** | high-token workloads / code generation / math | [api-docs.deepseek.com](https://api-docs.deepseek.com/zh-cn/) |
 | **Kimi** (Moonshot) | K3 (2.8T params, native multimodal) | **1M** | long context / Chinese long-form writing | whole-book reading / literature triage | [platform.moonshot.cn](https://platform.moonshot.cn/) |
-| **Hunyuan** (Tencent) | T1 (deep-thinking) + TurboS | 128k | **DeepSeek R1-comparable reasoning**, Chinese | Chinese reasoning / Tencent ecosystem | [hunyuan.tencent.com](https://hunyuan.tencent.com/) |
+| **Hunyuan** (Tencent) | T1 (deep-thinking) + TurboS | 128k | **Reasoning on par with the DeepSeek R1 baseline**, Chinese | Chinese reasoning / Tencent ecosystem | [hunyuan.tencent.com](https://hunyuan.tencent.com/) |
 | **MiniMax** | abab6.5 + M2.7 | 200k | multimodal / Chinese long prose | Chinese writing / video and audio multimodal | [platform.minimax.io](https://platform.minimax.io/) |
 
 > **Note**: This group is mostly cloud-API and proprietary. DeepSeek also has some open weights (on HF), but the cloud API is still the main way to use it (the legacy names `deepseek-chat`/`deepseek-reasoner` retire 2026-07-24 and now alias to v4-flash).

--- a/stages/01-llm-basics.md
+++ b/stages/01-llm-basics.md
@@ -64,7 +64,7 @@
 |---|---|---|---|---|---|
 | **DeepSeek**（深度求索）| V4-Flash（`deepseek-v4-flash`）/ V4-Pro（`deepseek-v4-pro`）| 1M | 推理 / coding / **cost 最低** | 大量 token / code 生成 / math | [api-docs.deepseek.com](https://api-docs.deepseek.com/zh-cn/) |
 | **Kimi**（Moonshot）| K3（2.8T 參數、原生多模態）| **1M** | 長 context / 中文長文 | 整本書讀 / 文獻分流 | [platform.moonshot.cn](https://platform.moonshot.cn/) |
-| **Hunyuan**（騰訊）| T1（深度思考）+ TurboS | 128k | **可比 DeepSeek R1 推理**、中文 | 中文推理 / 騰訊生態 | [hunyuan.tencent.com](https://hunyuan.tencent.com/) |
+| **Hunyuan**（騰訊）| T1（深度思考）+ TurboS | 128k | **可比 DeepSeek R1 推理 baseline**、中文 | 中文推理 / 騰訊生態 | [hunyuan.tencent.com](https://hunyuan.tencent.com/) |
 | **MiniMax** | abab6.5 + M2.7 | 200k | 多模態 / 中文長 prose | 中文寫作 / 影音 multimodal | [platform.minimax.io](https://platform.minimax.io/) |
 
 > **註**：這組以雲端 API 為主、多為 proprietary。DeepSeek 另有部分開源權重（在 HF），主要用法仍是雲端 API（舊名 `deepseek-chat`/`deepseek-reasoner` 於 2026-07-24 停用、已改指向 v4-flash）。

--- a/stages/01-llm-basics.zh-Hans.md
+++ b/stages/01-llm-basics.zh-Hans.md
@@ -61,7 +61,7 @@
 |---|---|---|---|---|---|
 | **DeepSeek**（深度求索）| V4-Flash（`deepseek-v4-flash`）/ V4-Pro（`deepseek-v4-pro`）| 1M | 推理 / coding / **cost 最低** | 大量 token / code 生成 / math | [api-docs.deepseek.com](https://api-docs.deepseek.com/zh-cn/) |
 | **Kimi**（Moonshot）| K3（2.8T 参数、原生多模态）| **1M** | 长 context / 中文长文 | 整本书读 / 文献分流 | [platform.moonshot.cn](https://platform.moonshot.cn/) |
-| **Hunyuan**（腾讯）| T1（深度思考）+ TurboS | 128k | **可比 DeepSeek R1 推理**、中文 | 中文推理 / 腾讯生态 | [hunyuan.tencent.com](https://hunyuan.tencent.com/) |
+| **Hunyuan**（腾讯）| T1（深度思考）+ TurboS | 128k | **可比 DeepSeek R1 推理 baseline**、中文 | 中文推理 / 腾讯生态 | [hunyuan.tencent.com](https://hunyuan.tencent.com/) |
 | **MiniMax** | abab6.5 + M2.7 | 200k | 多模态 / 中文长 prose | 中文写作 / 影音 multimodal | [platform.minimax.io](https://platform.minimax.io/) |
 
 > **注**：这组以云端 API 为主、多为 proprietary。DeepSeek 另有部分开源权重（在 HF），主要用法仍是云端 API（旧名 `deepseek-chat`/`deepseek-reasoner` 于 2026-07-24 停用、已改指向 v4-flash）。


### PR DESCRIPTION
## What & why

The 2026 model-freshness gate had two coverage holes a code review surfaced:

1. **Mirror locales were never scanned.** `EXCLUDE_MIRROR_SUFFIXES` hard-skipped `.en.md` / `.zh-Hans.md`, so a fact fixed in the zh-TW canonical but left stale in a mirror slipped through (e.g. `setup-guide` mirrors kept a bare `DeepSeek-R1` after canonical gained the `+ R2 lineage` qualifier).
2. **The DeepSeek regex required a literal hyphen.** `DeepSeek-R1(?!-Distill)` missed the space form `DeepSeek R1` in the `stages/01` picker rows.

## Gate changes (`scripts/check-2026-freshness.py` + `scripts/freshness-models.yml`)

- Widen the regex to `DeepSeek[- ]R1(?!-Distill)` — matches both `DeepSeek-R1` and `DeepSeek R1`, still exempts `-Distill` variants.
- Scan mirror locales; per-file overrides + `exclude_files` now follow a mirror to its zh-TW canonical form via a new `canonical_rel()` helper.
- Recognize the localized baseline qualifier (`基線` / `基线`) across all `stale_patterns`, so a current, correctly-qualified zh-Hans line (e.g. "Opus 4.6 基线") isn't a false positive.

## Content drift fixed (surfaced by the widened gate; strict mode now green)

- `resources/setup-guide.{en,zh-Hans}` — restore `+ R2 lineage` to match canonical.
- `stages/01-llm-basics.{md,en,zh-Hans}` — frame R1 as a reasoning baseline (faithful mirror sync across all three locales).

## Tests / CI

- New `scripts/test_freshness.py` (12 cases) pins both holes — reverting either fix fails a real-config test.
- New `freshness-tests` job in `.github/workflows/lint.yml` runs it on every PR the workflow triggers on.

## Verification

- `python scripts/check-2026-freshness.py` → exit 0 (strict mode clean)
- `python scripts/test_freshness.py` → 12/12 pass
- existing `scripts/test_refresh_stars.py` → 7/7 (unaffected)
- code-reviewer subagent verdict: **APPROVE**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
