### PR TITLE
docs: add ClawBench to agent benchmark landscape

### DIFF
--- a/stages/07-multi-agent-production.md
+++ b/stages/07-multi-agent-production.md
@@ -216,7 +216,7 @@ Production agent 跑久了、**cost / latency 兩條線會吃掉你大半預算�
 | **GAIA** | general assistant | **74.6%** | Claude Sonnet 4.5（Princeton HAL）|
 | [**WebArena**](https://github.com/web-arena-x/webarena) | web 導航 | **68.7%** | （領先 model 未公布）|
 | [**OSWorld**](https://github.com/xlang-ai/OSWorld) | OS-level 桌面控制 | v1 **76.26%**（接近飽和）| OpenAI CUA 38%；[OSWorld 2.0](https://osworld-v2.xlang.ai/)（2026-06、long-horizon）已取代 v1、真實長任務 SOTA 僅 ~20%（Opus 4.8 20.6%），見 Stage 8 |
-| [**ClawBench**](https://github.com/reacher-z/ClawBench) | 真實網站上的 web agent 任務 | V1 153 項、V2 130 項，涵蓋 144 個網站 | 以端到端任務成功率評估；[論文](https://arxiv.org/abs/2604.08523) · [專案頁](https://claw-bench.com) |
+| [**ClawBench**](https://github.com/TIGER-AI-Lab/ClawBench) | 真實網站上的 web agent 任務 | V1 153 項、V2 130 項，涵蓋 144 個網站 | 以端到端任務成功率評估；[論文](https://arxiv.org/abs/2604.08523) · [專案頁](https://claw-bench.com) |
 | [**τ-bench**](https://github.com/sierra-research/tau-bench) | tool use 多輪對話 | （較難 hack）| Anthropic / OpenAI 領先 |
 | **RE-bench** | research engineering | （較難 hack、接近人類 baseline）| Frontier model |
 

--- a/stages/07-multi-agent-production.md
+++ b/stages/07-multi-agent-production.md
@@ -216,6 +216,7 @@ Production agent 跑久了、**cost / latency 兩條線會吃掉你大半預算�
 | **GAIA** | general assistant | **74.6%** | Claude Sonnet 4.5（Princeton HAL）|
 | [**WebArena**](https://github.com/web-arena-x/webarena) | web 導航 | **68.7%** | （領先 model 未公布）|
 | [**OSWorld**](https://github.com/xlang-ai/OSWorld) | OS-level 桌面控制 | v1 **76.26%**（接近飽和）| OpenAI CUA 38%；[OSWorld 2.0](https://osworld-v2.xlang.ai/)（2026-06、long-horizon）已取代 v1、真實長任務 SOTA 僅 ~20%（Opus 4.8 20.6%），見 Stage 8 |
+| [**ClawBench**](https://github.com/reacher-z/ClawBench) | 真實網站上的 web agent 任務 | V1 153 項、V2 130 項，涵蓋 144 個網站 | 以端到端任務成功率評估；[論文](https://arxiv.org/abs/2604.08523) · [專案頁](https://claw-bench.com) |
 | [**τ-bench**](https://github.com/sierra-research/tau-bench) | tool use 多輪對話 | （較難 hack）| Anthropic / OpenAI 領先 |
 | **RE-bench** | research engineering | （較難 hack、接近人類 baseline）| Frontier model |
 

--- a/stages/07-multi-agent-production.md
+++ b/stages/07-multi-agent-production.md
@@ -216,7 +216,7 @@ Production agent 跑久了、**cost / latency 兩條線會吃掉你大半預算�
 | **GAIA** | general assistant | **74.6%** | Claude Sonnet 4.5（Princeton HAL）|
 | [**WebArena**](https://github.com/web-arena-x/webarena) | web 導航 | **68.7%** | （領先 model 未公布）|
 | [**OSWorld**](https://github.com/xlang-ai/OSWorld) | OS-level 桌面控制 | v1 **76.26%**（接近飽和）| OpenAI CUA 38%；[OSWorld 2.0](https://osworld-v2.xlang.ai/)（2026-06、long-horizon）已取代 v1、真實長任務 SOTA 僅 ~20%（Opus 4.8 20.6%），見 Stage 8 |
-| [**ClawBench**](https://github.com/TIGER-AI-Lab/ClawBench) | 真實網站上的 web agent 任務 | V1 153 項、V2 130 項，涵蓋 144 個網站 | 以端到端任務成功率評估；[論文](https://arxiv.org/abs/2604.08523) · [專案頁](https://claw-bench.com) |
+| [**ClawBench**](https://github.com/TIGER-AI-Lab/ClawBench) | 真實網站上的 web agent 任務 | V1 153 項、V2 130 項，共 283 項，涵蓋 163 個真實網站 | 以端到端任務成功率評估；[論文](https://arxiv.org/abs/2604.08523) · [專案頁](https://claw-bench.com) |
 | [**τ-bench**](https://github.com/sierra-research/tau-bench) | tool use 多輪對話 | （較難 hack）| Anthropic / OpenAI 領先 |
 | **RE-bench** | research engineering | （較難 hack、接近人類 baseline）| Frontier model |
 

--- a/stages/07-multi-agent-production.zh-Hans.md
+++ b/stages/07-multi-agent-production.zh-Hans.md
@@ -216,6 +216,7 @@ Production agent 跑久了，**cost / latency 两条线会吃掉你大半预算�
 | **GAIA** | general assistant | **74.6%** | Claude Sonnet 4.5（Princeton HAL）|
 | [**WebArena**](https://github.com/web-arena-x/webarena) | web 导航 | **68.7%** | （领先 model 未公布）|
 | [**OSWorld**](https://github.com/xlang-ai/OSWorld) | OS-level 桌面控制 | v1 **76.26%**（接近饱和）| OpenAI CUA 38%；[OSWorld 2.0](https://osworld-v2.xlang.ai/)（2026-06、long-horizon）已取代 v1、真实长任务 SOTA 仅 ~20%（Opus 4.8 20.6%），见 Stage 8 |
+| [**ClawBench**](https://github.com/reacher-z/ClawBench) | 真实网站上的 web agent 任务 | V1 153 项、V2 130 项，覆盖 144 个网站 | 以端到端任务成功率评估；[论文](https://arxiv.org/abs/2604.08523) · [项目页](https://claw-bench.com) |
 | [**τ-bench**](https://github.com/sierra-research/tau-bench) | tool use 多轮对话 | （较难 hack）| Anthropic / OpenAI 领先 |
 | **RE-bench** | research engineering | （较难 hack、接近人类 baseline）| Frontier model |
 

--- a/stages/07-multi-agent-production.zh-Hans.md
+++ b/stages/07-multi-agent-production.zh-Hans.md
@@ -216,7 +216,7 @@ Production agent 跑久了，**cost / latency 两条线会吃掉你大半预算�
 | **GAIA** | general assistant | **74.6%** | Claude Sonnet 4.5（Princeton HAL）|
 | [**WebArena**](https://github.com/web-arena-x/webarena) | web 导航 | **68.7%** | （领先 model 未公布）|
 | [**OSWorld**](https://github.com/xlang-ai/OSWorld) | OS-level 桌面控制 | v1 **76.26%**（接近饱和）| OpenAI CUA 38%；[OSWorld 2.0](https://osworld-v2.xlang.ai/)（2026-06、long-horizon）已取代 v1、真实长任务 SOTA 仅 ~20%（Opus 4.8 20.6%），见 Stage 8 |
-| [**ClawBench**](https://github.com/TIGER-AI-Lab/ClawBench) | 真实网站上的 web agent 任务 | V1 153 项、V2 130 项，覆盖 144 个网站 | 以端到端任务成功率评估；[论文](https://arxiv.org/abs/2604.08523) · [项目页](https://claw-bench.com) |
+| [**ClawBench**](https://github.com/TIGER-AI-Lab/ClawBench) | 真实网站上的 web agent 任务 | V1 153 项、V2 130 项，共 283 项，覆盖 163 个真实网站 | 以端到端任务成功率评估；[论文](https://arxiv.org/abs/2604.08523) · [项目页](https://claw-bench.com) |
 | [**τ-bench**](https://github.com/sierra-research/tau-bench) | tool use 多轮对话 | （较难 hack）| Anthropic / OpenAI 领先 |
 | **RE-bench** | research engineering | （较难 hack、接近人类 baseline）| Frontier model |
 

--- a/stages/07-multi-agent-production.zh-Hans.md
+++ b/stages/07-multi-agent-production.zh-Hans.md
@@ -216,7 +216,7 @@ Production agent 跑久了，**cost / latency 两条线会吃掉你大半预算�
 | **GAIA** | general assistant | **74.6%** | Claude Sonnet 4.5（Princeton HAL）|
 | [**WebArena**](https://github.com/web-arena-x/webarena) | web 导航 | **68.7%** | （领先 model 未公布）|
 | [**OSWorld**](https://github.com/xlang-ai/OSWorld) | OS-level 桌面控制 | v1 **76.26%**（接近饱和）| OpenAI CUA 38%；[OSWorld 2.0](https://osworld-v2.xlang.ai/)（2026-06、long-horizon）已取代 v1、真实长任务 SOTA 仅 ~20%（Opus 4.8 20.6%），见 Stage 8 |
-| [**ClawBench**](https://github.com/reacher-z/ClawBench) | 真实网站上的 web agent 任务 | V1 153 项、V2 130 项，覆盖 144 个网站 | 以端到端任务成功率评估；[论文](https://arxiv.org/abs/2604.08523) · [项目页](https://claw-bench.com) |
+| [**ClawBench**](https://github.com/TIGER-AI-Lab/ClawBench) | 真实网站上的 web agent 任务 | V1 153 项、V2 130 项，覆盖 144 个网站 | 以端到端任务成功率评估；[论文](https://arxiv.org/abs/2604.08523) · [项目页](https://claw-bench.com) |
 | [**τ-bench**](https://github.com/sierra-research/tau-bench) | tool use 多轮对话 | （较难 hack）| Anthropic / OpenAI 领先 |
 | **RE-bench** | research engineering | （较难 hack、接近人类 baseline）| Frontier model |
 


### PR DESCRIPTION
Adds ClawBench to the Stage 7 benchmark landscape in both Traditional and Simplified Chinese pages.

Links point to the paper, source repository, and project page; task counts and website coverage match the project README.

Please review for fit and wording.