### PR TITLE
content(stage1): add Meta Muse to the western open-source table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Format: `YYYY-MM-DD · category · 1-line summary (commit-sha)`.
 
 ---
 
+## 2026-08-11(第四批)
+
+- **content** · **Stage 1 的「西方開源」表加入 Meta 的 Muse(4 家 → 5 家)**,三語同步。`Muse Glimmer 30B`、**Apache 2.0**、131k context、多模態輸入、單張消費級 GPU 就跑得動,是 Meta 第一個**專為 agent 設計**的開放權重模型(tool use / 長任務 / 失敗回復)。查證走第一手:Meta 官方 developer 頁 + Meta 自己在 HF 上的 model card(`meta-models/Muse-Glimmer-30B`),不是引用新聞稿。
+- **content** · **`Muse Spark` 刻意只寫「還沒釋出」**。新聞普遍寫成「Meta 也會放 Spark 的權重」,但實際查 HF 是**空的**——那是宣告的意圖、不是已發生的事實。表格只收 Glimmer,註解寫明 Spark 未釋出。同理,Glimmer 是**多模態輸入**(image-text-to-text)而不是新聞常寫的純文字 agent 模型,這點依 model card 寫。
+- **content** · **順帶點出 Meta 現在兩條線並行**:Llama 走 Llama Community License、Muse 走 Apache 2.0。這是這次真正值得讀者知道的變化——同一家公司、兩種授權策略。
+- **docs** · **更正我自己一個講太重的判斷**。我原本說 `stages/01` 那條授權說明(把 Llama Community License 當成「有條款限制」的例子)會因為 Muse 而「變得不正確」,還說那是最該改的地方。實際重讀:那條是在定義**授權類型**、不是在宣稱 Meta 只用哪一種,本身依然成立,**不需要改**。這是同一天內第二次我把「這份文件現在錯了」講得比實情重(前一次是自投標示那條政策),記下來。
+
 ## 2026-08-11(第三批)
 
 - **content** · **Stage 7 的「精選 Projects」加入 `open-multi-agent/open-multi-agent`(issue #83)**,放在 Multi-Agent Orchestration 分類第 4 條。**第一手查證過才收**:★ 6,756、MIT、未封存、當天還有 push、**52 位 contributor、20 個 release**——不是一個人掛在那裡的專案。投稿者宣稱的兩件事也各自驗過:`npm create oma-app` 對應的 `create-oma-app` 套件**真的存在**(v0.8.0、2026-08-10 發佈),README 裡 `runTeam` / `runTasks` / Run Viewer / checkpoint 也都找得到。

--- a/stages/01-llm-basics.en.md
+++ b/stages/01-llm-basics.en.md
@@ -83,18 +83,19 @@ These are the main choices for Chinese-language work, in two groups: **API-only*
 
 > ⚠️ **Xiaomi MiMo** is listed in [`resources/cli-agents-guide.en.md`](../resources/cli-agents-guide.en.md) for Hermes Agent routing, but as of 2026-05 there is no authoritative official source to verify it, so it is not included in this table. To try it, connect through [Hermes Agent](https://github.com/NousResearch/hermes-agent) 200+ provider routing.
 
-### 🌍 Western Open-Source (4 providers, self-host defaults)
+### 🌍 Western Open-Source (5 providers, self-host defaults)
 
 These are the main choices for running on your own hardware, avoiding API fees, or handling privacy-sensitive work. You can install them in one command through [Ollama](https://ollama.com/).
 
 | Model family | Active size | License | Strengths | Best for | Official |
 |---|---|---|---|---|---|
 | **Llama** (Meta) | 3.3 70B | Llama Community License | general-purpose / broadest ecosystem / Ollama default | self-hosting intro / fine-tune base | [llama.com](https://www.llama.com/) · [HF Meta](https://huggingface.co/meta-llama) |
+| **Muse** (Meta) | Glimmer 30B dense | Apache 2.0 | **purpose-built for agents** (tool use / long tasks / failure recovery) / multimodal input / 131k context | local agents / coding agents / a single consumer GPU | [developer.meta.com](https://developer.meta.com/ai/models/muse-glimmer/) · [HF meta-models](https://huggingface.co/meta-models/Muse-Glimmer-30B) |
 | **Gemma** (Google) | Gemma 4 26B MoE + 31B dense | Apache 2.0 | **small and efficient** / strong Apple MLX integration / multimodal | edge / mobile / 4-8 GB RAM machines | [ai.google.dev/gemma](https://ai.google.dev/gemma) |
 | **Mistral** (Mistral AI) | Small 4 / Ministral 3 / Large 3 | open weights (license varies; Large 3 is Apache 2.0) | Small 4 unifies reasoning / vision / coding; EU sovereignty | commercial self-host / EU sovereignty | [mistral.ai](https://mistral.ai/) · [HF Mistral](https://huggingface.co/mistralai) |
 | **Phi** (Microsoft) | Phi-4 14B + multimodal | MIT | **small but strong** / reasoning / edge-friendly | 4 GB+ RAM / mobile / reasoning intro | [HF microsoft](https://huggingface.co/microsoft) |
 
-> **Note**: Llama 4 (Scout / Maverick) shipped 2025-04, but they're large MoE models, so 3.3 70B remains the practical single-GPU self-host base (the table shows 3.3); Behemoth never shipped. Gemma 4 was released 2026-04, ranked #3 on LMArena's open-weights board; Phi-4 also has a multimodal version.
+> **Note**: Llama 4 (Scout / Maverick) shipped 2025-04, but they're large MoE models, so 3.3 70B remains the practical single-GPU self-host base (the table shows 3.3); Behemoth never shipped. Gemma 4 was released 2026-04, ranked #3 on LMArena's open-weights board; Phi-4 also has a multimodal version. **Muse Glimmer** shipped 2026-08-10 and is Meta's first open-weight model built specifically for agents, distilled from the closed **Muse Spark** (Meta's own card calls it "generally less capable than Muse Spark"); **Spark's weights are not released** — Meta says they will be, but nothing is on Hugging Face yet, so only Glimmer is listed here. Note that Meta now runs two lines in parallel: Llama under the Llama Community License, Muse under Apache 2.0.
 
 ### 🎯 Which One Should I Pick? (by scenario)
 

--- a/stages/01-llm-basics.md
+++ b/stages/01-llm-basics.md
@@ -82,18 +82,19 @@
 
 > ⚠️ **小米 MiMo** 雖在 [`resources/cli-agents-guide.md`](../resources/cli-agents-guide.md) 列入 Hermes Agent routing、但 2026-05 無權威官方 source 可驗證、暫不收進此表。要試 → 透過 [Hermes Agent](https://github.com/NousResearch/hermes-agent) 200+ provider routing 接入。
 
-### 🌍 西方開源（4 家、self-host 主力）
+### 🌍 西方開源（5 家、self-host 主力）
 
 跑在自己機器、不付 API、隱私敏感場景的主力——可透過 [Ollama](https://ollama.com/) 一行指令裝起來：
 
 | Model 家族 | 大小（活躍）| License | 強項 | 適合任務 | 官方 |
 |---|---|---|---|---|---|
 | **Llama**（Meta）| 3.3 70B | Llama Community License | 通用 / 生態最廣 / Ollama 預設 | self-host 入門 / fine-tune base | [llama.com](https://www.llama.com/) · [HF Meta](https://huggingface.co/meta-llama) |
+| **Muse**（Meta）| Glimmer 30B dense | Apache 2.0 | **agent 專用**（tool use / 長任務 / 失敗回復）/ 多模態輸入 / 131k context | 本機 agent / coding agent / 單張消費級 GPU | [developer.meta.com](https://developer.meta.com/ai/models/muse-glimmer/) · [HF meta-models](https://huggingface.co/meta-models/Muse-Glimmer-30B) |
 | **Gemma**（Google）| Gemma 4 26B MoE + 31B dense | Apache 2.0 | **小巧高效** / Apple MLX 整合好 / multimodal | Edge / mobile / 4-8GB RAM 機器 | [ai.google.dev/gemma](https://ai.google.dev/gemma) |
 | **Mistral**（Mistral AI）| Small 4 / Ministral 3 / Large 3 | 開源權重（license 依版本、Large 3 為 Apache 2.0）| Small 4 統一 reasoning / vision / coding、EU 主權 | 商用 self-host / EU 主權 | [mistral.ai](https://mistral.ai/) · [HF Mistral](https://huggingface.co/mistralai) |
 | **Phi**（Microsoft）| Phi-4 14B + multimodal | MIT | **小但強** / reasoning / 適 edge | 4GB+ RAM / mobile / reasoning 入門 | [HF microsoft](https://huggingface.co/microsoft) |
 
-> **註**：Llama 4（Scout / Maverick）於 2025-04 釋出，但屬大型 MoE，單機自架的實用基準仍是 3.3 70B（表中為 3.3）、Behemoth 未釋出；Gemma 4 為 2026-04 釋出、LMArena 開源組第 3；Phi-4 另有 multimodal 版。
+> **註**：Llama 4（Scout / Maverick）於 2025-04 釋出，但屬大型 MoE，單機自架的實用基準仍是 3.3 70B（表中為 3.3）、Behemoth 未釋出；Gemma 4 為 2026-04 釋出、LMArena 開源組第 3；Phi-4 另有 multimodal 版。**Muse Glimmer** 為 2026-08-10 釋出、Meta 第一個專為 agent 設計的開放權重模型,由閉源的 **Muse Spark** 蒸餾而來(Meta 自己說它「整體不如 Spark」);**Spark 的 weights 目前還沒釋出**——Meta 說會放,但 HF 上還查不到,所以這裡只收 Glimmer。注意 Meta 現在兩條線並行:Llama 走 Llama Community License,Muse 走 Apache 2.0。
 
 ### 🎯 我該選哪家？（按場景反查）
 

--- a/stages/01-llm-basics.zh-Hans.md
+++ b/stages/01-llm-basics.zh-Hans.md
@@ -82,18 +82,19 @@
 
 > ⚠️ **小米 MiMo** 虽在 [`resources/cli-agents-guide.zh-Hans.md`](../resources/cli-agents-guide.zh-Hans.md) 列入 Hermes Agent routing，但 2026-05 无权威官方 source 可验证，暂不收进此表。要试 → 通过 [Hermes Agent](https://github.com/NousResearch/hermes-agent) 200+ provider routing 接入。
 
-### 🌍 西方开源（4 家、self-host 主力）
+### 🌍 西方开源（5 家、self-host 主力）
 
 跑在自己机器、不付 API、隐私敏感场景的主力——可通过 [Ollama](https://ollama.com/) 一行指令装起来：
 
 | Model 家族 | 大小（活跃）| License | 强项 | 适合任务 | 官方 |
 |---|---|---|---|---|---|
 | **Llama**（Meta）| 3.3 70B | Llama Community License | 通用 / 生态最广 / Ollama 默认 | self-host 入门 / fine-tune base | [llama.com](https://www.llama.com/) · [HF Meta](https://huggingface.co/meta-llama) |
+| **Muse**（Meta）| Glimmer 30B dense | Apache 2.0 | **agent 专用**（tool use / 长任务 / 失败恢复）/ 多模态输入 / 131k context | 本机 agent / coding agent / 单张消费级 GPU | [developer.meta.com](https://developer.meta.com/ai/models/muse-glimmer/) · [HF meta-models](https://huggingface.co/meta-models/Muse-Glimmer-30B) |
 | **Gemma**（Google）| Gemma 4 26B MoE + 31B dense | Apache 2.0 | **小巧高效** / Apple MLX 整合好 / multimodal | Edge / mobile / 4-8GB RAM 机器 | [ai.google.dev/gemma](https://ai.google.dev/gemma) |
 | **Mistral**（Mistral AI）| Small 4 / Ministral 3 / Large 3 | 开源权重（license 依版本、Large 3 为 Apache 2.0）| Small 4 统一 reasoning / vision / coding、EU 主权 | 商用 self-host / EU 主权 | [mistral.ai](https://mistral.ai/) · [HF Mistral](https://huggingface.co/mistralai) |
 | **Phi**（Microsoft）| Phi-4 14B + multimodal | MIT | **小但强** / reasoning / 适合 edge | 4GB+ RAM / mobile / reasoning 入门 | [HF microsoft](https://huggingface.co/microsoft) |
 
-> **注**：Llama 4（Scout / Maverick）于 2025-04 发布，但属大型 MoE，单机自架的实用基准仍是 3.3 70B（表中为 3.3）、Behemoth 未发布；Gemma 4 为 2026-04 发布、LMArena 开源组第 3；Phi-4 另有 multimodal 版。
+> **注**：Llama 4（Scout / Maverick）于 2025-04 发布，但属大型 MoE，单机自架的实用基准仍是 3.3 70B（表中为 3.3）、Behemoth 未发布；Gemma 4 为 2026-04 发布、LMArena 开源组第 3；Phi-4 另有 multimodal 版。**Muse Glimmer** 为 2026-08-10 发布、Meta 第一个专为 agent 设计的开放权重模型,由闭源的 **Muse Spark** 蒸馏而来（Meta 自己说它“整体不如 Spark”）；**Spark 的 weights 目前还没发布**——Meta 说会放,但 HF 上还查不到,所以这里只收 Glimmer。注意 Meta 现在两条线并行:Llama 走 Llama Community License,Muse 走 Apache 2.0。
 
 ### 🎯 我该选哪家？（按场景反查）
 


### PR DESCRIPTION
## Meta 2026-08-10 出了 Muse,加進 Stage 1「西方開源」表(4 家 → 5 家)

| 欄位 | 值 |
|---|---|
| 模型 | **Muse Glimmer 30B dense** |
| License | **Apache 2.0** |
| Context | 131,072+ |
| 模態 | text + **image 輸入**,text 輸出(audio 明確不支援) |
| 定位 | **專為 agent 設計**:tool use / 長任務 / 失敗回復 |
| 硬體 | 單張消費級 GPU 或 Mac |

**這個模型晚於助理的訓練資料,所以每一項都是實查的、不是回憶也不是引用新聞**:

- Meta 官方 developer 頁 [developer.meta.com/ai/models/muse-glimmer/](https://developer.meta.com/ai/models/muse-glimmer/) — 「tool use, long tasks, and failure recovery」這組三件事是**Meta 自己的原文**,不是轉述
- Meta 在 HF 上的 model card [`meta-models/Muse-Glimmer-30B`](https://huggingface.co/meta-models/Muse-Glimmer-30B) — 131,072+ context、輸入 text+image / 輸出 text、audio 明確不支援、「distilled from Muse Spark」、Meta 自己寫「generally less capable than Muse Spark」
- HF API — license `apache-2.0`、pipeline tag `image-text-to-text`

## 兩處刻意不跟著新聞寫

**① `Muse Spark` 寫成「還沒釋出」。** 新聞普遍報導 Meta 也會放 Spark 的權重,但實際查 HF 是**空的**。那是宣告的意圖、不是已發生的事實,所以表格只收 Glimmer、註解寫明 Spark 未釋出。

**② Glimmer 是多模態輸入**,不是多數報導寫的純文字 agent 模型。依 model card 與 pipeline tag 寫。

## 對讀者真正有意義的一句

註解點出:**Meta 現在兩條線並行——Llama 走 Llama Community License、Muse 走 Apache 2.0**。同一家公司、兩種授權策略。

Llama 那一側由 review 獨立複查過仍然成立(`meta-llama/Llama-3.3-70B-Instruct` 仍掛 `llama3.3` community license),因為送審時我自己沒有重新驗證那一半。

## 沒有改的地方

`stages/01:41` 那條授權說明(把 Llama Community License 當「有條款限制」的例子)**不動**。它定義的是授權**類型**、從來沒有宣稱 Meta 只用哪一種,所以依然成立。我送審前曾把它說成「會因為 Muse 而變得不正確」,重讀後確認是我講太重了,CHANGELOG 有記。

## 驗證

12 個 gate 綠(含 `check-anchors --strict`,因為動了三個語系的標題)、5/5/5 列、兩個已合併的 CHANGELOG 區塊與 `77143d6` byte-identical。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
