### PR TITLE
refactor(scripts): one fenced-code-block parser for all seven gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,14 @@ Format: `YYYY-MM-DD · category · 1-line summary (commit-sha)`.
 
 ---
 
-## 2026-08-14(第二批)
+## 2026-08-14(第三批)
+
+- **refactor** · **七支腳本各自寫了一套「哪幾行是程式碼」,現在全部共用一份([#97](https://github.com/WenyuChiou/awesome-agentic-ai-zh/issues/97))**。新增 `scripts/md_fences.py`,`check-anchors`、`check-hans-chars`、`check-image-locale`、`check-links`、`check-locale-links`、`check-mirror-parity`、`zh-hans-localize` 全部改成呼叫它。每一支轉完都**逐字比對輸出**才算數:五個 gate 的輸出與轉換前**完全相同**,`check-links` 抽出的 URL **零檔案差異、總數轉換前後相同**,`zh-hans-localize` 的 mask/unmask 在 68 個檔案上都是無損來回。
+- **fix** · **共用的那份必須在每個面向都不輸原本六份裡最好的那個,不是取平均**。原本只有 `zh-hans-localize` 的 DOTALL regex 認得 **blockquote 裡的 fence**(`> ```bash`),其他六份都不認——而 `check-anchors` 因此會去驗一個在網站上其實是純文字的連結。所以共用版補上了 blockquote 支援(記住開頭 fence 的引用層數,只在同層收尾)。拿全 repo **234 個版控內檔案**對**真正的 renderer** 比對標題數:零筆不一致。(刻意寫 234 不是 235——235 正是下面那條在修的 bug 產生的數字,把一個未追蹤的本地檔也算了進去。)
+- **fix** · **`collect_anchors()` 之前是在原始內容上跑的**——#95 只修了連結那一側,**目標那一側從來沒有排除程式碼**。所以一個只出現在程式碼範例裡的 `## 標題` 會被當成合法的錨點目標。全 repo **642 個**這種幽靈目標,現在不再被接受;沒有任何實際連結指到它們,所以修完 `--strict` 照樣全綠。
+- **fix** · **`_md_files()` 會把未追蹤的本地檔算進 gate 的輸入**,所以同一個 gate 在本機跟 CI 看到的檔案集不一樣——一個放在 repo 根目錄的暫存檔就足以讓標題總數對不上,目錄過濾也擋不掉。改成走 `git ls-files`,拿不到 git 時退回原本的 rglob(退化成比較寬,不會靜靜變成空集合)。
+- **test** · 新增 `test_no_script_reimplements_the_fence_rule`:**正面斷言七支 gate 都必須 `from md_fences import`**——黑名單擋得掉的形狀永遠有限(實測舊版黑名單只抓到七支裡的五支,漏掉 `check-mirror-parity` 的 `open_marker` 狀態機與 `check-anchors` 自己 #95 前那種寫法),而「沒有 import」是繞不過去的。黑名單保留當後備,掃原始碼裡的翻轉式判斷與 DOTALL ` ```…``` ` regex。這是照 `test_repo_scan_excludes.py` 擋「exclude-path」那個 bug 的同一種做法——那個 bug 復發了八次,**原始碼層級的守門才是讓一個修好的類別不再被下一個人重新引入的東西**。變異驗證過:把 toggler 塞回任一支就會紅。
+- **chore** · **這次 refactor 真的有代價,而且是我原本說錯的那個代價**。上一批我說「不共用是因為每支 gate 都彼此不 import」——那是錯的。真正的代價在別的地方:`test_mirror_parity` 與 `test_image_locale` 會把待測腳本複製到暫存目錄跑,而腳本現在多了一個相依,所以那四個 harness 全部 ImportError、31 條測試裡有 19 條為了錯誤的理由失敗。修法是 harness 一起複製 `md_fences.py`。**gate 本身全綠、只有單元測試紅**——如果我當時只看 gate 就以為沒事,這個問題會一路帶進 CI。
 
 - **fix** · **有一頁的四個標題在網站上是以「程式碼」的樣子呈現的,三個語系都一樣([#95](https://github.com/WenyuChiou/awesome-agentic-ai-zh/issues/95))**。`examples/stage-4/04-codeact-vs-json-tool` 想示範「LLM 回一段 Python」,所以在一個 code block 裡面又放了一個 ` ```python `。但 **CommonMark 規定收尾的 fence 不可以帶語言標籤**,所以那個 ` ```python ` 不會收尾、只是內容;真正收尾的是下一個裸 fence,而再下一個裸 fence 反而**又開了一個新的 block**——把後面〈CodeAct vs JSON tool 對照〉〈兩個 path 觀察重點〉〈常見坑〉〈想看更聰明的答案?〉整段吞進去。修法是把外層 fence 加長成四個反引號:**CommonMark 允許 block 內含較短的 fence**,這正是這種「示範用巢狀 fence」該有的寫法。三語都修,12 個標題全部回來。
 - **fix** · **`check-anchors.py` 的 `strip_code_blocks` 以前是「看到 ``` 就翻轉狀態」**,那既不是 CommonMark、也就跟真正在發布網站的 renderer 不一致。**gate 跟 renderer 對「哪幾行是程式碼」的認知不同,gate 就是在驗一份沒人發布的文件**。已改成照 CommonMark 判斷:記住開頭 fence 的字元與長度,收尾必須同字元、不短於開頭、而且不能帶語言標籤;另外支援 `~~~`、允許最多三格縮排、拒絕把 ` ```foo`bar ` 當成 fence(兩個 renderer 都不當)、以及**未收尾的 fence 會發警告**——那種情況 gate 會靜靜跳過檔案剩下的部分,然後照樣印「All internal anchors valid」。改完 repo 全域找到的 anchor link **零筆差異(689 → 689)**,因為 fence 已經先修好了,所以這次純粹是防未來。

--- a/scripts/check-anchors.py
+++ b/scripts/check-anchors.py
@@ -46,7 +46,8 @@ HEADER_RE = re.compile(r'^(#{1,6})\s+(.+?)\s*$', re.MULTILINE)
 # NOTE: a `CODE_FENCE_RE = re.compile(r'^```')` used to live here. It was never
 # referenced — strip_code_blocks did its own `line.startswith` — and it encodes
 # the fence rule that issue #95 proved wrong (any ``` opens or closes). Removed
-# rather than left as a trap. The real fence matcher is _FENCE_RE below.
+# rather than left as a trap. The fence parser now lives in md_fences.py,
+# shared by every gate (issue #97).
 
 
 def slugify(text: str) -> str:
@@ -93,115 +94,28 @@ def slugify(text: str) -> str:
     return s
 
 
-_FENCE_RE = re.compile(r'^ {0,3}(`{3,}|~{3,})(.*)$')
-
-
-def strip_code_blocks(content: str, source: str | None = None) -> str:
-    """Blank out fenced code blocks, following CommonMark's fence rules.
-
-    A naive "toggle on any line starting with ```" is WRONG in two ways that
-    both shipped defects (issue #95):
-
-    1. **A closing fence may not carry an info string.** In
-
-           ```                <- opens
-           ```python          <- info string, so this is CONTENT
-           ...
-           ```                <- THIS closes the block opened on line 1
-           ```                <- and THIS opens a new one
-
-       the naive toggler pairs 1-2 and 3-4, while the renderer pairs 1-3 and
-       leaves 4 opening an unterminated block. In
-       examples/stage-4/04-codeact-vs-json-tool/README.* that swallowed four
-       `##` headings into a code block on the published site while every gate
-       read green, because the gate and the renderer disagreed about which
-       lines were code.
-
-    2. **A closing fence must be at least as long as its opener**, which is how
-       a block legitimately contains a shorter fence — the fix applied to those
-       three files. A toggler treats the inner fence as a terminator.
-
-    Also handles `~~~` fences and the up-to-3-space indent CommonMark allows.
-    Lines are blanked rather than dropped so line numbers stay correct for
-    diagnostics.
-
-    KNOWN DEVIATIONS — this follows CommonMark, which is what GitHub renders,
-    and GitHub is what check-anchors.py validates against. The site's renderer
-    (pymdownx.superfences) differs in a few corners. All four are theoretical
-    in this repo today (measured: zero occurrences of each), and each is listed
-    so nobody reads "follows CommonMark" as "matches the site exactly":
-
-      * 1-3 space indent at top level — CommonMark/GitHub accept it as a fence;
-        superfences only honours indentation matching the container's content
-        indent, so at top level it renders as a paragraph. Inside a list item
-        both agree it is code, and that IS exercised in this repo (CLAUDE.md).
-      * Unterminated fence at EOF — GitHub runs it to end of document, as here;
-        superfences does not make a block at all. Now warns, see below.
-      * 4-space indented code blocks — not handled at all. No fence markers in
-        this repo are indented that far.
-      * Backtick inside a backtick info string — handled, both renderers agree
-        it is not a fence.
-      * Fence inside a BLOCKQUOTE (`> ```bash`) — not recognised at all, since
-        _FENCE_RE cannot match a `>`-prefixed line. Both renderers treat it as
-        code, so the gate OVER-validates: it will check a link that renders as
-        literal text. That direction is a loud false positive rather than
-        silent under-validation. Latent here — 3 files, 6 fence lines, all one
-        trio in walkthroughs/build-first-agent-in-7-steps.*, with no anchor
-        links or headings inside them. Not a regression: the previous parser
-        missed blockquote fences too.
-    """
-    out = []
-    fence_char: str | None = None
-    fence_len = 0
-    for line in content.split('\n'):
-        m = _FENCE_RE.match(line)
-        if m:
-            marker, rest = m.group(1), m.group(2)
-            char = marker[0]
-            if fence_char is None:
-                # Opening fence. An info string is allowed — except that a
-                # backtick info string may not itself contain a backtick
-                # (CommonMark; pymdownx.superfences agrees, its language class
-                # is [\w#.+-]+). Treating ```foo`bar as an opener would hide
-                # the rest of the file from the gate while the renderer keeps
-                # rendering it — the same divergence shape as #93/#95.
-                if char == '`' and '`' in rest:
-                    out.append(line)
-                    continue
-                fence_char, fence_len = char, len(marker)
-                out.append('')
-                continue
-            # Inside a block: only a bare fence of the same char and at least
-            # the opener's length closes it. Anything else is content.
-            if char == fence_char and len(marker) >= fence_len and not rest.strip():
-                fence_char, fence_len = None, 0
-                out.append('')
-                continue
-            out.append('')
-            continue
-        out.append('' if fence_char is not None else line)
-
-    if fence_char is not None and source is not None:
-        # Everything from the unterminated fence to EOF was skipped. GitHub
-        # agrees (an unclosed fence runs to end of document) but the site's
-        # renderer does not, so the gate is now validating less than is
-        # published — and would still print "All internal anchors valid".
-        # Say so rather than under-validate in silence.
-        #
-        # Only warns when a source is named, so unit-test fixtures (which use
-        # unterminated fences deliberately) do not emit CI annotations.
-        # stdout, matching main()'s ::warning:: convention in this file.
-        print(
-            f'::warning::{source}: unterminated {fence_char * fence_len} fence — '
-            f'the anchor gate skipped everything after it'
-        )
-
-    return '\n'.join(out)
+# The fence parser lives in md_fences.py so every gate shares ONE implementation.
+# Six scripts used to carry their own copy; each was wrong in at least one way and
+# one of them shipped #95 (four headings rendering as code on the published site
+# while every gate read green). sys.path insert so this resolves whether the script
+# is run directly (scripts/ is already on the path) or exec'd via importlib by a test.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from md_fences import strip_code_blocks  # noqa: E402  — re-exported for callers
 
 
 def collect_anchors(content: str) -> set[str]:
-    """All anchor slugs available in this file (from H1-H6)."""
-    return {slugify(m.group(2)) for m in HEADER_RE.finditer(content)}
+    """All anchor slugs available in this file (from H1-H6).
+
+    Code blocks are stripped first. Without that, a `## Heading` shown INSIDE a
+    fenced example counts as a real anchor target, so a link pointing at a
+    heading that only exists in a code sample validates green while the browser
+    finds nothing to jump to. That was 642 phantom targets across this repo
+    (issue #97); no live link depended on one, which is why it stayed invisible.
+
+    The LINK side has been stripped since #95 — this is the TARGET side, and it
+    was the half nobody had connected.
+    """
+    return {slugify(m.group(2)) for m in HEADER_RE.finditer(strip_code_blocks(content))}
 
 
 def parse_anchor_links(content: str, file_path: Path) -> list[tuple[int, str, str]]:

--- a/scripts/check-hans-chars.py
+++ b/scripts/check-hans-chars.py
@@ -46,9 +46,11 @@ import re
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from md_fences import strip_code_blocks  # noqa: E402
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
-FENCE_RE = re.compile(r"^\s*(```|~~~)")
 INLINE_CODE_RE = re.compile(r"`[^`\n]*`")
 LINK_TARGET_RE = re.compile(r"\]\([^)]*\)")
 BADGE_MARKER = "img.shields.io/badge"
@@ -78,12 +80,14 @@ def residue_in_file(fp: Path, convert, exempt_line=None) -> list:
     scope a per-file exemption to one construct instead of the whole file.
     """
     out = []
-    in_fence = False
-    for i, line in enumerate(fp.read_text(encoding="utf-8").split("\n"), 1):
-        if FENCE_RE.match(line):
-            in_fence = not in_fence
-            continue
-        if in_fence or BADGE_MARKER in line:
+    # Fenced code is blanked by the shared parser (md_fences) rather than by a
+    # local toggle. The local toggle got the rules wrong — see #95/#97 — and for
+    # THIS gate the consequence is a false positive that blocks CI: a nested
+    # ```python whose body holds a Traditional-character comment gets scanned as
+    # prose and reported as residue. Blanking keeps line numbers intact.
+    text = strip_code_blocks(fp.read_text(encoding="utf-8"), source=str(fp))
+    for i, line in enumerate(text.split("\n"), 1):
+        if BADGE_MARKER in line:
             continue
         if exempt_line is not None and exempt_line.match(line):
             continue

--- a/scripts/check-image-locale.py
+++ b/scripts/check-image-locale.py
@@ -35,11 +35,13 @@ import re
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from md_fences import strip_code_blocks  # noqa: E402
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 # ![alt](path) — relative paths only; skip external URLs and data: URIs.
 IMAGE_RE = re.compile(r"!\[[^\]]*\]\((?!https?:|data:)([^)\s]+)\)")
-FENCE_RE = re.compile(r"^\s*(```|~~~)")
 LOCALE_SUFFIXES = {".en.md": "en", ".zh-Hans.md": "zh-Hans"}
 IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp"}
 # `.claude` and `.ai` are listed for parity with the other gates even though
@@ -77,13 +79,10 @@ def base_name(asset: str) -> str:
 
 def scan(page: Path):
     """Yield (lineno, asset) for each relative image reference outside code fences."""
-    in_fence = False
-    for i, line in enumerate(page.read_text(encoding="utf-8").split("\n"), 1):
-        if FENCE_RE.match(line):
-            in_fence = not in_fence
-            continue
-        if in_fence:
-            continue
+    # Fenced code blanked by the shared parser (md_fences), not a local
+    # toggle — see #95/#97. Blanking preserves line numbers.
+    text = strip_code_blocks(page.read_text(encoding="utf-8"), source=str(page))
+    for i, line in enumerate(text.split("\n"), 1):
         for m in IMAGE_RE.finditer(line):
             asset = m.group(1)
             if Path(asset).suffix.lower() in IMAGE_EXTS:

--- a/scripts/check-links.py
+++ b/scripts/check-links.py
@@ -16,6 +16,9 @@ import re
 import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from md_fences import strip_code_blocks  # noqa: E402
 from typing import Iterable
 
 try:
@@ -55,16 +58,13 @@ def find_md_files(root: Path) -> list[Path]:
 def extract_urls(md_path: Path) -> list[tuple[int, str]]:
     """回傳 [(line_no, url), ...]，跳過程式碼區塊內的 URL。"""
     urls = []
-    text = md_path.read_text(encoding="utf-8")
-    in_fenced_code = False
+    # Fenced code blanked by the shared parser (md_fences), not a local toggle —
+    # see #95/#97. Without this the checker fetches every URL in every code
+    # sample, which is both slow and a source of phantom "dead link" reports.
+    text = strip_code_blocks(
+        md_path.read_text(encoding="utf-8"), source=str(md_path)
+    )
     for line_no, line in enumerate(text.splitlines(), start=1):
-        # Toggle fenced code block state on ``` or ~~~
-        stripped = line.lstrip()
-        if stripped.startswith("```") or stripped.startswith("~~~"):
-            in_fenced_code = not in_fenced_code
-            continue
-        if in_fenced_code:
-            continue
         # 也跳過 inline code（粗略：只在 ` ` 之間的 URL 不算）
         # Markdown 規範允許 inline code 內含 link 但通常不是真 link
         for match in LINK_RE.finditer(line):

--- a/scripts/check-locale-links.py
+++ b/scripts/check-locale-links.py
@@ -34,6 +34,9 @@ import re
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from md_fences import strip_code_blocks  # noqa: E402
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 EXCLUDE_DIRS = {".git", ".github", ".claude", ".ai", "_build", "node_modules", "book", ".venv"}
 LOCALES = [(".en.md", "*.en.md"), (".zh-Hans.md", "*.zh-Hans.md")]
@@ -51,7 +54,6 @@ SWITCHER_RE = re.compile(
     r"繁體中文|简体中文|\[English\]|\*\*English\*\*"
     r"|[(（]\s*zh(-Hans|-TW)?\s*[)）].*[(（]\s*en\s*[)）]"
 )
-FENCE_RE = re.compile(r"^\s*(```|~~~)")
 HEADING_RE = re.compile(r"^#{1,6}\s+(.*?)\s*$")
 
 # Reuse the repo's canonical slugger instead of re-implementing it. A second
@@ -69,13 +71,10 @@ slugify = _check_anchors.slugify
 
 def anchors_of(fp: Path) -> set[str]:
     """All heading anchors in a markdown file, ignoring fenced code."""
-    found, in_fence = set(), False
-    for line in fp.read_text(encoding="utf-8").split("\n"):
-        if FENCE_RE.match(line):
-            in_fence = not in_fence
-            continue
-        if in_fence:
-            continue
+    found = set()
+    for line in strip_code_blocks(
+        fp.read_text(encoding="utf-8"), source=str(fp)
+    ).split("\n"):
         m = HEADING_RE.match(line)
         if m:
             found.add(slugify(m.group(1)))
@@ -98,13 +97,14 @@ def iter_mirror_files(root: Path):
 
 def scan_file(suffix: str, fp: Path):
     """Yield (line_no, whole_link, target, fixed_target) for each fixable link."""
-    lines = fp.read_text(encoding="utf-8").split("\n")
-    in_fence = False
+    # Fenced code blanked by the shared parser (md_fences), not a local toggle —
+    # see #95/#97. This gate REWRITES link targets, so a false positive creates a
+    # dead link; a sample link inside a ```markdown template must stay untouched.
+    lines = strip_code_blocks(
+        fp.read_text(encoding="utf-8"), source=str(fp)
+    ).split("\n")
     for i, line in enumerate(lines, start=1):
-        if FENCE_RE.match(line):
-            in_fence = not in_fence
-            continue
-        if in_fence or SWITCHER_RE.search(line):
+        if SWITCHER_RE.search(line):
             continue
         for m in LINK_RE.finditer(line):
             target, anchor = m.group(3), m.group(4)

--- a/scripts/check-mirror-parity.py
+++ b/scripts/check-mirror-parity.py
@@ -43,39 +43,37 @@ import re
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from md_fences import code_line_flags, fence_marker_count  # noqa: E402
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 BASELINE = REPO_ROOT / "scripts" / "mirror-parity-baseline.json"
 LOCALES = {"en": ".en.md", "zh-Hans": ".zh-Hans.md"}
 SKIP_DIR_PARTS = {".git", ".claude", ".ai", "_build", "_site", "node_modules", "book", "archives"}
 SKIP_FILES = {"CHANGELOG.md"}
 
-FENCE_RE = re.compile(r"^\s*(`{3,}|~{3,})")
 IMAGE_RE = re.compile(r"!\[[^\]]*\]\(")
 
 
 def metrics(path: Path) -> dict:
     """Count reader-visible structural elements, ignoring anything inside code fences."""
     h2 = h3 = blockquote = fences = images = table_rows = 0
-    open_marker = None  # the character that opened the current fence, or None
-    for line in path.read_text(encoding="utf-8").split("\n"):
-        m = FENCE_RE.match(line)
-        if m:
-            marker = m.group(1)[0]
-            # Track WHICH marker opened the fence. A single boolean toggled by
-            # either ``` or ~~~ flips state on a mismatched marker and silently
-            # mis-scopes every count that follows — which in this gate means a
-            # real deficit can be hidden. Per CommonMark a fence closes only on
-            # its own marker type.
-            if open_marker is None:
-                open_marker = marker
-                fences += 1
-                continue
-            if marker == open_marker:
-                open_marker = None
-                fences += 1
-                continue
-            # a different marker inside a fence is literal content
-        if open_marker is not None:
+    # Both "which lines are code" and "how many fence markers" come from the
+    # shared parser (md_fences). The local version tracked the marker CHARACTER —
+    # better than a plain toggle — but still ignored the two rules #95 turned up:
+    # a closer may not carry an info string, and it must be at least as long as
+    # its opener, so a nested ```python counted as two markers it should not.
+    #
+    # fence_marker_count rather than counting code-run boundaries: two blocks
+    # with no blank line between them are ONE contiguous run, so boundaries
+    # report 1 block where there are 2 — and in this gate a metric that drops on
+    # one side of a trio is either a false deficit or a masked real one.
+    text = path.read_text(encoding="utf-8")
+    lines = text.split("\n")
+    flags = code_line_flags(text)
+    fences = fence_marker_count(text)
+    for line, in_code in zip(lines, flags):
+        if in_code:
             continue
         if line.startswith("## "):
             h2 += 1

--- a/scripts/md_fences.py
+++ b/scripts/md_fences.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""One fenced-code-block parser for every gate in this repo.
+
+WHY THIS MODULE EXISTS (issues #95, #97)
+
+Seven scripts here needed to know "which lines are code", and six of them had
+written their own version of the rule. Every one of those six was wrong in at
+least one way, and one of them shipped a defect: four `##` headings rendered as
+code on the published site in all three locales while every gate read green,
+because `check-anchors.py` and the renderer disagreed about which lines were
+code. A gate that disagrees with the renderer is validating a document nobody
+publishes.
+
+The rules the naive "toggle on any ``` line" version gets wrong:
+
+1. **A closing fence may not carry an info string.** Given
+
+       ```                <- opens
+       ```python          <- info string, so CONTENT, not a closer
+       ...
+       ```                <- closes the block opened on line 1
+       ```                <- OPENS a new one
+
+   a toggler pairs 1-2 and 3-4; the renderer pairs 1-3 and leaves 4 opening an
+   unterminated block. That is #95 verbatim.
+
+2. **A closing fence must be at least as long as its opener.** This is how a
+   block legitimately contains a shorter fence, and it is how the file in #95
+   was fixed (outer fence widened to ````).
+
+3. **A fence can live inside a blockquote.** None of the six line-based
+   parsers handled `> ```bash`; only `zh-hans-localize.py`'s DOTALL regex did,
+   by ignoring line structure entirely. So the shared parser has to be at least
+   as good as the BEST of the six on every axis, not the average — hence the
+   blockquote support here.
+
+4. **`~~~` fences exist**, and a backtick fence cannot be closed by a tilde one
+   (or vice versa).
+
+5. **A backtick info string may not itself contain a backtick.** ```foo`bar is
+   not a fence opener. CommonMark says so and pymdownx.superfences agrees (its
+   language class is a word/#/./+/- class with no backtick).
+
+KNOWN DEVIATIONS, deliberate. This follows CommonMark, which is what GitHub
+renders and what `check-anchors.py` validates against. The site's renderer
+(pymdownx.superfences) differs in corners; each is listed so nobody reads
+"follows CommonMark" as "matches the site exactly":
+
+  * 1-3 space indent at top level — CommonMark/GitHub treat it as a fence;
+    superfences only honours indentation matching the container's content
+    indent, so at top level it renders as a paragraph. Inside a list item both
+    agree it is code, and that case IS live in this repo (CLAUDE.md).
+  * Unterminated fence at EOF — runs to end of document, as GitHub does;
+    superfences declines to make a block. Warns when a source is named.
+  * 4-space indented code blocks — not handled. No fence marker in this repo is
+    indented that far.
+
+Usage:  from md_fences import strip_code_blocks, code_line_flags, fence_marker_count
+Tests:  scripts/test_check_anchors.py
+"""
+from __future__ import annotations
+
+import re
+
+__all__ = [
+    "strip_code_blocks",
+    "code_line_flags",
+    "fence_marker_count",
+    "FENCE_RE",
+    "BLOCKQUOTE_PREFIX_RE",
+]
+
+# Leading blockquote markers, e.g. "> ", ">> ", "  > > ". Captured separately so
+# a fence inside a quote is recognised and only closed at the same quote depth.
+BLOCKQUOTE_PREFIX_RE = re.compile(r"^(\s*(?:>\s?)*)(.*)$")
+
+# A fence marker: 3+ backticks or tildes, up to 3 leading spaces, then the info
+# string (which must be empty for a closer).
+FENCE_RE = re.compile(r"^ {0,3}(`{3,}|~{3,})(.*)$")
+
+
+def _split_quote(line: str) -> tuple[int, str]:
+    """Return (blockquote depth, the line with its quote markers removed).
+
+    When there is no quote marker the line is returned UNCHANGED, indentation
+    included. BLOCKQUOTE_PREFIX_RE's leading whitespace class matches even with
+    zero `>`, so stripping unconditionally would hand FENCE_RE a left-trimmed
+    line and its up-to-3-space bound would never fire — a lone fence indented
+    four spaces (an indented code block, not a fence) would then open a block
+    and swallow the rest of the document.
+    """
+    m = BLOCKQUOTE_PREFIX_RE.match(line)
+    prefix, body = m.group(1), m.group(2)
+    depth = prefix.count(">")
+    if depth == 0:
+        return 0, line
+    return depth, body
+
+
+class _Walk:
+    """One pass: per-line (is_code, is_marker), plus any still-open fence."""
+
+    __slots__ = ("rows", "unterminated")
+
+    def __init__(self, rows, unterminated):
+        self.rows = rows
+        self.unterminated = unterminated
+
+
+def _walk(content: str) -> _Walk:
+    """THE state machine, in one place.
+
+    `code_line_flags` and `fence_marker_count` both wrap this. They were briefly
+    two hand-transcribed copies of the same rules — precisely the drift shape
+    this module exists to eliminate, reintroduced inside the module written to
+    hold one copy. Review caught it. Neither caller re-walks anything now.
+
+    `is_marker` is True only for a line that OPENS or CLOSES a block. A fence
+    line that is merely content — a shorter nested fence, or one carrying an
+    info string where a closer is required — is (is_code=True, is_marker=False).
+    """
+    rows: list[tuple[bool, bool]] = []
+    fence_char: str | None = None
+    fence_len = 0
+    fence_depth = 0
+
+    for line in content.split("\n"):
+        depth, body = _split_quote(line)
+
+        if fence_char is not None and fence_depth > 0 and depth < fence_depth:
+            # The quote ended, so the fence inside it ended too. Two things this
+            # must NOT do:
+            #   * require the line to be non-blank — a BLANK line ends a
+            #     blockquote as surely as prose does, and treating it as
+            #     continuation left the rest of the file masked, silently.
+            #   * skip the line — the bail line may itself be a fence opener,
+            #     and consuming it turns a closer into an opener one line later.
+            # So: close the fence and fall through to normal handling.
+            fence_char, fence_len, fence_depth = None, 0, 0
+
+        m = FENCE_RE.match(body)
+        if m:
+            marker, rest = m.group(1), m.group(2)
+            char = marker[0]
+
+            if fence_char is None:
+                # Opening fence. An info string is allowed here, except that a
+                # backtick info string may not contain a backtick. Treating
+                # ```foo`bar as an opener would hide the rest of the file from
+                # the caller while the renderer keeps rendering it — the same
+                # divergence shape as #93/#95.
+                if char == "`" and "`" in rest:
+                    rows.append((False, False))
+                    continue
+                fence_char, fence_len, fence_depth = char, len(marker), depth
+                rows.append((True, True))
+                continue
+
+            # Inside a block: only a bare fence of the same character, at least
+            # the opener's length, at the same quote depth, closes it.
+            if (
+                char == fence_char
+                and len(marker) >= fence_len
+                and not rest.strip()
+                and depth == fence_depth
+            ):
+                fence_char, fence_len, fence_depth = None, 0, 0
+                rows.append((True, True))
+                continue
+
+            rows.append((True, False))
+            continue
+
+        rows.append((fence_char is not None, False))
+
+    unterminated = (fence_char, fence_len) if fence_char is not None else None
+    return _Walk(rows, unterminated)
+
+
+def code_line_flags(content: str, source: str | None = None) -> list[bool]:
+    """One bool per line: is this line part of a fenced code block?
+
+    The primitive most consumers share. Fence marker lines count as code, so a
+    caller that blanks or masks by flag removes the whole construct.
+
+    Callers differ in what they DO with it — check-anchors blanks the lines,
+    zh-hans-localize masks and later restores them — so the shared piece is the
+    classification, not the transformation.
+
+    `source` names the file for the unterminated-fence warning. Left as None
+    (the default) this is silent, so unit-test fixtures that use unterminated
+    fences on purpose do not emit CI annotations.
+    """
+    walk = _walk(content)
+
+    if walk.unterminated is not None and source is not None:
+        char, length = walk.unterminated
+        # stdout, matching the ::warning:: convention used elsewhere in these
+        # gates. An unterminated fence means everything after it was skipped;
+        # doing that silently is how a gate validates less and still prints its
+        # success line.
+        print(
+            f"::warning::{source}: unterminated {char * length} fence — "
+            f"the caller skipped everything after it"
+        )
+
+    return [is_code for is_code, _ in walk.rows]
+
+
+def fence_marker_count(content: str) -> int:
+    """How many fence MARKER lines the document has (openers + closers).
+
+    Exposed here rather than left to callers, because deriving it from
+    `code_line_flags` is wrong: two blocks with no blank line between them are
+    one contiguous run of True, so a run-boundary count reports 1 block where
+    there are 2. check-mirror-parity uses this as a structural metric, and a
+    metric that drops on one side of a trio is either a false deficit or a
+    masked real one.
+
+    An unterminated fence contributes its opener only, which is honest — there
+    is no closer. Note the consequence for a caller that halves this to get a
+    block count: an odd total rounds the last block away, so this and
+    `code_line_flags` CAN disagree about whether a block exists. It only ever
+    under-reports, so it cannot manufacture a deficit that is not there.
+    """
+    return sum(1 for _, is_marker in _walk(content).rows if is_marker)
+
+
+def strip_code_blocks(content: str, source: str | None = None) -> str:
+    """Blank out fenced code blocks, leaving everything else untouched.
+
+    Lines are blanked rather than deleted so line numbers stay correct for
+    diagnostics that cite them.
+    """
+    lines = content.split("\n")
+    return "\n".join(
+        "" if in_code else line
+        for line, in_code in zip(lines, code_line_flags(content, source))
+    )

--- a/scripts/test_anchor_slug_parity.py
+++ b/scripts/test_anchor_slug_parity.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 
 import importlib.util
 import re
+import subprocess
 import sys
 import unicodedata
 from pathlib import Path
@@ -68,13 +69,44 @@ ANCHOR_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]*?)#([^)]+)\)")
 
 
 def _md_files() -> list[Path]:
+    """Tracked .md files only.
+
+    A plain rglob pulls in UNTRACKED local files, so this gate's input differed
+    between a laptop and CI — a stray `.mirror-sync-comment.md` was enough to
+    shift the repo's heading count by one and make a published figure
+    unreproducible (issue #97). Directory filters cannot fix that: the file sits
+    at the repo root.
+
+    Falls back to the rglob walk when git is unavailable, so the test still runs
+    outside a checkout; the fallback is the old, slightly-wider behaviour rather
+    than a silent empty set.
+    """
+    try:
+        listed = subprocess.run(
+            ["git", "-C", str(REPO), "ls-files", "-z", "*.md"],
+            capture_output=True,
+            check=True,
+            timeout=30,
+        ).stdout.decode("utf-8")
+        candidates = [REPO / n for n in listed.split("\0") if n]
+        if not candidates:
+            # `git -C <dir> ls-files` in a directory that is not itself a repo
+            # walks UP, finds the enclosing one, and exits 0 with empty stdout.
+            # That never raises, so without this the walk returns [] and two of
+            # the tests below pass vacuously while printing green — the exact
+            # "scans 0 files, reports success" class this repo keeps paying for.
+            raise FileNotFoundError("git ls-files returned no .md paths")
+    except (OSError, subprocess.SubprocessError):
+        candidates = sorted(REPO.rglob("*.md"))
+
     out = []
-    for p in sorted(REPO.rglob("*.md")):
+    for p in candidates:
         rel = p.relative_to(REPO)
         if any(part in _SKIP for part in rel.parts):
             continue
-        out.append(p)
-    return out
+        if p.exists():  # `git ls-files` lists deleted-but-staged paths too
+            out.append(p)
+    return sorted(out)
 
 
 def _site_slugify():

--- a/scripts/test_check_anchors.py
+++ b/scripts/test_check_anchors.py
@@ -31,8 +31,12 @@ Run:  python scripts/test_check_anchors.py     (plain asserts, no pytest needed)
 from __future__ import annotations
 
 import importlib.util
+import re
 import sys
 from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
 
 _SPEC = importlib.util.spec_from_file_location(
     "check_anchors", Path(__file__).with_name("check-anchors.py")
@@ -287,6 +291,103 @@ def test_the_real_file_renders_all_its_headings() -> None:
                 f"#95 regression in {name}: {h!r} is swallowed by a code block again. "
                 f"saw {sorted(got)}"
             )
+
+
+def test_marker_count_and_flags_cannot_fork() -> None:
+    """`fence_marker_count` and `code_line_flags` must stay one state machine.
+
+    They briefly were two hand-transcribed copies — the drift shape this whole
+    module exists to eliminate, reintroduced INSIDE the module meant to hold one
+    copy. Both wrap `_walk` now, and the source guard below cannot see
+    intra-module duplication, so this pins the relationship instead.
+    """
+    import md_fences
+
+    fixtures = [
+        "```\na\n```\n```\nb\n```\n",          # adjacent, no blank line
+        "````\nx\n```python\ny\n```\n````\n",  # #95 nesting
+        "```\nx\n",                            # unterminated
+        "> ```\n> x\nplain\n",                 # quoted fence, bailed
+        "~~~\nx\n```\ny\n~~~\n",               # tilde outer, backtick inside
+        "```foo`bar\n\n## Visible\n",          # not a fence at all
+    ]
+    fixtures += [p.read_text(encoding="utf-8") for p in sorted((REPO / "scripts").glob("*.py"))[:3]]
+
+    for text in fixtures:
+        flags = md_fences.code_line_flags(text)
+        markers = md_fences.fence_marker_count(text)
+        assert markers == 0 or any(flags), (
+            f"markers counted but no line is code — the two have forked. "
+            f"markers={markers} text={text[:60]!r}"
+        )
+        assert markers <= sum(flags), (
+            f"more fence markers ({markers}) than code lines ({sum(flags)}) — "
+            f"a marker line is always a code line, so the two have forked. "
+            f"text={text[:60]!r}"
+        )
+
+
+def test_no_script_reimplements_the_fence_rule() -> None:
+    """Every gate's fence rule must come from md_fences, not a local copy.
+
+    Six scripts each carried their own; all six were wrong in at least one way
+    and one shipped #95. This is the same shape as
+    `test_repo_scan_excludes.py::test_no_script_matches_excludes_on_absolute_path`,
+    which pins the exclude-path bug that recurred eight times — a source-level
+    guard is what stops a fixed class from being reintroduced by the next person
+    who needs to know "is this line code".
+
+    `test_check_anchors.py` is exempt: it keeps a deliberate naive copy inside
+    `test_gate_matches_the_renderer_on_the_broken_shape`, as the discriminator
+    proving that fixture still distinguishes the two parsers.
+    """
+    # POSITIVE assertion first. A blocklist of known-bad shapes can always be
+    # evaded by inventing a new one — and it was: the regex below misses
+    # check-mirror-parity's `open_marker` state machine and check-anchors' own
+    # pre-#95 `line.startswith('```')`, i.e. 2 of the 7 real historical shapes.
+    # Requiring the import cannot be evaded that way.
+    gates = {
+        "check-anchors.py",
+        "check-hans-chars.py",
+        "check-image-locale.py",
+        "check-links.py",
+        "check-locale-links.py",
+        "check-mirror-parity.py",
+        "zh-hans-localize.py",
+    }
+    missing = [
+        n for n in sorted(gates)
+        if "from md_fences import" not in (REPO / "scripts" / n).read_text(encoding="utf-8")
+    ]
+    assert not missing, (
+        "issues #95/#97: these gates no longer import the shared fence parser, so "
+        f"they have their own answer to 'which lines are code' again: {missing}"
+    )
+
+    # Blocklist second, as a backstop for scripts not in the set above.
+    toggler = re.compile(
+        r"in_fence\s*=\s*not\s+in_fence"
+        r"|in_code\s*=\s*not\s+in_code"
+        r"|in_fenced_code\s*=\s*not\s+in_fenced_code"
+        r"|open_marker\s*=\s*marker"
+        r"|re\.compile\(\s*r?[\"']```\.\*\?```"
+    )
+    offenders = []
+    for p in sorted((REPO / "scripts").glob("*.py")):
+        if p.name == Path(__file__).name:
+            # Exempt: this file keeps a deliberate naive copy inside
+            # test_gate_matches_the_renderer_on_the_broken_shape, as the
+            # discriminator proving that fixture still tells the parsers apart.
+            continue
+        if toggler.search(p.read_text(encoding="utf-8")):
+            offenders.append(p.name)
+
+    assert not offenders, (
+        "issues #95/#97: a fence closer may not carry an info string and must be "
+        "at least as long as its opener; a DOTALL ```...``` regex mis-pairs nested "
+        "fences. These scripts reimplement the rule instead of importing "
+        f"md_fences.strip_code_blocks / code_line_flags: {offenders}"
+    )
 
 
 def main() -> int:

--- a/scripts/test_image_locale.py
+++ b/scripts/test_image_locale.py
@@ -39,6 +39,13 @@ def _run(files: dict, assets=(), args=()):
         (root / "scripts" / SCRIPT.name).write_text(
             SCRIPT.read_text(encoding="utf-8"), encoding="utf-8"
         )
+        # The gate imports the shared fence parser (md_fences, issue #97),
+        # so the temp repo needs it too or the subprocess dies on ImportError
+        # and every assertion below fails for the wrong reason.
+        _SHARED = SCRIPT.parent / "md_fences.py"
+        (root / "scripts" / _SHARED.name).write_text(
+            _SHARED.read_text(encoding="utf-8"), encoding="utf-8"
+        )
         for a in assets:
             p = root / a
             p.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/test_mirror_parity.py
+++ b/scripts/test_mirror_parity.py
@@ -39,6 +39,13 @@ def _run(files: dict, baseline=None, args=()):
         (root / "scripts" / SCRIPT.name).write_text(
             SCRIPT.read_text(encoding="utf-8"), encoding="utf-8"
         )
+        # The gate imports the shared fence parser (md_fences, issue #97),
+        # so the temp repo needs it too or the subprocess dies on ImportError
+        # and every assertion below fails for the wrong reason.
+        _SHARED = SCRIPT.parent / "md_fences.py"
+        (root / "scripts" / _SHARED.name).write_text(
+            _SHARED.read_text(encoding="utf-8"), encoding="utf-8"
+        )
         if baseline is not None:
             (root / "scripts" / "mirror-parity-baseline.json").write_text(
                 json.dumps({"deficits": baseline}, ensure_ascii=False), encoding="utf-8"
@@ -169,6 +176,13 @@ def test_trio_count_drop_fails():
         (root / "scripts" / SCRIPT.name).write_text(
             SCRIPT.read_text(encoding="utf-8"), encoding="utf-8"
         )
+        # The gate imports the shared fence parser (md_fences, issue #97),
+        # so the temp repo needs it too or the subprocess dies on ImportError
+        # and every assertion below fails for the wrong reason.
+        _SHARED = SCRIPT.parent / "md_fences.py"
+        (root / "scripts" / _SHARED.name).write_text(
+            _SHARED.read_text(encoding="utf-8"), encoding="utf-8"
+        )
         (root / "scripts" / "mirror-parity-baseline.json").write_text(
             json.dumps({"trios": 1, "deficits": {}}), encoding="utf-8"
         )
@@ -210,6 +224,13 @@ def test_update_baseline_then_clean():
         (root / "scripts").mkdir()
         (root / "scripts" / SCRIPT.name).write_text(
             SCRIPT.read_text(encoding="utf-8"), encoding="utf-8"
+        )
+        # The gate imports the shared fence parser (md_fences, issue #97),
+        # so the temp repo needs it too or the subprocess dies on ImportError
+        # and every assertion below fails for the wrong reason.
+        _SHARED = SCRIPT.parent / "md_fences.py"
+        (root / "scripts" / _SHARED.name).write_text(
+            _SHARED.read_text(encoding="utf-8"), encoding="utf-8"
         )
         for name, body in files.items():
             (root / name).write_text(body, encoding="utf-8")

--- a/scripts/zh-hans-localize.py
+++ b/scripts/zh-hans-localize.py
@@ -37,6 +37,9 @@ import re
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from md_fences import code_line_flags  # noqa: E402
+
 # Curated blanket-safe Taiwan→Mainland vocabulary (grep-verified, this repo)
 VOCAB = {
     "呼叫": "调用",      # programming call/invoke (mainland: 调用)
@@ -79,21 +82,47 @@ PROTECT = {
 }
 
 REPO = Path(__file__).resolve().parent.parent
-FENCE_RE = re.compile(r"```.*?```", re.DOTALL)
 INLINE_RE = re.compile(r"`[^`\n]*`")
 
 
 def _mask(text: str):
     """Replace fenced + inline code with placeholders so substitutions
-    never touch code. Returns (masked_text, restore_map)."""
+    never touch code. Returns (masked_text, restore_map).
+
+    Fenced blocks are located by the shared parser (md_fences) rather than by
+    the `​```.*?```` DOTALL regex this used to use. That regex pairs fences
+    greedily-left-to-right, so it mis-pairs a nested example — exactly the #95
+    shape — and here the consequence is worse than a bad report: this script
+    REWRITES files, so a mis-paired fence means vocabulary substitutions land
+    inside a code sample.
+
+    Inline code is still handled by the regex below; md_fences is line-based
+    and deliberately says nothing about spans within a line.
+    """
     store: list[str] = []
 
-    def stash(m: re.Match) -> str:
-        store.append(m.group(0))
+    def stash_text(chunk: str) -> str:
+        store.append(chunk)
         return f"\x00{len(store) - 1}\x00"
 
-    text = FENCE_RE.sub(stash, text)
-    text = INLINE_RE.sub(stash, text)
+    # Fenced blocks, by line, using the shared classification.
+    lines = text.split("\n")
+    flags = code_line_flags(text)
+    out: list[str] = []
+    run: list[str] = []
+    for line, in_code in zip(lines, flags):
+        if in_code:
+            run.append(line)
+            continue
+        if run:
+            out.append(stash_text("\n".join(run)))
+            run = []
+        out.append(line)
+    if run:
+        out.append(stash_text("\n".join(run)))
+    text = "\n".join(out)
+
+    text = INLINE_RE.sub(lambda m: stash_text(m.group(0)), text)
     return text, store
 
 


### PR DESCRIPTION
Closes #97.

## The problem

Seven scripts in `scripts/` needed to know **"which lines are code"**, and six had written their own version of the rule. Each was wrong in at least one way, and one of them shipped #95: four `##` headings rendered as code on the published site in all three locales while every gate read green — because the gate and the renderer disagreed about which lines were code.

## The fix

New `scripts/md_fences.py` owns the rule. All seven gates call it: `check-anchors`, `check-hans-chars`, `check-image-locale`, `check-links`, `check-locale-links`, `check-mirror-parity`, `zh-hans-localize`.

**Every conversion was verified by comparing output, not by reading the diff:**

| gate | result |
|---|---|
| check-anchors, check-hans-chars, check-image-locale, check-locale-links, check-mirror-parity | byte-identical |
| check-links | 0 files differing, total unchanged |
| zh-hans-localize | mask/unmask lossless across all 68 zh-Hans files |
| check-mirror-parity metrics | changed on exactly 6 files; deficits identical under old and new |

## The shared copy has to beat the best of the six, not the average

Only `zh-hans-localize`'s DOTALL regex handled **fences inside blockquotes** — the other six, including `check-anchors`, would validate a link that renders as literal text. So `md_fences` handles them: it tracks the opener's quote depth and closes only at the same depth.

Against the real renderer across the whole corpus: **0 heading-count disagreements**.

## Three #97 findings fixed alongside

- **`collect_anchors` ran on raw content**, so the fence rule gated only the *link* side. **642** anchor targets existing only inside code blocks were accepted as valid. No live link depended on one, which is why it stayed invisible.
- **`_md_files()` walked untracked files**, so a gate's input differed between a laptop and CI. Now `git ls-files`, with a fallback that raises rather than returning `[]` when git reports nothing — two tests would otherwise have passed vacuously.
- **Blockquote fences**, above.

## What review caught that the gates could not

Worth stating plainly, because all three were introduced *by this PR*:

1. The quote-prefix regex consumed plain indentation even with zero `>`, so `FENCE_RE`'s 3-space bound never fired and a **4-space-indented lone fence swallowed the rest of the document**. Zero live occurrences, but a new silent under-validation against HEAD.
2. The blockquote exit rule required a non-blank line and consumed the bail line — so a blank line left the file masked to EOF, and a closer could be turned into an opener.
3. The first `fences`-metric fix counted code-run boundaries, which reports 1 block for two *adjacent* blocks.

And fixing (3) reintroduced exactly what this module exists to remove: **a second hand-transcribed copy of the state machine, inside the module written to hold one copy.** Both wrappers now share a single `_walk()`, with a test pinning them so they cannot fork again.

## Guard

`test_no_script_reimplements_the_fence_rule` asserts **positively** that all seven gates contain `from md_fences import`. A blocklist of known-bad shapes is always evadable and was — measured against `git show HEAD:scripts/*.py`, it caught 5 of the 7 historical shapes, missing `check-mirror-parity`'s `open_marker` state machine and `check-anchors`' own pre-#95 form. "Does not import" cannot be evaded. The blocklist stays as a backstop.

## Verification

- 8 gates + `zh-hans-localize --check` green; 11/11 test files (`test_check_anchors` 16/16)
- site builds exit 0, anchor diagnostics 0, WARNINGs unchanged at 179
- `md_fences` vs the real renderer, whole corpus: 0 disagreements
- guard mutation-tested: reinserting a toggler into any gate fails it

## Deferred to a #97 follow-up

Other gates still `rglob` untracked files; `_unmask` is lossy if the source already contains `\x00` (pre-existing, HEAD is equally lossy); `sys.path.insert` ordering; an import-group split in `check-links.py`. None is a regression from this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
