### PR TITLE
新增 UIZZE anti-UI-slop Skill 與 UI quality gate

### DIFF
--- a/.github/outreach/awesome-claude-code.md
+++ b/.github/outreach/awesome-claude-code.md
@@ -47,7 +47,7 @@ Wanted to surface a proposal for when you're ready:
 I maintain [awesome-agentic-ai-zh](https://github.com/WenyuChiou/awesome-agentic-ai-zh)
 — a trilingual (zh-TW canonical · zh-Hans · English) 8-stage learning roadmap
 for agentic AI. **Stage 5 is dedicated entirely to the Claude Code ecosystem**
-(MCP, Skills, Plugins, Hello-World walkthroughs, 77+ entry integration catalog
+(MCP, Skills, Plugins, Hello-World walkthroughs, 78+ entry integration catalog
 by use case).
 
 awesome-claude-code is already in our `Related projects` section
@@ -77,7 +77,7 @@ trilingual translation discipline, CI lint on every PR.
 Hey @hesreallyhim — your awesome-claude-code list is already in our README's
 "Related projects". Built a complement: a trilingual (zh-TW / zh-Hans / en)
 8-stage learning roadmap, with Stage 5 dedicated to Claude Code (MCP, Skills,
-Plugins, walkthroughs, 77+ integrations grouped by use case).
+Plugins, walkthroughs, 78+ integrations grouped by use case).
 
 ★525 in week 1, MIT licensed. If a reciprocal link in awesome-claude-code's
 Learning Resources section makes sense, just opened a PR

--- a/.github/outreach/awesome-mcp-servers.md
+++ b/.github/outreach/awesome-mcp-servers.md
@@ -37,7 +37,7 @@ catalog browsing.
 + - [awesome-agentic-ai-zh](https://github.com/WenyuChiou/awesome-agentic-ai-zh)
 +   — Trilingual (zh-TW · zh-Hans · en) 8-stage learning roadmap. Stage 5.2 is
 +   a dedicated walkthrough of MCP (concept → first install → writing your
-+   own server), with prerequisites and time estimates. Catalog includes 77+
++   own server), with prerequisites and time estimates. Catalog includes 78+
 +   integrations grouped by use case.
 ```
 

--- a/README.en.md
+++ b/README.en.md
@@ -35,7 +35,7 @@ Concretely:
 | Pillar | What it does | Scale |
 |---|---|---|
 | **Learning roadmap** | Organizes scattered high-quality projects, tutorials, and required reading into **8 stages** (including Stage 5 + Stage 8 as two shared hubs) + 2 tracks + 5 specialized branches, from zero to advanced | 8 stages, 2 tracks |
-| **Resource curation** | Each stage curates **240+** projects (star rating, audience, what they teach, how to run) plus an MCP/Skill catalog covering the Chinese AI ecosystem (DeepSeek, Zhipu, Kimi, …) | 240+ projects, 77 MCP/Skill |
+| **Resource curation** | Each stage curates **240+** projects (star rating, audience, what they teach, how to run) plus an MCP/Skill catalog covering the Chinese AI ecosystem (DeepSeek, Zhipu, Kimi, …) | 240+ projects, 78 MCP/Skill |
 | **Simple illustrative cases** | Each stage ships 1-5 **foundational exercises** (70-150 line starter + dual-path Ollama/Anthropic SDK comparison + mock-based tests) | 23 exercise folders |
 
 After the main path, you go from "**LLM user**" to "**agent system builder**" — capable of designing multi-agent collaboration, writing your own MCP server, and shipping real agent systems.
@@ -227,7 +227,7 @@ Common quick links, grouped by **scenario**:
 | Your situation | Where | Scope |
 |---|---|---|
 | Connect to Notion / Obsidian / Excel / GitHub / etc. | [`RESOURCES.en.md` daily-tool integrations](RESOURCES.en.md#daily-tool-integrations-mcp-servers--skills) | 7-8 highlights |
-| Full MCP server / Skill catalog (stars, categories) | [`resources/mcp-skills-catalog.en.md`](resources/mcp-skills-catalog.en.md) | 77+ entries, 16 categories |
+| Full MCP server / Skill catalog (stars, categories) | [`resources/mcp-skills-catalog.en.md`](resources/mcp-skills-catalog.en.md) | 78+ entries, 16 categories |
 
 ### 🔬 Research / Production
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 | 核心 | 做什麼 | 規模 |
 |---|---|---|
 | **學習路線圖** | 把網路散落的高品質專案、教材、必修閱讀，按**從零開始、循序漸進**整理成 **8 個階段**（含 Stage 5 + Stage 8 兩個共用 hub）+ 2 條學習路線 + 5 條延伸路徑 | 8 stages、2 tracks |
-| **資源 curation** | 每階段精選 **240+** 個 project（含星等、適合誰、教什麼、怎麼跑），加上中文 AI 生態(DeepSeek / Zhipu / Kimi 等)MCP / Skill 完整 catalog | 240+ projects、77 MCP/Skill |
+| **資源 curation** | 每階段精選 **240+** 個 project（含星等、適合誰、教什麼、怎麼跑），加上中文 AI 生態(DeepSeek / Zhipu / Kimi 等)MCP / Skill 完整 catalog | 240+ projects、78 MCP/Skill |
 | **簡單 illustrative 案例** | 每階段附 1-5 個**基礎練習**（70-150 行 starter + dual-path Ollama/Anthropic SDK 對照 + mock-based test） | 23 個練習 folder |
 
 走完整條路線，你會從「**LLM 使用者**」進階到「**agent 系統建構者**」——能看懂 framework 在做什麼、能設計多 agent 協作、能寫自己的 MCP server。
@@ -227,7 +227,7 @@ cd awesome-agentic-ai-zh
 | 你的狀況 | 去哪 | 規模 |
 |---|---|---|
 | 接 Notion / Obsidian / Excel / GitHub 等工具 | [`RESOURCES.md` 接日常工具](RESOURCES.md#接日常工具常用-mcp-server--skill) | 7-8 個 highlight |
-| 完整 MCP server / Skill 目錄（含星等、分類） | [`resources/mcp-skills-catalog.md`](resources/mcp-skills-catalog.md) | 77+ 條、16 大分類 |
+| 完整 MCP server / Skill 目錄（含星等、分類） | [`resources/mcp-skills-catalog.md`](resources/mcp-skills-catalog.md) | 78+ 條、16 大分類 |
 
 ### 🔬 研究 / production 級
 

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -33,7 +33,7 @@
 | 核心 | 做什么 | 规模 |
 |---|---|---|
 | **学习路线图** | 把网上散落的高质量项目、教材、必修阅读，按**从零开始、循序渐进**整理成 **8 个阶段**（含 Stage 5 + Stage 8 两个共用 hub）+ 2 条学习路线 + 5 条延伸路径 | 8 stages、2 tracks |
-| **资源 curation** | 每阶段精选 **240+** 个 project（含星等、适合谁、教什么、怎么跑），加上中文 AI 生态(DeepSeek / Zhipu / Kimi 等)MCP / Skill 完整 catalog | 240+ projects、77 MCP/Skill |
+| **资源 curation** | 每阶段精选 **240+** 个 project（含星等、适合谁、教什么、怎么跑），加上中文 AI 生态(DeepSeek / Zhipu / Kimi 等)MCP / Skill 完整 catalog | 240+ projects、78 MCP/Skill |
 | **简单 illustrative 案例** | 每阶段附 1-5 个**基础练习**（70-150 行 starter + dual-path Ollama/Anthropic SDK 对照 + mock-based test） | 23 个练习 folder |
 
 走完这条路线，你会从“**LLM 用户**”进阶到“**agent 系统构建者**”——能看懂 framework 在做什么、能设计多 agent 协作、能写自己的 MCP server。
@@ -227,7 +227,7 @@ cd awesome-agentic-ai-zh
 | 你的状况 | 去哪 | 规模 |
 |---|---|---|
 | 接 Notion / Obsidian / Excel / GitHub 等工具 | [`RESOURCES.zh-Hans.md` 接日常工具](RESOURCES.zh-Hans.md#接日常工具常用-mcp-server--skill) | 7-8 个 highlight |
-| 完整 MCP server / Skill 目录（含星等、分类） | [`resources/mcp-skills-catalog.zh-Hans.md`](resources/mcp-skills-catalog.zh-Hans.md) | 77+ 条、16 大分类 |
+| 完整 MCP server / Skill 目录（含星等、分类） | [`resources/mcp-skills-catalog.zh-Hans.md`](resources/mcp-skills-catalog.zh-Hans.md) | 78+ 条、16 大分类 |
 
 ### 🔬 研究 / production 级
 

--- a/RESOURCES.en.md
+++ b/RESOURCES.en.md
@@ -62,7 +62,7 @@ Connect Claude Code (or any other CLI agent) to the apps you already use, withou
 
 - [**leemysw/feishu-docx**](https://github.com/leemysw/feishu-docx) ★ 235 — Feishu (Lark) docs / sheet / bitable ↔ Markdown with Claude Skills support
 
-> The above is just the highlights. **Full 77+ entry catalog by category** (incl. databases, browser automation, Figma, Excalidraw, Cloudflare, Stripe, academic-writing / multi-LLM delegation, etc.) lives in [`resources/mcp-skills-catalog.en.md`](resources/mcp-skills-catalog.en.md).
+> The above is just the highlights. **Full 78+ entry catalog by category** (incl. databases, browser automation, Figma, Excalidraw, Cloudflare, Stripe, academic-writing / multi-LLM delegation, etc.) lives in [`resources/mcp-skills-catalog.en.md`](resources/mcp-skills-catalog.en.md).
 
 > Looking for more MCP server catalogs? See [`wong2/awesome-mcp-servers`](https://github.com/wong2/awesome-mcp-servers) / [`punkpeye/awesome-mcp-servers`](https://github.com/punkpeye/awesome-mcp-servers) (categorized). **Canva** now ships an official MCP ([canva.dev/docs/mcp](https://www.canva.dev/docs/mcp/), endpoint `mcp.canva.com`, ~32 tools, works on any plan, supports Claude / ChatGPT / Cursor / VS Code).
 

--- a/RESOURCES.md
+++ b/RESOURCES.md
@@ -62,7 +62,7 @@
 
 - [**leemysw/feishu-docx**](https://github.com/leemysw/feishu-docx) ★ 235 — 飛書（Lark）docs / sheet / bitable ↔ Markdown，含 Claude Skills 支援
 
-> 上面只是 highlight。**完整 77+ 個整合的分類目錄**（含資料庫、瀏覽器自動化、Figma、Excalidraw、Cloudflare、Stripe、學術寫作 / Multi-LLM delegation 等）在 [`resources/mcp-skills-catalog.md`](resources/mcp-skills-catalog.md)。
+> 上面只是 highlight。**完整 78+ 個整合的分類目錄**（含資料庫、瀏覽器自動化、Figma、Excalidraw、Cloudflare、Stripe、學術寫作 / Multi-LLM delegation 等）在 [`resources/mcp-skills-catalog.md`](resources/mcp-skills-catalog.md)。
 
 > 想找更多 MCP server catalog？看 [`wong2/awesome-mcp-servers`](https://github.com/wong2/awesome-mcp-servers) / [`punkpeye/awesome-mcp-servers`](https://github.com/punkpeye/awesome-mcp-servers)（依分類整理）。**Canva** 現有官方 MCP（[canva.dev/docs/mcp](https://www.canva.dev/docs/mcp/)、endpoint `mcp.canva.com`、~32 工具、任何方案可用、支援 Claude / ChatGPT / Cursor / VS Code）。
 

--- a/RESOURCES.zh-Hans.md
+++ b/RESOURCES.zh-Hans.md
@@ -62,7 +62,7 @@
 
 - [**leemysw/feishu-docx**](https://github.com/leemysw/feishu-docx) ★ 235 — 飞书（Lark）docs / sheet / bitable ↔ Markdown，含 Claude Skills 支持
 
-> 上面只是 highlight。**完整 77+ 个集成的分类目录**（含数据库、浏览器自动化、Figma、Excalidraw、Cloudflare、Stripe、学术写作 / Multi-LLM delegation 等）在 [`resources/mcp-skills-catalog.zh-Hans.md`](resources/mcp-skills-catalog.zh-Hans.md)。
+> 上面只是 highlight。**完整 78+ 个集成的分类目录**（含数据库、浏览器自动化、Figma、Excalidraw、Cloudflare、Stripe、学术写作 / Multi-LLM delegation 等）在 [`resources/mcp-skills-catalog.zh-Hans.md`](resources/mcp-skills-catalog.zh-Hans.md)。
 
 > 想找更多 MCP server catalog？看 [`wong2/awesome-mcp-servers`](https://github.com/wong2/awesome-mcp-servers) / [`punkpeye/awesome-mcp-servers`](https://github.com/punkpeye/awesome-mcp-servers)（按分类整理）。**Canva** 现有官方 MCP（[canva.dev/docs/mcp](https://www.canva.dev/docs/mcp/)、endpoint `mcp.canva.com`、~32 工具、任何方案可用、支持 Claude / ChatGPT / Cursor / VS Code）。
 

--- a/branches/for-developer.en.md
+++ b/branches/for-developer.en.md
@@ -26,7 +26,7 @@ The table below splits a developer's day into 7 common scenarios. Each has a dif
 
 > **CLI agent comparison**: 8 major CLI agents (Claude Code / Codex / OpenCode / Gemini CLI / goose / Aider / Hermes Agent / Grok Build) compared side-by-side in [`resources/cli-agents-guide.en.md`](../resources/cli-agents-guide.en.md). New to CLI agents and want step-by-step onboarding → [`tracks/cli/A1-cli-intro.en.md`](../tracks/cli/A1-cli-intro.en.md) (Track A first stop).
 >
-> **MCP catalog**: Looking for integrations to wire CLI into daily tools (GitHub, Linear, Atlassian, Postgres, Playwright, Figma…) → [`resources/mcp-skills-catalog.en.md`](../resources/mcp-skills-catalog.en.md) (77+ entries by category).
+> **MCP catalog**: Looking for integrations to wire CLI into daily tools (GitHub, Linear, Atlassian, Postgres, Playwright, Figma…) → [`resources/mcp-skills-catalog.en.md`](../resources/mcp-skills-catalog.en.md) (78+ entries by category).
 >
 > This page only lists tool entry points directly relevant to developer workflows.
 

--- a/branches/for-developer.md
+++ b/branches/for-developer.md
@@ -26,7 +26,7 @@
 
 > **CLI agent 比較**：8 個主流 CLI agent（Claude Code / Codex / OpenCode / Gemini CLI / goose / Aider / Hermes Agent / Grok Build）的並列比較見 [`resources/cli-agents-guide.md`](../resources/cli-agents-guide.md)。第一次接觸 CLI agent 想要 step-by-step 入門 → [`tracks/cli/A1-cli-intro.md`](../tracks/cli/A1-cli-intro.md)（Track A 第一站）。
 >
-> **MCP catalog**：要把 CLI 接到日常工具（GitHub、Linear、Atlassian、Postgres、Playwright、Figma 等）→ [`resources/mcp-skills-catalog.md`](../resources/mcp-skills-catalog.md)（77+ 個分類整理）。
+> **MCP catalog**：要把 CLI 接到日常工具（GitHub、Linear、Atlassian、Postgres、Playwright、Figma 等）→ [`resources/mcp-skills-catalog.md`](../resources/mcp-skills-catalog.md)（78+ 個分類整理）。
 >
 > 本頁只列**跟開發者 workflow 直接相關**的工具入口。
 

--- a/branches/for-developer.zh-Hans.md
+++ b/branches/for-developer.zh-Hans.md
@@ -26,7 +26,7 @@
 
 > **CLI agent 比较**：8 个主流 CLI agent（Claude Code / Codex / OpenCode / Gemini CLI / goose / Aider / Hermes Agent / Grok Build）的并列比较见 [`resources/cli-agents-guide.zh-Hans.md`](../resources/cli-agents-guide.zh-Hans.md)。第一次接触 CLI agent 想要 step-by-step 入门 → [`tracks/cli/A1-cli-intro.zh-Hans.md`](../tracks/cli/A1-cli-intro.zh-Hans.md)（Track A 第一站）。
 >
-> **MCP catalog**：要把 CLI 接到日常工具（GitHub、Linear、Atlassian、Postgres、Playwright、Figma 等）→ [`resources/mcp-skills-catalog.zh-Hans.md`](../resources/mcp-skills-catalog.zh-Hans.md)（77+ 个分类整理）。
+> **MCP catalog**：要把 CLI 接到日常工具（GitHub、Linear、Atlassian、Postgres、Playwright、Figma 等）→ [`resources/mcp-skills-catalog.zh-Hans.md`](../resources/mcp-skills-catalog.zh-Hans.md)（78+ 个分类整理）。
 >
 > 本页只列**跟开发者 workflow 直接相关**的工具入口。
 

--- a/branches/for-everyday-users.en.md
+++ b/branches/for-everyday-users.en.md
@@ -74,7 +74,7 @@ Desktop version of ChatGPT. Ask questions about screenshots, voice conversation,
 >
 > Want step-by-step onboarding? See [`tracks/cli/A1-cli-intro.en.md`](../tracks/cli/A1-cli-intro.en.md) — Track A first stop, from install to your first task.
 >
-> Want to wire your CLI agent to Notion / Obsidian / Excel / Google docs / etc.? See [`resources/mcp-skills-catalog.en.md`](../resources/mcp-skills-catalog.en.md) — 77+ MCP servers / Skills grouped by use case.
+> Want to wire your CLI agent to Notion / Obsidian / Excel / Google docs / etc.? See [`resources/mcp-skills-catalog.en.md`](../resources/mcp-skills-catalog.en.md) — 78+ MCP servers / Skills grouped by use case.
 
 #### [anthropics/claude-code](https://github.com/anthropics/claude-code) ⭐⭐⭐⭐⭐
 ★ 138k+ — Anthropic's official CLI agent. Reads/writes files, runs commands, handles multi-step tasks. **The most beginner-friendly CLI tool for everyday users.**

--- a/branches/for-everyday-users.md
+++ b/branches/for-everyday-users.md
@@ -76,7 +76,7 @@ ChatGPT 桌面版。可以對螢幕截圖問問題、語音對話、跟其他 Ap
 >
 > 想要 step-by-step 上手？見 [`tracks/cli/A1-cli-intro.md`](../tracks/cli/A1-cli-intro.md)（Track A 第一站，從安裝到第一個任務）。
 >
-> 想把 CLI agent 接到你的 Notion / Obsidian / Excel / Google 文件等日常工具？見 [`resources/mcp-skills-catalog.md`](../resources/mcp-skills-catalog.md)（按分類整理 77+ 個 MCP server / Skill）。
+> 想把 CLI agent 接到你的 Notion / Obsidian / Excel / Google 文件等日常工具？見 [`resources/mcp-skills-catalog.md`](../resources/mcp-skills-catalog.md)（按分類整理 78+ 個 MCP server / Skill）。
 
 #### [anthropics/claude-code](https://github.com/anthropics/claude-code) ⭐⭐⭐⭐⭐
 ★ 138k+ — Anthropic 官方的 CLI agent。能讀寫檔案、執行指令、做多步驟任務。**日常使用者最容易上手的 CLI 工具**。

--- a/branches/for-everyday-users.zh-Hans.md
+++ b/branches/for-everyday-users.zh-Hans.md
@@ -76,7 +76,7 @@ ChatGPT 桌面版。可以对屏幕截图问问题、语音对话、跟其他 Ap
 >
 > 想要 step-by-step 上手？见 [`tracks/cli/A1-cli-intro.zh-Hans.md`](../tracks/cli/A1-cli-intro.zh-Hans.md)（Track A 第一站，从安装到第一个任务）。
 >
-> 想把 CLI agent 接到你的 Notion / Obsidian / Excel / Google 文件等日常工具？见 [`resources/mcp-skills-catalog.zh-Hans.md`](../resources/mcp-skills-catalog.zh-Hans.md)（按分类整理 77+ 个 MCP server / Skill）。
+> 想把 CLI agent 接到你的 Notion / Obsidian / Excel / Google 文件等日常工具？见 [`resources/mcp-skills-catalog.zh-Hans.md`](../resources/mcp-skills-catalog.zh-Hans.md)（按分类整理 78+ 个 MCP server / Skill）。
 
 #### [anthropics/claude-code](https://github.com/anthropics/claude-code) ⭐⭐⭐⭐⭐
 ★ 138k+ — Anthropic 官方的 CLI agent。能读写文件、执行指令、做多步骤任务。**日常用户最容易上手的 CLI 工具**。

--- a/branches/for-knowledge-worker.en.md
+++ b/branches/for-knowledge-worker.en.md
@@ -24,7 +24,7 @@ The table below splits a knowledge worker's day into 7 common scenarios. Most of
 
 ## Curated Projects
 
-> 💡 **Want to wire your AI agent to Notion / Gmail / Outlook / Slack / Excel / Lark?** Example: automatically turn Gmail messages into Notion todos. 77+ commonly-used office integration tools are listed in [`resources/mcp-skills-catalog.en.md`](../resources/mcp-skills-catalog.en.md) (grouped by use case). The section below stays focused on workflow / integration-platform-level tools.
+> 💡 **Want to wire your AI agent to Notion / Gmail / Outlook / Slack / Excel / Lark?** Example: automatically turn Gmail messages into Notion todos. 78+ commonly-used office integration tools are listed in [`resources/mcp-skills-catalog.en.md`](../resources/mcp-skills-catalog.en.md) (grouped by use case). The section below stays focused on workflow / integration-platform-level tools.
 
 ### Workflow Tools
 

--- a/branches/for-knowledge-worker.md
+++ b/branches/for-knowledge-worker.md
@@ -24,7 +24,7 @@
 
 ## 精選 Projects
 
-> 💡 **想把 AI agent 接到 Notion / Gmail / Outlook / Slack / Excel / 飛書？**（例：把 Gmail 來信自動整理成 Notion 待辦）77+ 個常用辦公整合工具表見 [`resources/mcp-skills-catalog.md`](../resources/mcp-skills-catalog.md)（按使用情境分類）。下面這節保留 workflow / 整合平台級的工具。
+> 💡 **想把 AI agent 接到 Notion / Gmail / Outlook / Slack / Excel / 飛書？**（例：把 Gmail 來信自動整理成 Notion 待辦）78+ 個常用辦公整合工具表見 [`resources/mcp-skills-catalog.md`](../resources/mcp-skills-catalog.md)（按使用情境分類）。下面這節保留 workflow / 整合平台級的工具。
 
 ### 工作流工具
 

--- a/branches/for-knowledge-worker.zh-Hans.md
+++ b/branches/for-knowledge-worker.zh-Hans.md
@@ -24,7 +24,7 @@
 
 ## 精选 Projects
 
-> 💡 **想把 AI agent 接到 Notion / Gmail / Outlook / Slack / Excel / 飞书？**（例：把 Gmail 来信自动整理成 Notion 待办）77+ 个常用办公集成工具表见 [`resources/mcp-skills-catalog.zh-Hans.md`](../resources/mcp-skills-catalog.zh-Hans.md)（按使用场景分类）。下面这节保留 workflow / 集成平台级的工具。
+> 💡 **想把 AI agent 接到 Notion / Gmail / Outlook / Slack / Excel / 飞书？**（例：把 Gmail 来信自动整理成 Notion 待办）78+ 个常用办公集成工具表见 [`resources/mcp-skills-catalog.zh-Hans.md`](../resources/mcp-skills-catalog.zh-Hans.md)（按使用场景分类）。下面这节保留 workflow / 集成平台级的工具。
 
 ### 工作流工具
 

--- a/branches/for-researcher.en.md
+++ b/branches/for-researcher.en.md
@@ -24,7 +24,7 @@ Research days break into stages, and AI plays a different role at each stage. Us
 
 ## Curated Projects
 
-> 💡 **Want to wire Claude Code into NotebookLM, Obsidian, Notion, Excel, PDF, Excalidraw, and other research tools?** 77+ integrations in [`resources/mcp-skills-catalog.en.md`](../resources/mcp-skills-catalog.en.md) (grouped by use case). The section below keeps research-specific tools and marketplaces.
+> 💡 **Want to wire Claude Code into NotebookLM, Obsidian, Notion, Excel, PDF, Excalidraw, and other research tools?** 78+ integrations in [`resources/mcp-skills-catalog.en.md`](../resources/mcp-skills-catalog.en.md) (grouped by use case). The section below keeps research-specific tools and marketplaces.
 
 ### Research Workflow Marketplaces
 

--- a/branches/for-researcher.md
+++ b/branches/for-researcher.md
@@ -24,7 +24,7 @@
 
 ## 精選 Projects
 
-> 💡 **想把 Claude Code 接到 NotebookLM、Obsidian、Notion、Excel、PDF、Excalidraw 等研究常用工具？** 77+ 個整合在 [`resources/mcp-skills-catalog.md`](../resources/mcp-skills-catalog.md)（按使用情境分類）。下面這節保留「研究專屬」的工具與 marketplace。
+> 💡 **想把 Claude Code 接到 NotebookLM、Obsidian、Notion、Excel、PDF、Excalidraw 等研究常用工具？** 78+ 個整合在 [`resources/mcp-skills-catalog.md`](../resources/mcp-skills-catalog.md)（按使用情境分類）。下面這節保留「研究專屬」的工具與 marketplace。
 
 ### 研究流程 Marketplace
 

--- a/branches/for-researcher.zh-Hans.md
+++ b/branches/for-researcher.zh-Hans.md
@@ -24,7 +24,7 @@
 
 ## 精选 Projects
 
-> 💡 **想把 Claude Code 接到 NotebookLM、Obsidian、Notion、Excel、PDF、Excalidraw 等研究常用工具？** 77+ 个集成在 [`resources/mcp-skills-catalog.zh-Hans.md`](../resources/mcp-skills-catalog.zh-Hans.md)（按使用场景分类）。下面这节保留“研究专属”的工具与 marketplace。
+> 💡 **想把 Claude Code 接到 NotebookLM、Obsidian、Notion、Excel、PDF、Excalidraw 等研究常用工具？** 78+ 个集成在 [`resources/mcp-skills-catalog.zh-Hans.md`](../resources/mcp-skills-catalog.zh-Hans.md)（按使用场景分类）。下面这节保留“研究专属”的工具与 marketplace。
 
 ### 研究流程 Marketplace
 

--- a/resources/README.en.md
+++ b/resources/README.en.md
@@ -14,7 +14,7 @@
 |---|---|---|---|
 | [`glossary.en.md`](glossary.en.md) | **30-second term lookup** | You hit terms like LLM / RAG / token / agent / vector DB / streaming / batch API while reading a stage | ~210 |
 | [`cli-agents-guide.en.md`](cli-agents-guide.en.md) | **8 CLI agents compared** | First time choosing among Claude Code / Codex / OpenCode / Gemini CLI / goose / Aider / Hermes Agent / Grok Build | ~134 |
-| [`mcp-skills-catalog.en.md`](mcp-skills-catalog.en.md) | **77+ integration catalog** | You want Claude Code connected to Notion / Obsidian / Excel / Postgres / Slack / other real tools | ~775 |
+| [`mcp-skills-catalog.en.md`](mcp-skills-catalog.en.md) | **78+ integration catalog** | You want Claude Code connected to Notion / Obsidian / Excel / Postgres / Slack / other real tools | ~775 |
 | [`schema-design-cheatsheet.en.md`](schema-design-cheatsheet.en.md) | **5 function-schema rules + 5 anti-patterns** | You are writing a tool schema / MCP server schema / function calling and the LLM picks the wrong tool or arguments | ~159 |
 | [`cookbook.en.md`](cookbook.en.md) | **6 step-by-step recipes** | You want to build a first Skill / MCP server / Office integration / NotebookLM flow / Zotero flow / local LLM in 30-50 minutes | ~620 |
 | [`setup-guide.en.md`](setup-guide.en.md) | **From-zero setup guide** | No dev background; first time creating an API key, installing Python, or using Claude Code | ~400 |
@@ -40,7 +40,7 @@ You do not need any reference first. **Start with the main [README](../README.en
 
 ### 🔌 I Want to Connect Claude Code to Tool X (Notion / Excel / Postgres / etc.)
 
-→ [`mcp-skills-catalog.en.md`](mcp-skills-catalog.en.md) (77+ integrations in 16 categories)
+→ [`mcp-skills-catalog.en.md`](mcp-skills-catalog.en.md) (78+ integrations in 16 categories)
 
 ### 🍳 I Want to Build My First Skill / MCP Server / Word Integration
 

--- a/resources/README.md
+++ b/resources/README.md
@@ -14,7 +14,7 @@
 |---|---|---|---|
 | [`glossary.md`](glossary.md) | **30 秒查詞典** | 看 stage 內文時遇到 LLM / RAG / token / agent / vector DB / streaming / batch API 不知道什麼意思 | ~210 |
 | [`cli-agents-guide.md`](cli-agents-guide.md) | **8 個 CLI agent 比較** | 第一次選 CLI agent（Claude Code / Codex / OpenCode / Gemini CLI / goose / Aider / Hermes Agent / Grok Build）不知道挑哪個 | ~134 |
-| [`mcp-skills-catalog.md`](mcp-skills-catalog.md) | **77+ 個整合 catalog** | 想把 Claude Code 接 Notion / Obsidian / Excel / Postgres / Slack / 等等實際工具 | ~775 |
+| [`mcp-skills-catalog.md`](mcp-skills-catalog.md) | **78+ 個整合 catalog** | 想把 Claude Code 接 Notion / Obsidian / Excel / Postgres / Slack / 等等實際工具 | ~775 |
 | [`schema-design-cheatsheet.md`](schema-design-cheatsheet.md) | **function schema 設計 5 規則 + 5 anti-pattern** | 寫 tool schema / MCP server schema / function calling，發現 LLM 選錯 tool / 傳錯參數 | ~159 |
 | [`cookbook.md`](cookbook.md) | **6 個 step-by-step recipe** | 想 30-50 分鐘做出第一個 Skill / MCP server / 接 Office / 接 NotebookLM / 接 Zotero / 接本機 LLM | ~620 |
 | [`setup-guide.md`](setup-guide.md) | **從零開始的 setup 指南** | 完全沒 dev 背景、第一次申請 API key / 裝 Python / 用 Claude Code | ~400 |
@@ -40,7 +40,7 @@
 
 ### 🔌 我要把 Claude Code 接 X 工具（Notion / Excel / Postgres 等）
 
-→ [`mcp-skills-catalog.md`](mcp-skills-catalog.md)（77+ 個整合分 16 類）
+→ [`mcp-skills-catalog.md`](mcp-skills-catalog.md)（78+ 個整合分 16 類）
 
 ### 🍳 我想動手寫第一個 Skill / MCP server / 接 Word 等
 

--- a/resources/README.zh-Hans.md
+++ b/resources/README.zh-Hans.md
@@ -14,7 +14,7 @@
 |---|---|---|---|
 | [`glossary.zh-Hans.md`](glossary.zh-Hans.md) | **30 秒查词典** | 看 stage 内容时遇到 LLM / RAG / token / agent / vector DB / streaming / batch API 不知道什么意思 | ~210 |
 | [`cli-agents-guide.zh-Hans.md`](cli-agents-guide.zh-Hans.md) | **8 个 CLI agent 比较** | 第一次选 CLI agent（Claude Code / Codex / OpenCode / Gemini CLI / goose / Aider / Hermes Agent / Grok Build）不知道挑哪个 | ~134 |
-| [`mcp-skills-catalog.zh-Hans.md`](mcp-skills-catalog.zh-Hans.md) | **77+ 个集成 catalog** | 想把 Claude Code 接 Notion / Obsidian / Excel / Postgres / Slack / 等实际工具 | ~775 |
+| [`mcp-skills-catalog.zh-Hans.md`](mcp-skills-catalog.zh-Hans.md) | **78+ 个集成 catalog** | 想把 Claude Code 接 Notion / Obsidian / Excel / Postgres / Slack / 等实际工具 | ~775 |
 | [`schema-design-cheatsheet.zh-Hans.md`](schema-design-cheatsheet.zh-Hans.md) | **function schema 设计 5 规则 + 5 anti-pattern** | 写 tool schema / MCP server schema / function calling，发现 LLM 选错 tool / 传错参数 | ~159 |
 | [`cookbook.zh-Hans.md`](cookbook.zh-Hans.md) | **6 个 step-by-step recipe** | 想 30-50 分钟做出第一个 Skill / MCP server / 接 Office / 接 NotebookLM / 接 Zotero / 接本机 LLM | ~620 |
 | [`setup-guide.zh-Hans.md`](setup-guide.zh-Hans.md) | **从零开始的 setup 指南** | 完全没有 dev 背景、第一次申请 API key / 装 Python / 用 Claude Code | ~400 |
@@ -40,7 +40,7 @@
 
 ### 🔌 我要把 Claude Code 接 X 工具（Notion / Excel / Postgres 等）
 
-→ [`mcp-skills-catalog.zh-Hans.md`](mcp-skills-catalog.zh-Hans.md)（77+ 个集成分 16 类）
+→ [`mcp-skills-catalog.zh-Hans.md`](mcp-skills-catalog.zh-Hans.md)（78+ 个集成分 16 类）
 
 ### 🍳 我想动手写第一个 Skill / MCP server / 接 Word 等
 

--- a/resources/mcp-skills-catalog.en.md
+++ b/resources/mcp-skills-catalog.en.md
@@ -2,7 +2,7 @@
 
 > [繁體中文](./mcp-skills-catalog.md) | [简体中文](./mcp-skills-catalog.zh-Hans.md) | **English**
 
-> Connect Claude Code (or any other CLI agent) to the apps you already use, without window-hopping. This page is a curated index of 77+ MCP servers / Claude Skills / integrations grouped by use case (incl. research-workflow + multi-LLM-delegation dedicated sections).
+> Connect Claude Code (or any other CLI agent) to the apps you already use, without window-hopping. This page is a curated index of 78+ MCP servers / Claude Skills / integrations grouped by use case (incl. research-workflow + multi-LLM-delegation dedicated sections).
 
 ---
 
@@ -28,7 +28,7 @@
 5. [Dev Collaboration (GitHub / Atlassian / Slack…)](#5-dev-collaboration-github--atlassian--slack) (9)
 6. [Databases](#6-databases) (8)
 7. [Browser Automation / Web Scraping](#7-browser-automation--web-scraping) (4)
-8. [Design (Figma / Excalidraw)](#8-design-figma--excalidraw) (4)
+8. [Design (Figma / Excalidraw)](#8-design-figma--excalidraw) (5)
 9. [Monitoring / Observability](#9-monitoring--observability) (3)
 10. [Media / Streaming (YouTube / Spotify)](#10-media--streaming-youtube--spotify) (3)
 11. [Chinese-language Ecosystem](#11-chinese-language-ecosystem) (11)
@@ -597,6 +597,23 @@
 **What it does**: "**The design language that makes your AI harness better at design.**" A vocabulary / pattern set that helps AI agents produce UI / visual output that escapes the generic "AI-generated" feel.
 **Audience**: developers using AI to generate UI / mockups / visual designs but getting generic results; front-end + AI workflows.
 **Notes**: not an MCP server or Skill bundle — it's a **design language** reference. Feed AI the higher-quality design vocabulary and it produces better output.
+
+### [uizze/uizze](https://github.com/uizze/uizze) ⭐⭐⭐⭐
+
+| Field | Value |
+|---|---|
+| Stars | ★ 7 |
+| License | MIT |
+| Rating | ⭐⭐⭐⭐ |
+
+**What it does**: a free `anti-ui-slop` Skill and UI quality gate for coding agents. Before a UI change is merged, it checks the design contract, required states, interaction semantics, and finish-gate criteria for generic UI, inert controls, missing states, and token drift. The full UIZZE workflow can use 800,000+ real web and iOS screens as reference evidence.
+**Audience**: people using Codex, Claude Code, Cursor, Copilot, or another coding agent to build web / iOS UI who want repeatable pre-merge quality checks.
+**Notes**: the Skill runs locally for free; the no-account preview exposes deterministic `check_ui_slop`. The full workflow adds live search, validation, audits, and rendered critique, with the free Skill and hosted MCP kept separate.
+
+**How to run**:
+```bash
+npx skills add https://uizze.com --skill anti-ui-slop
+```
 
 ---
 

--- a/resources/mcp-skills-catalog.md
+++ b/resources/mcp-skills-catalog.md
@@ -2,7 +2,7 @@
 
 > **繁體中文** | [简体中文](./mcp-skills-catalog.zh-Hans.md) | [English](./mcp-skills-catalog.en.md)
 
-> 把 Claude Code（或其他 CLI agent）接到你已經在用的工具，不用反覆切換視窗。本頁是 77+ 個分類整理過的 MCP server / Claude Skill / 整合範例（含研究工作流 + multi-LLM delegation 兩個專屬區）。
+> 把 Claude Code（或其他 CLI agent）接到你已經在用的工具，不用反覆切換視窗。本頁是 78+ 個分類整理過的 MCP server / Claude Skill / 整合範例（含研究工作流 + multi-LLM delegation 兩個專屬區）。
 
 ---
 
@@ -28,7 +28,7 @@
 5. [開發協作（GitHub / Atlassian / Slack…）](#5-開發協作github--atlassian--slack)（9）
 6. [資料庫](#6-資料庫)（8）
 7. [瀏覽器自動化 / 網頁抓取](#7-瀏覽器自動化--網頁抓取)（4）
-8. [設計（Figma / Excalidraw）](#8-設計figma--excalidraw)（4）
+8. [設計（Figma / Excalidraw）](#8-設計figma--excalidraw)（5）
 9. [監控 / Observability](#9-監控--observability)（3）
 10. [媒體 / 串流（YouTube / Spotify）](#10-媒體--串流youtube--spotify)（3）
 11. [中文圈專用](#11-中文圈專用)（11）
@@ -597,6 +597,23 @@
 **教什麼**：「**讓你 AI harness 在 design 上更強的 design language**」——一套設計 vocabulary / pattern，幫 AI 在生成 UI / 視覺成品時跳出常見的「AI 感」生硬風格。
 **適合誰**：用 AI 生 UI / mockup / visual design 但結果都很 generic 的開發者；前端 + AI workflow。
 **備註**：不是 MCP server 也不是 Skill 包——是一份「**design language**」reference。讓 AI 看到比較高品質的設計詞彙才生得出比較好的東西。
+
+### [uizze/uizze](https://github.com/uizze/uizze) ⭐⭐⭐⭐
+
+| 欄位 | 內容 |
+|---|---|
+| Stars | ★ 7 |
+| License | MIT |
+| 推薦度 | ⭐⭐⭐⭐ |
+
+**教什麼**：免費 `anti-ui-slop` Skill 與 UI quality gate，讓 coding agent 在 UI merge 前用 design contract、required states、interaction checks 與 finish gate 抓出 generic UI、inert controls、missing states 與 token drift。完整 UIZZE workflow 可用 800,000+ 真實 web 與 iOS screens 作為參考。
+**適合誰**：使用 Codex、Claude Code、Cursor、Copilot 或其他 coding agent 產生 web / iOS UI、想在送出前做可重複品質檢查的人。
+**備註**：Skill 可在本地免費執行；no-account preview 是 deterministic `check_ui_slop`。完整 workflow 另提供 live search、validation、audits 與 rendered critique，免費 Skill 與 hosted MCP 的範圍清楚分開。
+
+**怎麼跑**：
+```bash
+npx skills add https://uizze.com --skill anti-ui-slop
+```
 
 ---
 

--- a/resources/mcp-skills-catalog.zh-Hans.md
+++ b/resources/mcp-skills-catalog.zh-Hans.md
@@ -2,7 +2,7 @@
 
 > [繁體中文](./mcp-skills-catalog.md) | **简体中文** | [English](./mcp-skills-catalog.en.md)
 
-> 把 Claude Code（或其他 CLI agent）接到你已经正在用的工具，不用反复切换视窗。本页是 77+ 个分类整理过的 MCP server / Claude Skill / 集成范例（含研究工作流 + multi-LLM delegation 两个专属区）。
+> 把 Claude Code（或其他 CLI agent）接到你已经正在用的工具，不用反复切换视窗。本页是 78+ 个分类整理过的 MCP server / Claude Skill / 集成范例（含研究工作流 + multi-LLM delegation 两个专属区）。
 
 ---
 
@@ -28,7 +28,7 @@
 5. [开发协作（GitHub / Atlassian / Slack…）](#5-开发协作github--atlassian--slack)（9）
 6. [数据库](#6-数据库)（8）
 7. [浏览器自动化 / 网页抓取](#7-浏览器自动化--网页抓取)（4）
-8. [设计（Figma / Excalidraw）](#8-设计figma--excalidraw)（4）
+8. [设计（Figma / Excalidraw）](#8-设计figma--excalidraw)（5）
 9. [监控 / Observability](#9-监控--observability)（3）
 10. [媒体 / 串流（YouTube / Spotify）](#10-媒体--串流youtube--spotify)（3）
 11. [中文圈专属](#11-中文圈专属)（11）
@@ -597,6 +597,23 @@
 **教什么**："**让你 AI harness 在 design 上更强的 design language**"——一套设计 vocabulary / pattern，帮 AI 在生成 UI / 视觉成品时跳出常见的"AI 感"生硬风格。
 **适合谁**：用 AI 生 UI / mockup / visual design 但结果都很 generic 的开发者；前端 + AI workflow。
 **备注**：不是 MCP server 也不是 Skill 包——是一份"**design language**"reference。让 AI 看到比较高质量的设计词汇才生得出比较好的东西。
+
+### [uizze/uizze](https://github.com/uizze/uizze) ⭐⭐⭐⭐
+
+| 栏位 | 内容 |
+|---|---|
+| Stars | ★ 7 |
+| License | MIT |
+| 推荐度 | ⭐⭐⭐⭐ |
+
+**教什么**：免费的 `anti-ui-slop` Skill 与 UI quality gate，让 coding agent 在 UI merge 前用 design contract、required states、interaction checks 与 finish gate 抓出 generic UI、inert controls、missing states 与 token drift。完整 UIZZE workflow 可使用 800,000+ 个真实 web 与 iOS screens 作为参考。
+**适合谁**：使用 Codex、Claude Code、Cursor、Copilot 或其他 coding agent 产生 web / iOS UI、想在提交前做可重复质量检查的人。
+**备注**：Skill 可在本地免费运行；no-account preview 提供 deterministic `check_ui_slop`。完整 workflow 另提供 live search、validation、audits 与 rendered critique，免费 Skill 与 hosted MCP 的范围清楚分开。
+
+**怎么运行**：
+```bash
+npx skills add https://uizze.com --skill anti-ui-slop
+```
 
 ---
 

--- a/stages/05-claude-code-ecosystem.en.md
+++ b/stages/05-claude-code-ecosystem.en.md
@@ -305,7 +305,7 @@ MCP / Skills give the agent *more* abilities; **Hooks are the reverse: you attac
 ### Curated Projects (for spec / SDK / template reference)
 
 > 💡 **Looking for MCP servers for everyday tools (Notion / Obsidian / Excel / Postgres / Playwright / Figma, etc.)?**
-> Check out [`resources/mcp-skills-catalog.en.md`](../resources/mcp-skills-catalog.en.md)—it organizes 77+ common MCP servers / Skills into 16 categories, each with stars / license / intended audience. The table below retains official servers / SDKs that serve as a "**reference for writing your own MCP server**."
+> Check out [`resources/mcp-skills-catalog.en.md`](../resources/mcp-skills-catalog.en.md)—it organizes 78+ common MCP servers / Skills into 16 categories, each with stars / license / intended audience. The table below retains official servers / SDKs that serve as a "**reference for writing your own MCP server**."
 
 | Project | ⭐ | Best for | Why it's recommended / Notes |
 |---|---|---|---|

--- a/stages/05-claude-code-ecosystem.md
+++ b/stages/05-claude-code-ecosystem.md
@@ -305,7 +305,7 @@ MCP / Skills 是「給 agent 更多能力」；**Hooks 則是反過來：在 age
 ### 精選 Projects（spec / SDK / 範本參考）
 
 > 💡 **找日常工具的 MCP（Notion / Obsidian / Excel / Postgres / Playwright / Figma 等）？**
-> 看 [`resources/mcp-skills-catalog.md`](../resources/mcp-skills-catalog.md)——按 16 個分類整理 77+ 個常用 MCP server / Skill，每個都附 stars / license / 適合誰。下表保留的是「**寫自己 MCP server 時的 reference**」性質的官方 server / SDK。
+> 看 [`resources/mcp-skills-catalog.md`](../resources/mcp-skills-catalog.md)——按 16 個分類整理 78+ 個常用 MCP server / Skill，每個都附 stars / license / 適合誰。下表保留的是「**寫自己 MCP server 時的 reference**」性質的官方 server / SDK。
 
 | Project | ⭐ | 適合誰 | 為什麼推薦 / 備註 |
 |---|---|---|---|

--- a/stages/05-claude-code-ecosystem.zh-Hans.md
+++ b/stages/05-claude-code-ecosystem.zh-Hans.md
@@ -305,7 +305,7 @@ MCP / Skills 是“给 agent 更多能力”；**Hooks 则是反过来：在 age
 ### 精选 Projects（spec / SDK / 范本参考）
 
 > 💡 **找日常工具的 MCP（Notion / Obsidian / Excel / Postgres / Playwright / Figma 等）？**
-> 看 [`resources/mcp-skills-catalog.zh-Hans.md`](../resources/mcp-skills-catalog.zh-Hans.md)——按 16 个分类整理 77+ 个常用 MCP server / Skill，每个都附 stars / license / 适合谁。下表保留的是“**写自己 MCP server 时的 reference**”性质的官方 server / SDK。
+> 看 [`resources/mcp-skills-catalog.zh-Hans.md`](../resources/mcp-skills-catalog.zh-Hans.md)——按 16 个分类整理 78+ 个常用 MCP server / Skill，每个都附 stars / license / 适合谁。下表保留的是“**写自己 MCP server 时的 reference**”性质的官方 server / SDK。
 
 | Project | ⭐ | 适合谁 | 为什么推荐 / 备注 |
 |---|---|---|---|

--- a/tracks/cli/A3-cli-production.en.md
+++ b/tracks/cli/A3-cli-production.en.md
@@ -190,7 +190,7 @@ Track A users are **already using** [Stage 7.5 advanced concepts](../../stages/0
 
 Four categories, nine projects, one table. **Pick an entry point from the "Who it's for" column; click through to the repo when you want the details.**
 
-> 💡 **Looking for MCPs that connect to daily tools** (Notion / Obsidian / Excel / Postgres / Playwright / Slack / Linear / Figma…): see [`resources/mcp-skills-catalog.en.md`](../../resources/mcp-skills-catalog.en.md) — 77+ entries grouped by category, each with stars / license / audience. The table below is for "writing your own MCP server / finding reference implementations".
+> 💡 **Looking for MCPs that connect to daily tools** (Notion / Obsidian / Excel / Postgres / Playwright / Slack / Linear / Figma…): see [`resources/mcp-skills-catalog.en.md`](../../resources/mcp-skills-catalog.en.md) — 78+ entries grouped by category, each with stars / license / audience. The table below is for "writing your own MCP server / finding reference implementations".
 
 | Category | Project | ⭐ | Who it's for | Why recommended / notes |
 |---|---|---|---|---|

--- a/tracks/cli/A3-cli-production.md
+++ b/tracks/cli/A3-cli-production.md
@@ -190,7 +190,7 @@ Track A 的人**已經在用** [Stage 7.5 的進階概念](../../stages/07.5-adv
 
 按用途分 4 類、9 個項目一張表搞定。**挑入口看「適合誰」、想深入細節點連結看 repo**。
 
-> 💡 **要找接日常工具的 MCP**（Notion / Obsidian / Excel / Postgres / Playwright / Slack / Linear / Figma 等）：[`resources/mcp-skills-catalog.md`](../../resources/mcp-skills-catalog.md)——77+ 個分類整理，每個都有 stars / license / 適合誰。下表只列「寫自己 MCP server / 找 reference」用的核心 catalog。
+> 💡 **要找接日常工具的 MCP**（Notion / Obsidian / Excel / Postgres / Playwright / Slack / Linear / Figma 等）：[`resources/mcp-skills-catalog.md`](../../resources/mcp-skills-catalog.md)——78+ 個分類整理，每個都有 stars / license / 適合誰。下表只列「寫自己 MCP server / 找 reference」用的核心 catalog。
 
 | 分類 | Project | ⭐ | 適合誰 | 為什麼推薦 / 備註 |
 |---|---|---|---|---|

--- a/tracks/cli/A3-cli-production.zh-Hans.md
+++ b/tracks/cli/A3-cli-production.zh-Hans.md
@@ -190,7 +190,7 @@ Track A 的人**已经在用** [Stage 7.5 的进阶概念](../../stages/07.5-adv
 
 按用途分 4 类、9 个项目一张表搞定。**挑入口看“适合谁”，想深入细节点链接看 repo**。
 
-> 💡 **要找接日常工具的 MCP**（Notion / Obsidian / Excel / Postgres / Playwright / Slack / Linear / Figma 等）：[`resources/mcp-skills-catalog.zh-Hans.md`](../../resources/mcp-skills-catalog.zh-Hans.md)——77+ 个分类整理，每个都有 stars / license / 适合谁。下表只列“写自己 MCP server / 找 reference”用的核心 catalog。
+> 💡 **要找接日常工具的 MCP**（Notion / Obsidian / Excel / Postgres / Playwright / Slack / Linear / Figma 等）：[`resources/mcp-skills-catalog.zh-Hans.md`](../../resources/mcp-skills-catalog.zh-Hans.md)——78+ 个分类整理，每个都有 stars / license / 适合谁。下表只列“写自己 MCP server / 找 reference”用的核心 catalog。
 
 | 分类 | Project | ⭐ | 适合谁 | 为什么推荐 / 备注 |
 |---|---|---|---|---|


### PR DESCRIPTION
## 內容

在 MCP / Skills catalog 的「設計」分類加入 [uizze/uizze](https://github.com/uizze/uizze)：

- 免費 MIT `anti-ui-slop` Skill，供 Codex、Claude Code、Cursor、Copilot 等 coding agent 使用
- 在 UI merge 前檢查 design contract、required states、interaction semantics 與 finish gate
- 清楚區分免費本地 Skill / deterministic `check_ui_slop` preview 與可選的完整 UIZZE workflow
- 完整 workflow 可用 800,000+ 真實 web 與 iOS screens 作為參考證據
- 同步更新 zh-TW、简体中文、English 三份 catalog mirrors，以及所有 78+ catalog count references

Intake rationale: #110

## 驗證

- `python3 scripts/check-catalog-counts.py` — 78 entries; all 39 size claims agree
- `python3 scripts/check-mirror-parity.py` — pass
- `python3 scripts/check-locale-links.py` — pass
- `python3 scripts/test_catalog_counts.py` — 11/11 pass
- `python3 scripts/test_mirror_parity.py` — 17/17 pass
- `python3 scripts/test_locale_links.py` — 14/14 pass
- `git diff --check` — pass

The UIZZE project is disclosed as the known implementation; this entry is intended as a curated design/quality resource, not an undisclosed advertisement.