### PR TITLE
chore(release): v2026.08.19

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,8 +16,8 @@ abstract: >-
   ecosystem, memory/RAG, and multi-agent production, organized as
   staged tracks and audience-specific branches.
 license: MIT
-version: "2026.08.14-5"
-date-released: "2026-08-14"
+version: "2026.08.19"
+date-released: "2026-08-19"
 keywords:
   - agentic-ai
   - ai-agents


### PR DESCRIPTION
`CITATION.cff` 版號 `2026.08.14-5` → `2026.08.19`（當日第一個，依慣例無後綴）。

## 這一版收了 5 個 commit

- **[#104](https://github.com/WenyuChiou/awesome-agentic-ai-zh/pull/104)** — zh-Hans 的「影片」規則改成**帶守衛**而不是整條排除。原本 gate 一直回報 clean，樹上卻躺著五處真的台灣用語：因為「影片」是「投影片」的子字串，純字串取代會弄壞後者，於是整條規則被拿掉了。**排除是看不見的，守衛是可以測的。** 跑了六輪 review，守衛最後改成以**空行**為邊界而不是字元數上限，而且這支會改寫檔案的 gate 終於有了單元測試。
- **71089cd** — 「投影片」→「幻灯片」，zh-Hans 的最後一個。其他 5 處早就寫「幻灯片」，包括前一個 stage 裡同一堂李宏毅課程的同一句。
- **53243f4** — 把碰撞範例重新錨定到繁中 canonical，因為上一個 commit 正好移除了兩段註解引用的那行「活證據」。
- **[#109](https://github.com/WenyuChiou/awesome-agentic-ai-zh/pull/109)** — 每週星數自動刷新（bot）。
- **[#113](https://github.com/WenyuChiou/awesome-agentic-ai-zh/pull/113)** — Stage 7 加入 orca / qm / edict 三個多 agent harness；catalog 開第 17 類**資安**，原本 16 類一個資安項目都沒有。條目 77 → 79。

## 查證

- **日期用 `api.github.com` 獨立確認**，沒有採信 session context——本週稍早它曾經差了三天。
- 版號 parity 用涵蓋「點」與「連字號」兩種日期寫法的 pattern 掃過，CHANGELOG 以外只有 `CITATION.cff:19,20` 命中；`lint.yml` 那兩處是 2026-08-14 事件的歷史註解，不是版號。
- `v2026.08.19` tag 未被使用。
- 6 個內容 gate、`zh-hans-localize --check`、13 份測試全綠。

🤖 Generated with [Claude Code](https://claude.com/claude-code)