### PR TITLE
fix(zh-Hans): 协定 → 协议（五處 protocol 語義）

### DIFF
--- a/RESOURCES.zh-Hans.md
+++ b/RESOURCES.zh-Hans.md
@@ -16,7 +16,7 @@
 
 主 README 跟各 stage 会频繁提到这三个 Claude Code 生态的关键词，先快速说明：
 
-- **MCP（Model Context Protocol）** — Anthropic 推的开放协定，让任何 LLM host（Claude Code、其他 IDE、自写 agent）都能用同一套接口去调用外部 tool server（文件、DB、API、自家系统）。把它想成“LLM 的 USB 接口”。详见 [Stage 5.2](stages/05-claude-code-ecosystem.zh-Hans.md#52--mcpmodel-context-protocol-基础)。
+- **MCP（Model Context Protocol）** — Anthropic 推的开放协议，让任何 LLM host（Claude Code、其他 IDE、自写 agent）都能用同一套接口去调用外部 tool server（文件、DB、API、自家系统）。把它想成“LLM 的 USB 接口”。详见 [Stage 5.2](stages/05-claude-code-ecosystem.zh-Hans.md#52--mcpmodel-context-protocol-基础)。
 - **Skills** — Claude Code 的“行为包”。一个 Skill 就是一份 `SKILL.md`，描述“在什么场景要做什么、可以调用哪些 MCP tool”。写好之后 Claude Code 会自动 discover。详见 [Stage 5.3](stages/05-claude-code-ecosystem.zh-Hans.md#53--skillsclaude-code-的行为层-claude-code-生态最关键的一层)。
 - **Plugins / Marketplaces** — 把 Skills、slash commands、hooks、MCP 设置打包成一个发布单位给 team 或社群安装。Marketplace 就是 plugin 的 catalog。详见 [Stage 5.4](stages/05-claude-code-ecosystem.zh-Hans.md#54--plugins-与-marketplaces)。
 

--- a/resources/glossary.zh-Hans.md
+++ b/resources/glossary.zh-Hans.md
@@ -239,7 +239,7 @@ Anthropic 2024 提的方法——chunk 加上“整份文件的脉络摘要”�
 
 ### A2A（Agent-to-Agent）Protocol
 
-Google 发起、现由 Linux Foundation 治理的 agent 之间沟通协定，类似 MCP 但用于 agent ↔ agent（不是 agent ↔ tool）。2026 已达 **v1.0**（已有 150+ 组织采用，并加入身分验证、让一个 agent 能确认对方是不是真的它），是 MCP（agent↔tool）的姊妹标准。
+Google 发起、现由 Linux Foundation 治理的 agent 之间沟通协议，类似 MCP 但用于 agent ↔ agent（不是 agent ↔ tool）。2026 已达 **v1.0**（已有 150+ 组织采用，并加入身分验证、让一个 agent 能确认对方是不是真的它），是 MCP（agent↔tool）的姊妹标准。
 
 ---
 
@@ -247,7 +247,7 @@ Google 发起、现由 Linux Foundation 治理的 agent 之间沟通协定，类
 
 ### MCP（Model Context Protocol）
 
-Anthropic 在 2024 推出的开放协定，让任何 LLM host（Claude Code、Cursor、自写 agent）都能用同一套接口连接外部 tool server，2025-12 已捐给 Linux Foundation 旗下的 Agentic AI Foundation。把它想成“**LLM 的 USB 接口**”。
+Anthropic 在 2024 推出的开放协议，让任何 LLM host（Claude Code、Cursor、自写 agent）都能用同一套接口连接外部 tool server，2025-12 已捐给 Linux Foundation 旗下的 Agentic AI Foundation。把它想成“**LLM 的 USB 接口**”。
 
 **技术上标准化了 3 种 primitives**：
 

--- a/scripts/zh-hans-localize.py
+++ b/scripts/zh-hans-localize.py
@@ -67,6 +67,15 @@ VOCAB = {
     #   预设/教学  : context-sensitive (default vs assume / tutorial vs
     #                teaching) — no single mainland equivalent.
     #   影片→视频  : MOVED to GUARDED_VOCAB below — see why there.
+    #   协定→协议  : NOT auto-replaced, and not guarded either. 协定 is a
+    #                legitimate mainland word for an AGREEMENT (贸易协定,
+    #                停战协定); it is only wrong when it means PROTOCOL. Both
+    #                senses are open sets, so neither a lookbehind nor a
+    #                blocklist of compounds would hold. Five protocol-sense
+    #                occurrences were fixed by hand on 2026-08-23; a reviewer
+    #                caught them because `--check` reporting clean is not
+    #                evidence for a pair this table does not contain.
+    #                If you are about to add it: don't. Fix by hand.
 }
 
 # Terms that are UNSAFE as blanket substrings but safe with a context guard.

--- a/stages/03-tool-use-and-hello-agent.zh-Hans.md
+++ b/stages/03-tool-use-and-hello-agent.zh-Hans.md
@@ -453,7 +453,7 @@ messages.append({"role": "tool", "tool_call_id": tc.id,
 
 → **基础 starter 范本** → [`examples/stage-3/06-schema-design/`](../examples/stage-3/06-schema-design/)（含 bad schema vs good schema 两个版本对照；illustrative，**不是 chapter-length 完整教程**——深度章节见 stage 开头 📚 hello-agents callout）
 
-> 💡 **手写 schema 之后，认识 MCP**：你上面手写的 tool schema，真实世界已经有标准——**MCP（Model Context Protocol）** 把“工具长什么样、怎么调用”标准化成跨 agent 可复用的协定：写一次，任何支持 MCP 的 agent（Claude Code / Cursor / …）都能用。这里先记得这个名字，[Stage 5.2](05-claude-code-ecosystem.zh-Hans.md#52--mcpmodel-context-protocol-基础) 细讲。
+> 💡 **手写 schema 之后，认识 MCP**：你上面手写的 tool schema，真实世界已经有标准——**MCP（Model Context Protocol）** 把“工具长什么样、怎么调用”标准化成跨 agent 可复用的协议：写一次，任何支持 MCP 的 agent（Claude Code / Cursor / …）都能用。这里先记得这个名字，[Stage 5.2](05-claude-code-ecosystem.zh-Hans.md#52--mcpmodel-context-protocol-基础) 细讲。
 
 ## 🪞 反思（Reflexion / Self-Refine）— 概念 + 路由
 

--- a/stages/07-multi-agent-production.zh-Hans.md
+++ b/stages/07-multi-agent-production.zh-Hans.md
@@ -365,7 +365,7 @@ Production agent 跑久了，**cost / latency 两条线会吃掉你大半预算�
 
 你能不能：
 
-- [ ] 设计一个 multi-agent 系统，协作协定讲得清楚
+- [ ] 设计一个 multi-agent 系统，协作协议讲得清楚
 - [ ] 在 CI 跑自动 eval pipeline
 - [ ] 把 observability（tracing）接到 production agent
 - [ ] 在真实 workload 上量测 prompt caching 前后的成本差异


### PR DESCRIPTION
[PR #121](https://github.com/WenyuChiou/awesome-agentic-ai-zh/pull/121) 的 review 發現简中 MCP callout 用了「协定」（台灣用語），而**同一個檔案的下一則 callout 已經在用「协议」**。掃過全 repo 又找到五處既有殘留。

五處都先讀過脈絡才改，**全部是 protocol 的意思**（开放协议、沟通协议、可复用的协议、协作协议），沒有一處是「協定＝agreement」。

| 檔案 | 處 |
|---|---|
| `RESOURCES.zh-Hans.md` | 1 |
| `resources/glossary.zh-Hans.md` | 2 |
| `stages/03-tool-use-and-hello-agent.zh-Hans.md` | 1 |
| `stages/07-multi-agent-production.zh-Hans.md` | 1 |

## 沒有加進自動改寫規則，這是刻意的

`协定` 在陸語是**合法詞**——貿易協定、停戰協定。它只有在指 protocol 時才錯。兩種語義都是開放集合，lookbehind 擋不住，列舉複合詞的黑名單也守不住。

而 `zh-hans-localize.py` 是會**改寫 tracked 檔案**的 gate：在那裡取代錯了是無聲的破壞，而那正是要命的方向。所以排除理由寫進腳本、跟其他排除項放在一起，並明寫「**如果你正想加上去：不要。手動修。**」

## 一句值得記的

`zh-hans-localize.py --check` 從頭到尾都回報 clean——因為**表裡沒有的詞，gate 就看不見**。gate 通過從來不是關於這個字的證據。

## 驗證

6 個內容 gate、`--check`、13 份測試全綠。

🤖 Generated with [Claude Code](https://claude.com/claude-code)