### PR TITLE
tooling: 同一張表列到同一個 repo 兩次就擋下來

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -323,6 +323,20 @@ jobs:
         # check-links.py in a finally block.
         run: python3 scripts/mutate_check_links.py
 
+      - name: check-duplicate-repos.py (same repo listed twice in one table)
+        # 2026-08-23: microsoft/agent-framework was added to the Stage 4 table
+        # as new when it had been in that same table since 2026-06-13. Stars,
+        # license and push date were verified; the slug was never grepped, and
+        # all six content gates stayed green because the only entry-counting
+        # gate is scoped to resources/mcp-skills-catalog.* and cannot see a
+        # stage's prose table. Compares within one table or list only, using
+        # each row's first link, so cross-references and monorepo subdirectory
+        # entries are not reported. stdlib-only, network-free.
+        run: python3 scripts/check-duplicate-repos.py --quiet
+
+      - name: check-duplicate-repos.py unit tests
+        run: python3 scripts/test_duplicate_repos.py
+
       - name: zh-hans-localize.py substitution rule tests
         # This gate REWRITES tracked files, and until 2026-08-14 nothing tested
         # its substitution logic — the #102 shape. The cost was concrete:

--- a/scripts/check-duplicate-repos.py
+++ b/scripts/check-duplicate-repos.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""
+check-duplicate-repos.py — 同一個 GitHub repo 在同一個檔案裡被列了兩次就報錯。
+
+為什麼需要這個 gate：2026-08-23，`microsoft/agent-framework` 被當成新專案加進
+`stages/04-agent-frameworks.md`，但它 2026-06-13 就已經在同一張表裡了。星數、
+license、push 日期全部查證過，唯獨沒有先 grep 一次 slug。**六個內容 gate 全綠**,
+因為 `check-catalog-counts.py` 只掃 `resources/mcp-skills-catalog.*`,看不到
+stage 裡的散文表格,而其他 gate 根本不管重複。是 reviewer 讀 diff 讀出來的。
+
+順帶暴露了第二件事:那張表的表頭寫「17 個項目」,而它在那次改動之前就已經有
+18 列。加一列又刪一列、淨變動為零,所以那個 off-by-one 差點被一起遮掉。
+
+檢查範圍刻意是「同一個檔案內」而不是「跨檔案」:同一個 repo 出現在 Stage 4 的
+框架表、Stage 7 的 harness 表、跟 catalog 裡是**正常且刻意**的(不同 stage 從不同
+角度講同一個工具),跨檔案報錯只會製造雜訊。真正的錯誤形狀是「同一份清單裡列了
+兩次」。
+
+用法:
+    python scripts/check-duplicate-repos.py            # 全掃
+    python scripts/check-duplicate-repos.py --quiet    # 只印問題
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from md_fences import code_line_flags  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+# Mirrors the other gates' exclude sets. `.claude` holds git worktrees, which
+# are a second full copy of the tree: without this every finding doubles.
+SCAN_EXCLUDE_DIRS = {".git", ".claude", "_build", "node_modules", "book", ".venv"}
+
+# The FULL path, not just owner/repo. Collapsing subdirectory links to their
+# repo root was the first version's mistake: `claude-plugins-official` alone
+# contributes eleven rows, one per plugin under /tree/main/plugins/, and a book
+# repo contributes one row per chapter. Those are eleven and two distinct
+# entries, not duplicates, and reporting them made the gate useless.
+#
+# The defect this exists for had both rows pointing at the same repo ROOT, so
+# comparing full paths still catches it while leaving monorepo listings alone.
+REPO_RE = re.compile(
+    r"github\.com/([A-Za-z0-9][\w.-]*)/([\w.-]+(?:/[\w.\-/]*[\w.-])?)(?=[)\s\"'>#?]|$)",
+    re.IGNORECASE,
+)
+
+# Not real project links.
+IGNORE_OWNERS = {"sponsors", "orgs", "features", "settings", "marketplace", "apps"}
+# A repo legitimately named like a path segment we would otherwise mistake.
+IGNORE_REPOS = {"", ".", ".."}
+
+# Files where repeating a repo is the point, not a defect.
+SKIP_FILES = {
+    "CHANGELOG.md",          # history: the same repo recurs across dated entries
+    "CONTRIBUTORS.md",
+}
+SKIP_DIR_PARTS = {".github"}  # outreach drafts quote the same repo repeatedly
+
+# Deliberate repeats a human has already looked at. Same shape as
+# scripts/mirror-parity-baseline.json: a ratchet, so a NEW duplicate still
+# fails while a confirmed-intentional one stays quiet. Keyed "<file>::<slug>".
+#
+# The one entry here is a book listed one row per chapter, where every row
+# necessarily links the same repo root. That is not the defect this gate is
+# for, and no URL comparison can separate the two, so it is recorded rather
+# than engineered around.
+BASELINE = {
+    "stages/03-tool-use-and-hello-agent.md::datawhalechina/hello-agents",
+    "stages/03-tool-use-and-hello-agent.en.md::datawhalechina/hello-agents",
+    "stages/03-tool-use-and-hello-agent.zh-Hans.md::datawhalechina/hello-agents",
+}
+
+
+def _blocks(text: str):
+    """Yield (kind, start_line, [lines]) for each contiguous TABLE or LIST block.
+
+    The unit of comparison is deliberately the block, not the file. A repo named
+    in prose and then listed in a table below is normal and correct; the repo
+    does that on purpose, since a stage explains a tool and then catalogues it.
+    The defect shape is narrower: the same repo occupying two rows of ONE table,
+    or two items of ONE list. The first version of this gate compared per file
+    and reported 229 problems, almost all of them legitimate — a check that
+    noisy gets muted, which is worse than not having it.
+    """
+    cur_kind = None
+    cur: list[tuple[int, str]] = []
+    # Fenced code is classified by the shared parser, never by a local ```
+    # toggle: issues #95/#97 showed a closer may not carry an info string and
+    # must be at least as long as its opener, so the naive toggle mis-pairs a
+    # nested sample. test_check_anchors.py enforces this and caught the first
+    # version of this file doing exactly that.
+    flags = code_line_flags(text)
+    for n, (line, is_code) in enumerate(zip(text.split("\n"), flags), start=1):
+        if is_code:
+            if cur:
+                yield cur_kind, cur
+                cur, cur_kind = [], None
+            continue
+        s = line.lstrip()
+        kind = None
+        if s.startswith("|"):
+            kind = "table"
+        elif re.match(r"(?:[-*+]|\d+\.)\s", s):
+            kind = "list"
+        if kind and kind == cur_kind:
+            cur.append((n, line))
+        elif kind:
+            if cur:
+                yield cur_kind, cur
+            cur_kind, cur = kind, [(n, line)]
+        else:
+            # A blank line does not end a list (loose lists are still one list);
+            # any other prose line does.
+            if s == "" and cur_kind == "list":
+                continue
+            if cur:
+                yield cur_kind, cur
+            cur, cur_kind = [], None
+    if cur:
+        yield cur_kind, cur
+
+
+def _slug(line: str) -> str | None:
+    """The repo this row/item IS, which is its FIRST github link.
+
+    Later links on the same line are cross-references, not entries. Comparing
+    every link on the line made an entry that says "see also X" collide with X's
+    own entry further down, which is a normal and useful thing to write. Every
+    one of the six findings the previous version produced was that shape.
+    """
+    for m in REPO_RE.finditer(line):
+        owner, repo = m.group(1), m.group(2)
+        if owner.lower() in IGNORE_OWNERS or repo in IGNORE_REPOS:
+            continue
+        return f"{owner}/{re.sub(r'[.]git$', '', repo)}"
+    return None
+
+
+def dupes_in(text: str) -> dict[str, list[int]]:
+    """slug -> line numbers, but only when repeated INSIDE one table or list."""
+    found: dict[str, list[int]] = {}
+    for kind, block in _blocks(text):
+        seen: dict[str, list[int]] = defaultdict(list)
+        for n, line in block:
+            slug = _slug(line)
+            if slug and n not in seen[slug]:
+                seen[slug].append(n)
+        for slug, lines in seen.items():
+            if len(lines) > 1:
+                found.setdefault(slug, []).extend(lines)
+    return found
+
+
+def md_files() -> list[Path]:
+    out = []
+    for fp in REPO_ROOT.rglob("*.md"):
+        rel = fp.relative_to(REPO_ROOT)
+        if any(p in SCAN_EXCLUDE_DIRS for p in rel.parts):  # abs-parts-ok: rel = fp.relative_to(REPO_ROOT) two lines up
+            continue
+        if fp.name in SKIP_FILES or any(p in SKIP_DIR_PARTS for p in rel.parts):  # abs-parts-ok: same rel as above
+            continue
+        out.append(fp)
+    return sorted(out)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--quiet", action="store_true", help="只印問題")
+    args = ap.parse_args()
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, "reconfigure"):
+            try:
+                stream.reconfigure(encoding="utf-8", errors="replace")
+            except (AttributeError, ValueError):
+                pass
+
+    files = md_files()
+    problems = 0
+    for fp in files:
+        rel = fp.relative_to(REPO_ROOT).as_posix()
+        for slug, lines in sorted(dupes_in(fp.read_text(encoding="utf-8")).items()):
+            if len(lines) < 2 or f"{rel}::{slug}" in BASELINE:
+                continue
+            problems += 1
+            print(f"❌ {rel}: {slug} 出現在 {len(lines)} 行 — {', '.join(map(str, lines))}")
+
+    if not args.quiet:
+        print(f"checked {len(files)} markdown file(s)")
+    if problems:
+        print()
+        print(f"Found {problems} duplicate-repo problem(s).")
+        print("同一份清單列同一個 repo 兩次,通常是「以為是新的」而沒有先 grep slug。")
+        print("跨檔案重複是正常的,這個 gate 只看同一個檔案內。")
+        return 1
+    print("✓ No repo is listed twice within the same file.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_duplicate_repos.py
+++ b/scripts/test_duplicate_repos.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Regression tests for scripts/check-duplicate-repos.py.
+
+The gate exists because on 2026-08-23 `microsoft/agent-framework` was added to
+the Stage 4 table as a new project when it had been in that same table since
+2026-06-13. Stars, license and push date were all verified; the slug was never
+grepped. All six content gates stayed green, because the only gate that counts
+catalog entries is scoped to resources/mcp-skills-catalog.* and cannot see a
+prose table in a stage.
+
+The gate's first two versions were WRONG in the noisy direction, and that
+matters more than it sounds: a check that reports 229 problems gets muted, and
+a muted check is worse than no check because it looks like coverage.
+
+  v1: compared per FILE  -> 229 findings. A repo explained in prose and then
+      listed in a table below is normal; that is most of the corpus.
+  v2: compared per BLOCK but used every link on a line -> 6 findings, all of
+      them an entry that cross-references another entry ("see also X").
+  v3: per block, FIRST link per line only -> 3 findings, all one book listed
+      one row per chapter, which no URL comparison can separate from the real
+      defect. Those three are baselined, not engineered around.
+
+These tests pin both directions: the real defect must fail, and each of the
+three false-positive shapes must pass.
+
+Run:  python scripts/test_duplicate_repos.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+_SPEC = importlib.util.spec_from_file_location(
+    "check_duplicate_repos", Path(__file__).with_name("check-duplicate-repos.py")
+)
+dup = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(dup)
+
+G = "https://github.com"
+
+
+def test_the_defect_this_gate_exists_for_is_caught() -> None:
+    """Two table rows listing the same repo root. The 2026-08-23 shape."""
+    md = (
+        "| 分類 | Project | 備註 |\n"
+        "|---|---|---|\n"
+        f"| A | [x]({G}/microsoft/agent-framework) | 舊的那列 |\n"
+        f"| B | [x]({G}/microsoft/agent-framework) | 以為是新的 |\n"
+    )
+    found = dup.dupes_in(md)
+    assert "microsoft/agent-framework" in found, (
+        f"the duplicate row was not detected: {found!r}"
+    )
+
+
+def test_the_same_defect_in_a_list_is_caught() -> None:
+    md = (
+        f"1. [a]({G}/owner/repo) — first\n"
+        f"2. [b]({G}/owner/repo) — same repo again\n"
+    )
+    assert "owner/repo" in dup.dupes_in(md)
+
+
+def test_prose_mention_plus_a_listing_is_not_a_duplicate() -> None:
+    """v1's failure mode. A stage explains a tool, then lists it; that is the
+    point of the document, not a defect."""
+    md = (
+        f"Some prose about [thing]({G}/owner/repo) and why it matters.\n"
+        "\n"
+        "| Project | 備註 |\n"
+        "|---|---|\n"
+        f"| [thing]({G}/owner/repo) | the entry |\n"
+    )
+    assert dup.dupes_in(md) == {}, "a prose mention was counted as a listing"
+
+
+def test_a_cross_reference_inside_one_entry_is_not_a_duplicate() -> None:
+    """v2's failure mode. Row 1 IS repo-a and merely points at repo-b, whose
+    own row follows. Both rows are correct and distinct."""
+    md = (
+        f"1. [a]({G}/owner/repo-a) — see also [b]({G}/owner/repo-b)\n"
+        f"2. [b]({G}/owner/repo-b) — its own entry\n"
+    )
+    assert dup.dupes_in(md) == {}, (
+        "an entry that cross-references another entry was called a duplicate"
+    )
+
+
+def test_monorepo_subdirectories_are_distinct_entries() -> None:
+    """Eleven plugins under one repo are eleven entries, not one repeated."""
+    md = (
+        "| Plugin | 備註 |\n"
+        "|---|---|\n"
+        f"| [a]({G}/anthropics/claude-plugins-official/tree/main/plugins/a) | x |\n"
+        f"| [b]({G}/anthropics/claude-plugins-official/tree/main/plugins/b) | y |\n"
+    )
+    assert dup.dupes_in(md) == {}, "monorepo subdirectory entries were collapsed"
+
+
+def test_two_separate_tables_do_not_collide() -> None:
+    """Listing a repo in a frameworks table and again in a harness table is
+    deliberate; only repetition inside ONE block is a defect."""
+    md = (
+        "| Project |\n|---|\n" f"| [x]({G}/owner/repo) |\n"
+        "\n本段散文把兩張表隔開。\n\n"
+        "| Project |\n|---|\n" f"| [x]({G}/owner/repo) |\n"
+    )
+    assert dup.dupes_in(md) == {}, "two different tables were treated as one block"
+
+
+def test_code_blocks_are_ignored() -> None:
+    md = (
+        "```bash\n"
+        f"git clone {G}/owner/repo\n"
+        f"git clone {G}/owner/repo\n"
+        "```\n"
+    )
+    assert dup.dupes_in(md) == {}, "a shell sample was read as two listings"
+
+
+def test_baseline_is_exact_and_scoped() -> None:
+    """Exact equality, not a membership check. Widening the baseline is how a
+    ratchet quietly stops ratcheting, and every key must name a real file."""
+    assert dup.BASELINE == {
+        "stages/03-tool-use-and-hello-agent.md::datawhalechina/hello-agents",
+        "stages/03-tool-use-and-hello-agent.en.md::datawhalechina/hello-agents",
+        "stages/03-tool-use-and-hello-agent.zh-Hans.md::datawhalechina/hello-agents",
+    }, f"baseline changed: {dup.BASELINE!r}"
+    for key in dup.BASELINE:
+        rel = key.split("::")[0]
+        assert (REPO / rel).exists(), f"baseline names a missing file: {rel}"
+
+
+def test_repo_is_currently_clean() -> None:
+    import subprocess
+    r = subprocess.run(
+        [sys.executable, str(REPO / "scripts" / "check-duplicate-repos.py"), "--quiet"],
+        cwd=REPO, capture_output=True, text=True, encoding="utf-8", errors="replace",
+    )
+    assert r.returncode == 0, f"gate reports duplicates:\n{r.stdout[-1200:]}"
+
+
+def main() -> int:
+    if hasattr(sys.stdout, "reconfigure"):
+        try:
+            sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+        except Exception:
+            pass
+    tests = [(n, f) for n, f in sorted(globals().items())
+             if n.startswith("test_") and callable(f)]
+    failed = 0
+    for name, fn in tests:
+        try:
+            fn()
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {name}\n  {e}")
+        except BaseException as e:
+            failed += 1
+            print(f"ERROR {name}: {type(e).__name__}: {e}")
+    if failed:
+        print(f"\n{failed}/{len(tests)} failed.")
+        return 1
+    print(f"{len(tests)}/{len(tests)} passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
昨天 `microsoft/agent-framework` 被當成新專案加進 Stage 4 的表，但它 **2026-06-13 就已經在同一張表裡**。星數、license、push 日期全部對 GitHub API 查證過，**唯獨沒有 grep 一次 slug**。

**六個內容 gate 全綠**——唯一會數條目的 `check-catalog-counts.py` 只掃 `resources/mcp-skills-catalog.*`，看不到 stage 裡的散文表格。是 reviewer 讀 diff 讀出來的。

## 前兩版都錯在「太吵」那一邊

這比聽起來嚴重：**一個報 229 個問題的檢查會被無視，而被無視的檢查比沒有檢查更糟，因為它看起來像有覆蓋。**

| 版本 | 比較單位 | 命中 | 為什麼錯 |
|---|---|---|---|
| v1 | 整個檔案 | **229** | 散文提到、下面表格再收錄，是正常的，而且是這個 corpus 的多數 |
| v2 | 區塊，但取整行所有連結 | **6** | 全部是「條目 A 說 see also B」而 B 自己也有條目 |
| v3 | 區塊，只取每列**第一個**連結 | **3** | 同一本書一章一列，每列都連 repo 根——沒有任何 URL 比對分得出來 |

最後那 3 筆逐一看過確認是刻意的，用 baseline 記錄（ratchet：新的重複照樣會擋），而不是硬改演算法去繞過。

## 兩個既有 gate 反過來抓到這支新腳本

1. **`test_check_anchors.py`** 擋下它，因為我自己寫了 ```` ``` ```` 開關——正是 #95/#97 證明錯誤的那種 naive 作法。已改用 `md_fences.code_line_flags`。
2. **`test_repo_scan_excludes.py`** 擋下它，因為路徑元件無法確認是相對路徑——那個形狀曾讓一個 blocking gate 從 worktree 掃 0/68 個檔案還回報全綠。已照該 gate 自己的慣例加註記。

**兩個 gate 都是先前事故之後才建的，而且都在第一支新腳本上就發動了。這就是 gate 在做事。**

## 驗證

7 個內容 gate、`zh-hans-localize --check`、14 份測試全綠。9 條單元測試雙向釘住：模擬的重複列會被抓到；散文提及、交叉引用、monorepo 子目錄條目、兩張不同的表、程式碼範例都不會誤報。

🤖 Generated with [Claude Code](https://claude.com/claude-code)