### PR TITLE
fix(stage4): Modernize framework examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Format: `YYYY-MM-DD · category · 1-line summary (commit-sha)`.
 
 ---
 
+## 2026-08-28
+
+- **examples / Stage 4 / current SDK** · **五個 framework 範例升到查核日 current major，並改成每題自己的 Python 3.11 環境**：LangGraph／LangChain、CrewAI、Smolagents、LiteLLM 與 Pydantic AI requirements 不再鎖在舊 major；三語索引與 15 份 README 都先給可直接複製的 PowerShell `.venv` 指令，再用關閉的 `<details>` 放 macOS／Linux。乾淨的 Exercise 2 專用環境實際抓出共用環境曾遮住的缺件：CrewAI Anthropic Path B 必須安裝 `crewai[anthropic]`；修正後五個獨立環境都能 `pip check`，不再把不同 framework 的 requirements 混裝。
+- **fix / behavior / safety** · **雙路徑從「能 import」提升為可觀察的離線行為測試**：Exercise 1 限制 LangGraph recursion、驗證 tool name／參數並真正走 tool loop／Crew 結構；Exercise 2 鎖住三角色 handoff、`max_iter=4` 與停止條件；Exercise 3 改用現行 `interrupt()` + `Command(resume=...)`、checkpoint 與固定 `thread_id`，也把 node 內暫停和 caller 外部恢復分開教；Exercise 4 移除 `eval`，改用有節點／字數／數值上限的 AST 算術與 JSON allowlist。CodeAct 使用一般 Docker bridge 保留 host → Jupyter 控制通道，控制埠只綁 `127.0.0.1`，再 drop capabilities、禁止提權與限制資源；正文也明說容器仍可能連網、這不是 production sandbox。Exercise 5 遷移到 Pydantic AI 2.35 的 `OpenAIChatModel`／`AnthropicModel`／官方 `TestModel`，拒絕空答案、空 sources 與越界 confidence，並明說「格式通過不代表內容真實」。11 個直接執行的離線入口與 compileall 均通過；另附真正啟動 executor、核對實際 loopback port binding 的 `test_docker_smoke.py`，但本機 Docker daemon 未啟動，所以沒有把 live CodeAct 容器冒充為已驗收。
+- **docs / cost / acceptance** · **原有深度閱讀、延伸與五星編輯推薦不因現代化而被刪短**：五題三語保留原資源與教學段落，刪除固定成功率、固定秒數、沒有來源的「最穩／10 倍／production 必用」結論；CrewAI streaming 改成現行 `Crew(..., stream=True)`，Smolagents `HfApiModel` 改成 `InferenceClientModel`，HITL 比較改為中性事實。Ollama `$0` 限定為模型 API 費，Anthropic 改用 `$1／$5` 每百萬 token 公式、明示 2,000 input + 1,000 output 的 `$0.007` 假設與每題保守支出上限。新增 `scripts/test_stage04_examples.py` 鎖住五資料夾、current-major requirements、雙行為測試、固定 model ID、PowerShell-first、關閉 details、三語 URL／數字／安全語意、舊 API 與過期主張；DESIGN、三語 style guide 與執行計畫同步記錄獨立 `.venv` 和「import-only 不算通過」。本層只會開在 #152 上的 stacked PR，未經使用者明確同意不合併或清理。
+
 ## 2026-08-27
 
 - **content / reader UX** · **Stage 0、2、3、4 三語把易變資料的查核日期移出可見主線**：日期只留在預設關閉的資源／時間區與機器可讀 freshness marker；刪除「日期只表示……」一類沒有幫助讀者開始學習的固定提醒，並把同一規則寫回 DESIGN 與三語 style guide。另逐頁檢查「動手練習」標題的實際 Markdown 與 MkDocs HTML，確認標題沒有 `""`；Stage 2 的 `"""` 是 Python 多行字串，Stage 3 原本較容易誤讀的 `print("".join(...))` 改為直接以換行連接。

--- a/docs/plans/2026-08-27-stage04-reader-ux-and-framework-examples.md
+++ b/docs/plans/2026-08-27-stage04-reader-ux-and-framework-examples.md
@@ -22,6 +22,8 @@
 - PR 04A branch：`codex/stage04-reader-ux`。
 - PR 04A base：`codex/stage02-prompt-map`（PR #150）。
 - PR 04B branch：完成 04A 後建立 `codex/stage04-example-hardening`，base 指向 04A。
+- 04B 候選已完成五個 current-major 範例與三語 README。每個資料夾都用獨立 Python 3.11 環境驗收；乾淨的 Exercise 2 環境實際抓出並修正 `crewai[anthropic]` extra 遺漏，五組 `pip check` 與 11 個直接執行的離線入口均通過。
+- CodeAct 的離線測試已驗 AST allowlist、JSON tool 邊界、loopback 控制埠與 Docker 資源限制；`network_mode="none"` 會切斷 Smolagents 的 host → Jupyter 控制通道，而 internal bridge 在現行 Docker 也不能可靠支援這條 published-port 路徑。因此範例使用一般 bridge、只把控制埠綁到 `127.0.0.1`，並明說容器仍可能連網、不是 production sandbox。另增 `test_docker_smoke.py` 實測 executor 與實際 port binding；本機 Docker client 存在但 daemon 未啟動，因此不宣稱 live 容器已跑過。
 - 主工作區有 Claude 的 `stages/01-llm-basics.md` 修改；本計畫只使用隔離 worktree，不切換、不覆蓋。
 - 本次不修改 Stage 05 正文。只允許修正 Stage 07／07.5／08 指向 Stage 04 的既有 anchor 或同源過時敘述；若能保留原 anchor，就不改後續章節結構。
 - 不合併 PR、不刪 branch、不清 worktree。只有使用者明確說可以合併時才執行安全合併流程。
@@ -248,6 +250,8 @@
 
 ## Task 6：建立 PR 04B 範例層
 
+**狀態：完成候選實作。** 保留五份原有深度閱讀與延伸段落，沒有再接受 delegate 的過度壓縮稿；requirements、雙路徑、行為測試、三語 PowerShell／macOS/Linux 指令、成本公式與安全邊界已同步。等待 Task 7 的全站 gate、獨立 review、commit 與未合併 stacked PR。
+
 **Files:**
 
 - Modify: `examples/stage-4/01-same-agent-two-frameworks/**`
@@ -284,9 +288,11 @@
 
 ## Task 7：PR 04B 驗證、review 與未合併 PR
 
+**狀態：進行中。** 五個獨立 clean-env installs、`pip check`、11 個離線入口、compileall、Stage 4 結構 gate、323 個 scripts tests、locale／Hans／mirror／freshness 檢查與三語 MkDocs build 已通過；只剩 staged fingerprint、獨立 reviewer、commit 與未合併 stacked PR。
+
 1. 執行 04A 全套內容 gate，再加：
    - clean Python 3.11 dependency installs
-   - 十個 Stage 04 offline mock entrypoints
+    - 十一個 Stage 04 offline mock entrypoints
    - starter `ast.parse`
    - `scripts/test_stage04_examples.py`
 2. 重新查 PyPI、Anthropic model ID 與價格；三語 README 同步。

--- a/examples/README.en.md
+++ b/examples/README.en.md
@@ -249,11 +249,13 @@ Main differences: the message-creation method name, the response shape (`choices
 | 1 LLM basics | 6 | inline 4 + folder 2 (`examples/stage-1/`) |
 | 2 Prompt engineering | 4 | inline 3 + folder 1 (`examples/stage-2/`) |
 | **3 Tool use** | **6** | folder 6 (`examples/stage-3/`) |
-| 4 Frameworks | 5 | all folder (`examples/stage-4/`) |
+| 4 Frameworks | 5 | five dual-path, offline-verifiable folders (`examples/stage-4/`; Python 3.11) |
 | 5 Claude Code ecosystem | 11 | inline 6 + folder 5 (`examples/stage-5/`) |
 | 6 Memory/RAG | 5 | all folder (`examples/stage-6/`) |
 | 7 Multi-agent | 5 | inline 1 + folder 4 (`examples/stage-7/`) |
 | Track A1-A3 | 12 | 12 inline exercises; no separate `examples/track-a/` folder |
+
+> The five Stage 4 folders use different frameworks. Create a **separate Python 3.11 `.venv` in each folder**; do not combine their five `requirements.txt` files.
 
 → T1 scope: **Stage 3 全 6 exercises only** (remaining stages roll out per plan tiers).
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -249,11 +249,13 @@ r = client.messages.create(model="claude-haiku-4-5-20251001", ...)
 | 1 LLM 基礎 | 6 個 | inline 4 + folder 2（`examples/stage-1/`） |
 | 2 Prompt eng | 4 個 | inline 3 + folder 1（`examples/stage-2/`） |
 | **3 Tool use** | **6 個** | folder 6（`examples/stage-3/`） |
-| 4 Frameworks | 5 個 | 全 folder（`examples/stage-4/`） |
+| 4 Frameworks | 5 個 | 5 個雙路徑、離線可驗證的 folder（`examples/stage-4/`；Python 3.11） |
 | 5 Claude Code 生態 | 11 個 | inline 6 + folder 5（`examples/stage-5/`） |
 | 6 Memory/RAG | 5 個 | 全 folder（`examples/stage-6/`） |
 | 7 Multi-agent | 5 個 | inline 1 + folder 4（`examples/stage-7/`） |
 | Track A1-A3 | 12 個 | 12 個 inline 練習；沒有獨立的 `examples/track-a/` 資料夾 |
+
+> Stage 4 的五個 folder 使用不同 framework。請在**每個 folder 各建一個 Python 3.11 `.venv`**，不要合併五份 `requirements.txt`。
 
 → T1 完成範圍：**只有 Stage 3 全部 6 個**（剩餘 stage 按 plan 分批推進）。
 

--- a/examples/README.zh-Hans.md
+++ b/examples/README.zh-Hans.md
@@ -249,11 +249,13 @@ r = client.messages.create(model="claude-haiku-4-5-20251001", ...)
 | 1 LLM 基础 | 6 个 | inline 4 + folder 2（`examples/stage-1/`） |
 | 2 Prompt eng | 4 个 | inline 3 + folder 1（`examples/stage-2/`） |
 | **3 Tool use** | **6 个** | folder 6（`examples/stage-3/`） |
-| 4 Frameworks | 5 个 | 全 folder（`examples/stage-4/`） |
+| 4 Frameworks | 5 个 | 5 个双路径、离线可验证的 folder（`examples/stage-4/`；Python 3.11） |
 | 5 Claude Code 生态 | 11 个 | inline 6 + folder 5（`examples/stage-5/`） |
 | 6 Memory/RAG | 5 个 | 全 folder（`examples/stage-6/`） |
 | 7 Multi-agent | 5 个 | inline 1 + folder 4（`examples/stage-7/`） |
 | Track A1-A3 | 12 个 | 12 个 inline 练习；没有独立的 `examples/track-a/` 文件夹 |
+
+> Stage 4 的五个文件夹使用不同 framework。请在**每个文件夹各建一个 Python 3.11 `.venv`**，不要合并五份 `requirements.txt`。
 
 → T1 完成范围：**只有 Stage 3 全部 6 个**（剩余 stage 按 plan 分批推进）。
 

--- a/examples/stage-4/01-same-agent-two-frameworks/README.en.md
+++ b/examples/stage-4/01-same-agent-two-frameworks/README.en.md
@@ -1,5 +1,5 @@
 <div align="right">
-  <a href="./README.md">繁體中文</a> | <a href="./README.zh-Hans.md">简体中文</a> | <strong>English</strong>
+  <a href="./README.md">Traditional Chinese</a> | <a href="./README.zh-Hans.md">Simplified Chinese</a> | <strong>English</strong>
 </div>
 
 # Exercise 1: Same Agent, Two Frameworks (LangGraph + CrewAI)
@@ -25,35 +25,52 @@ Built once in **LangGraph** and once in **CrewAI** — compare styles.
 
 ## How to run — two paths + two frameworks
 
+> ⚠️ **Give each exercise its own Python 3.11 `.venv`.** Do not install all five `requirements.txt` files together. They demonstrate different frameworks whose dependency ranges can conflict.
+
 ### Path A (default, free, local)
 
-```bash
-pip install -r requirements.txt
+```powershell
+py -3.11 -m venv .venv
+.\.venv\Scripts\python.exe -m pip install -r requirements.txt
 ollama pull qwen2.5:3b
 ollama serve
 
-python starter.py         # LangGraph + Ollama
-python starter_crewai.py  # CrewAI + Ollama (comparison)
+.\.venv\Scripts\python.exe starter.py # LangGraph + Ollama
+.\.venv\Scripts\python.exe starter_crewai.py # CrewAI + Ollama comparison
 ```
 
-Budget: **$0**.
+Budget: the model API costs **$0**. Your computer, memory, electricity, and download time are not free.
 
-### Path B (Anthropic, cloud-quality)
+### Path B (Anthropic, compare a cloud result)
+
+```powershell
+$env:ANTHROPIC_API_KEY="sk-ant-..."
+.\.venv\Scripts\python.exe starter_anthropic.py # LangGraph + Claude
+```
+
+Pinned default: `claude-haiku-4-5-20251001`. Haiku 4.5 costs **$1** per million input tokens and **$5** per million output tokens. A request with 2,000 input + 1,000 output tokens costs `2,000 / 1,000,000 × $1 + 1,000 / 1,000,000 × $5 = $0.007`. A framework may make more than one request, so set a provider spend limit of **$0.05** for this exercise. This is an estimate, not a billing promise.
+
+<details markdown="1">
+<summary>macOS/Linux commands and verification information</summary>
 
 ```bash
-pip install -r requirements.txt
-export ANTHROPIC_API_KEY=sk-ant-...
-python starter_anthropic.py   # LangGraph + Claude
+python3.11 -m venv .venv
+./.venv/bin/python -m pip install -r requirements.txt
+export ANTHROPIC_API_KEY="sk-ant-..."
+./.venv/bin/python test.py
 ```
 
-Budget: ~**$0.001** per run (claude-haiku-4-5).
+Official sources: [LangGraph overview](https://docs.langchain.com/oss/python/langgraph/overview) | [CrewAI docs](https://docs.crewai.com/) | [Anthropic pricing](https://platform.claude.com/docs/en/about-claude/pricing)
+
+<small>Packages, model IDs, prices, and official links verified: 2026-08-28 UTC.</small>
+</details>
 
 ## Validate the logic (mock-based)
 
-```bash
-python test.py             # LangGraph + mock LLM
-python test_anthropic.py   # starter_anthropic loads + ChatAnthropic constructs
-python test_crewai.py      # CrewAI tool + module loads
+```powershell
+.\.venv\Scripts\python.exe test.py # LangGraph behavior
+.\.venv\Scripts\python.exe test_anthropic.py # Anthropic-path behavior
+.\.venv\Scripts\python.exe test_crewai.py # CrewAI behavior
 ```
 
 ## Side-by-side framework comparison
@@ -63,9 +80,8 @@ python test_crewai.py      # CrewAI tool + module loads
 | Core abstraction | `StateGraph` + node + edge | `Agent` + `Task` + `Crew` |
 | Mental model | "How does state flow?" | "Who plays what role?" |
 | Loop control | Explicit conditional edges | Hidden inside `Crew.kickoff()` |
-| Lines of code (this task) | ~50 | ~25 |
-| Debug path | Inspect graph state, time-travel | Verbose logs, hard to step |
-| Best for | Complex branching, production, audit | Multi-agent prototypes, role-based tasks |
+| Debug path | Inspect graph state and checkpoints | Inspect task output and verbose logs |
+| Useful when | You need explicit state and branches | You want to express role/task collaboration quickly |
 | Learning curve | Medium-high | Low |
 
 ### LangGraph style (condensed)
@@ -94,25 +110,25 @@ crew.kickoff()
 ## What to observe
 
 1. **Abstraction cost**: CrewAI hides more, writes less code; but stack depth grows when debugging
-2. **Small-model friendliness**: LangGraph is more stable with qwen2.5:3b; CrewAI's denser prompts can confuse small models
+2. **Small-model behavior**: test both paths; role descriptions, tool schemas, and task length can all change the result
 3. **Controllability**: LangGraph exposes state transitions; CrewAI is "result-oriented"
-4. **When to pick**: production / audit → LangGraph. Multi-agent prototypes / role-based → CrewAI
+4. **When to pick**: try LangGraph when you need to inspect each state transition; try CrewAI when roles are the clearest first description, then measure on your own task
 
 ## Common pitfalls
 
 - **LangGraph `bind_tools`**: must `llm.bind_tools([search])` to expose tool schema. Without it the model doesn't know the tool exists
-- **CrewAI model spec**: needs LiteLLM format (`"ollama/qwen2.5:3b"`, not `"qwen2.5:3b"`). Misspell and framework silently falls back to OpenAI default
+- **CrewAI model spec**: use LiteLLM format (`"ollama/qwen2.5:3b"`, not `"qwen2.5:3b"`). A wrong provider prefix can select a different backend, so print and verify the setting before a run
 - **CrewAI return type**: `crew.kickoff()` returns a `CrewOutput` object; `str(result)` to get text. Bare `print(result)` may show repr
 
 ## Want smarter answers?
 
-```bash
-MODEL=claude-sonnet-5 python starter_anthropic.py    # more stable
-MODEL=qwen2.5:7b python starter.py                      # larger local model
+```powershell
+$env:MODEL="claude-sonnet-5"; .\.venv\Scripts\python.exe starter_anthropic.py
+$env:MODEL="qwen2.5:7b"; .\.venv\Scripts\python.exe starter.py
 ```
 
 ## Extensions
 
-- **Streaming**: LangGraph `graph.stream(...)`, CrewAI `crew.kickoff(stream=True)`
+- **Streaming**: use LangGraph `graph.stream(...)`; for CrewAI, construct `Crew(..., stream=True)` and then call `crew.kickoff()`
 - **Checkpointing**: LangGraph + `MemorySaver` for time-travel debug
 - **Human-in-the-loop**: see Exercise 3

--- a/examples/stage-4/01-same-agent-two-frameworks/README.md
+++ b/examples/stage-4/01-same-agent-two-frameworks/README.md
@@ -25,35 +25,52 @@
 
 ## 怎麼跑 — 兩條路徑 + 兩個 framework
 
+> ⚠️ **每個練習都要有自己的 Python 3.11 `.venv`。** 不要把五個 `requirements.txt` 混在一起安裝；它們示範不同 framework，套件需求可能互相衝突。
+
 ### Path A（默認、本機免費）
 
-```bash
-pip install -r requirements.txt
+```powershell
+py -3.11 -m venv .venv
+.\.venv\Scripts\python.exe -m pip install -r requirements.txt
 ollama pull qwen2.5:3b
 ollama serve
 
-python starter.py # LangGraph + Ollama
-python starter_crewai.py # CrewAI + Ollama（對照）
+.\.venv\Scripts\python.exe starter.py # LangGraph + Ollama
+.\.venv\Scripts\python.exe starter_crewai.py # CrewAI + Ollama（對照）
 ```
 
-預算：**$0**。
+預算：模型 API 是 **$0**；電腦記憶體、電力與下載時間仍有成本。
 
-### Path B（Anthropic、想看 cloud 高品質）
+### Path B（Anthropic、比較雲端結果）
+
+```powershell
+$env:ANTHROPIC_API_KEY="sk-ant-..."
+.\.venv\Scripts\python.exe starter_anthropic.py # LangGraph + Claude
+```
+
+預設固定型號：`claude-haiku-4-5-20251001`。Haiku 4.5 為每百萬 input tokens **$1**、output tokens **$5**。若一次請求用 2,000 input + 1,000 output tokens，算式是 `2,000 / 1,000,000 × $1 + 1,000 / 1,000,000 × $5 = $0.007`。Framework 可能呼叫多次；本練習先把供應商支出上限設為 **$0.05**，不要把估算當帳單保證。
+
+<details markdown="1">
+<summary>macOS／Linux 指令與查核資訊</summary>
 
 ```bash
-pip install -r requirements.txt
-export ANTHROPIC_API_KEY=sk-ant-...
-python starter_anthropic.py # LangGraph + Claude
+python3.11 -m venv .venv
+./.venv/bin/python -m pip install -r requirements.txt
+export ANTHROPIC_API_KEY="sk-ant-..."
+./.venv/bin/python test.py
 ```
 
-預算：每次 ≈ **$0.001**（claude-haiku-4-5）。
+官方來源：[LangGraph overview](https://docs.langchain.com/oss/python/langgraph/overview)｜[CrewAI docs](https://docs.crewai.com/)｜[Anthropic pricing](https://platform.claude.com/docs/en/about-claude/pricing)
+
+<small>套件、model ID、價格與官方連結查核：2026-08-28 UTC。</small>
+</details>
 
 ## 不花錢驗證程式邏輯（mock-based）
 
-```bash
-python test.py # LangGraph + mock LLM
-python test_anthropic.py # starter_anthropic 可載入 + ChatAnthropic 可建構
-python test_crewai.py # CrewAI tool 邏輯 + 模組可載入
+```powershell
+.\.venv\Scripts\python.exe test.py # LangGraph 行為
+.\.venv\Scripts\python.exe test_anthropic.py # Anthropic 路徑行為
+.\.venv\Scripts\python.exe test_crewai.py # CrewAI 行為
 ```
 
 ## 兩個 framework 的並排比較
@@ -63,9 +80,8 @@ python test_crewai.py # CrewAI tool 邏輯 + 模組可載入
 | 核心抽象 | `StateGraph` + node + edge | `Agent` + `Task` + `Crew` |
 | 思考方式 | 「狀態怎麼流動」 | 「角色怎麼分工」 |
 | Loop 控制 | 顯式 conditional edge | 隱藏在 `Crew.kickoff()` 裡 |
-| 程式碼行數（這題） | ~50 行 | ~25 行 |
-| Debug 路徑 | 看 graph state、可 time-travel | 看 verbose log、不容易 step |
-| 適合場景 | 複雜分支、production、需要 audit | 多 agent 雛形、role-based 任務 |
+| Debug 路徑 | 看 graph state 與 checkpoint | 看 task output 與 verbose log |
+| 適合場景 | 需要明確狀態與分支的 workflow | 用角色與任務快速表達合作流程 |
 | 學習曲線 | 中-高 | 低 |
 
 ### LangGraph 風格（精簡）
@@ -94,25 +110,25 @@ crew.kickoff()
 ## 觀察重點
 
 1. **抽象代價**：CrewAI 隱藏的多、寫得少；要 debug 時 stack 比較深
-2. **小 model 友善度**：LangGraph 對 qwen2.5:3b 較穩；CrewAI 可能讓小 model 多繞幾步（因為 prompt 比較複雜）
+2. **小 model 友善度**：兩邊都要實測；角色描述、工具 schema 與任務長度都會影響結果
 3. **可控性**：LangGraph 你能看到每個 state 變化；CrewAI 偏向「結果導向」
-4. **何時選哪個**：production 級 / 需要 audit → LangGraph。多 agent 雛形 / role-based → CrewAI
+4. **何時選哪個**：需要逐步看狀態時先試 LangGraph；想先表達角色分工時先試 CrewAI，再用自己的任務測量
 
 ## 常見坑
 
 - **LangGraph `bind_tools`**：要 `llm.bind_tools([search])` 才會把 tool schema 給 LLM。沒 bind 模型就不知道 tool 存在
-- **CrewAI LLM 設定**：要靠 LiteLLM 格式（譬如 `"ollama/qwen2.5:3b"`、不是 `"qwen2.5:3b"`）。錯一個字 framework 不會 raise、會直接連到 OpenAI 預設
+- **CrewAI LLM 設定**：要用 LiteLLM 格式（譬如 `"ollama/qwen2.5:3b"`、不是 `"qwen2.5:3b"`）。寫錯 provider 前綴可能連到不同後端，所以執行前要印出設定並確認
 - **CrewAI 結果型別**：`crew.kickoff()` 回 `CrewOutput` 物件、`str(result)` 拿文字。直接 `print(result)` 有可能拿到 repr
 
 ## 想看更聰明的答案？
 
-```bash
-MODEL=claude-sonnet-5 python starter_anthropic.py # 更穩
-MODEL=qwen2.5:7b python starter.py # 大本機 model
+```powershell
+$env:MODEL="claude-sonnet-5"; .\.venv\Scripts\python.exe starter_anthropic.py
+$env:MODEL="qwen2.5:7b"; .\.venv\Scripts\python.exe starter.py
 ```
 
 ## 延伸
 
-- **改成 streaming**：LangGraph `graph.stream(...)` 邊跑邊看 state、CrewAI `crew.kickoff(stream=True)`
+- **改成 streaming**：LangGraph 用 `graph.stream(...)` 邊跑邊看 state；CrewAI 在建立 `Crew(..., stream=True)` 時開啟，再呼叫 `crew.kickoff()`
 - **加 checkpointing**：LangGraph 加 `MemorySaver` 就能 time-travel debug
 - **加 human-in-the-loop**：練習 3 會做

--- a/examples/stage-4/01-same-agent-two-frameworks/README.zh-Hans.md
+++ b/examples/stage-4/01-same-agent-two-frameworks/README.zh-Hans.md
@@ -18,42 +18,59 @@
 最简单的 search + summarize agent：
 
 - 给一个 query（譬如“summarize Taipei”）
-- Agent 用 `search` tool 拿 knowledge base 数据
+- Agent 用 `search` tool 拿 knowledge base 资料
 - LLM 把 search result 摘成 1-2 句
 
 用 **LangGraph** 跟 **CrewAI** 各做一次、比较风格差异。
 
 ## 怎么跑 — 两条路径 + 两个 framework
 
+> ⚠️ **每个练习都要有自己的 Python 3.11 `.venv`。** 不要把五个 `requirements.txt` 混在一起安装；它们示范不同 framework，套件需求可能互相冲突。
+
 ### Path A（默认、本机免费）
 
-```bash
-pip install -r requirements.txt
+```powershell
+py -3.11 -m venv .venv
+.\.venv\Scripts\python.exe -m pip install -r requirements.txt
 ollama pull qwen2.5:3b
 ollama serve
 
-python starter.py         # LangGraph + Ollama
-python starter_crewai.py  # CrewAI + Ollama（对照）
+.\.venv\Scripts\python.exe starter.py # LangGraph + Ollama
+.\.venv\Scripts\python.exe starter_crewai.py # CrewAI + Ollama（对照）
 ```
 
-预算：**$0**。
+预算：模型 API 是 **$0**；电脑记忆体、电力与下载时间仍有成本。
 
-### Path B（Anthropic、想看 cloud 高质量）
+### Path B（Anthropic、比较云端结果）
+
+```powershell
+$env:ANTHROPIC_API_KEY="sk-ant-..."
+.\.venv\Scripts\python.exe starter_anthropic.py # LangGraph + Claude
+```
+
+预设固定型号：`claude-haiku-4-5-20251001`。Haiku 4.5 为每百万 input tokens **$1**、output tokens **$5**。若一次请求用 2,000 input + 1,000 output tokens，算式是 `2,000 / 1,000,000 × $1 + 1,000 / 1,000,000 × $5 = $0.007`。Framework 可能调用多次；本练习先把供应商支出上限设为 **$0.05**，不要把估算当帐单保证。
+
+<details markdown="1">
+<summary>macOS／Linux 指令与查核资讯</summary>
 
 ```bash
-pip install -r requirements.txt
-export ANTHROPIC_API_KEY=sk-ant-...
-python starter_anthropic.py   # LangGraph + Claude
+python3.11 -m venv .venv
+./.venv/bin/python -m pip install -r requirements.txt
+export ANTHROPIC_API_KEY="sk-ant-..."
+./.venv/bin/python test.py
 ```
 
-预算：每次 ≈ **$0.001**（claude-haiku-4-5）。
+官方来源：[LangGraph overview](https://docs.langchain.com/oss/python/langgraph/overview)｜[CrewAI docs](https://docs.crewai.com/)｜[Anthropic pricing](https://platform.claude.com/docs/en/about-claude/pricing)
+
+<small>套件、model ID、价格与官方连结查核：2026-08-28 UTC。</small>
+</details>
 
 ## 不花钱验证程序逻辑（mock-based）
 
-```bash
-python test.py             # LangGraph + mock LLM
-python test_anthropic.py   # starter_anthropic 可载入 + ChatAnthropic 可构造
-python test_crewai.py      # CrewAI tool 逻辑 + 模块可载入
+```powershell
+.\.venv\Scripts\python.exe test.py # LangGraph 行为
+.\.venv\Scripts\python.exe test_anthropic.py # Anthropic 路径行为
+.\.venv\Scripts\python.exe test_crewai.py # CrewAI 行为
 ```
 
 ## 两个 framework 的并排比较
@@ -63,9 +80,8 @@ python test_crewai.py      # CrewAI tool 逻辑 + 模块可载入
 | 核心抽象 | `StateGraph` + node + edge | `Agent` + `Task` + `Crew` |
 | 思考方式 | “状态怎么流动” | “角色怎么分工” |
 | Loop 控制 | 显式 conditional edge | 隐藏在 `Crew.kickoff()` 里 |
-| 程序码行数（这题） | ~50 行 | ~25 行 |
-| Debug 路径 | 看 graph state、可 time-travel | 看 verbose log、不容易 step |
-| 适合场景 | 复杂分支、production、需要 audit | 多 agent 雏形、role-based 任务 |
+| Debug 路径 | 看 graph state 与 checkpoint | 看 task output 与 verbose log |
+| 适合场景 | 需要明确状态与分支的 workflow | 用角色与任务快速表达合作流程 |
 | 学习曲线 | 中-高 | 低 |
 
 ### LangGraph 风格（精简）
@@ -94,25 +110,25 @@ crew.kickoff()
 ## 观察重点
 
 1. **抽象代价**：CrewAI 隐藏的多、写得少；要 debug 时 stack 比较深
-2. **小 model 友善度**：LangGraph 对 qwen2.5:3b 较稳；CrewAI 可能让小 model 多绕几步（因为 prompt 比较复杂）
+2. **小 model 友善度**：两边都要实测；角色描述、工具 schema 与任务长度都会影响结果
 3. **可控性**：LangGraph 你能看到每个 state 变化；CrewAI 偏向“结果导向”
-4. **何时选哪个**：production 级 / 需要 audit → LangGraph。多 agent 雏形 / role-based → CrewAI
+4. **何时选哪个**：需要逐步看状态时先试 LangGraph；想先表达角色分工时先试 CrewAI，再用自己的任务测量
 
 ## 常见坑
 
 - **LangGraph `bind_tools`**：要 `llm.bind_tools([search])` 才会把 tool schema 给 LLM。没 bind 模型就不知道 tool 存在
-- **CrewAI LLM 设定**：要靠 LiteLLM 格式（譬如 `"ollama/qwen2.5:3b"`、不是 `"qwen2.5:3b"`）。错一个字 framework 不会 raise、会直接连到 OpenAI 预设
-- **CrewAI 结果类型**：`crew.kickoff()` 回 `CrewOutput` 对象、`str(result)` 拿文字。直接 `print(result)` 有可能拿到 repr
+- **CrewAI LLM 设定**：要用 LiteLLM 格式（譬如 `"ollama/qwen2.5:3b"`、不是 `"qwen2.5:3b"`）。写错 provider 前缀可能连到不同后端，所以执行前要打印设定并确认
+- **CrewAI 结果型别**：`crew.kickoff()` 回 `CrewOutput` 对象、`str(result)` 拿文字。直接 `print(result)` 有可能拿到 repr
 
 ## 想看更聪明的答案？
 
-```bash
-MODEL=claude-sonnet-5 python starter_anthropic.py    # 更稳
-MODEL=qwen2.5:7b python starter.py                      # 大本机 model
+```powershell
+$env:MODEL="claude-sonnet-5"; .\.venv\Scripts\python.exe starter_anthropic.py
+$env:MODEL="qwen2.5:7b"; .\.venv\Scripts\python.exe starter.py
 ```
 
 ## 延伸
 
-- **改成 streaming**：LangGraph `graph.stream(...)` 边跑边看 state、CrewAI `crew.kickoff(stream=True)`
+- **改成 streaming**：LangGraph 用 `graph.stream(...)` 边跑边看 state；CrewAI 在创建 `Crew(..., stream=True)` 时开启，再调用 `crew.kickoff()`
 - **加 checkpointing**：LangGraph 加 `MemorySaver` 就能 time-travel debug
 - **加 human-in-the-loop**：练习 3 会做

--- a/examples/stage-4/01-same-agent-two-frameworks/requirements.txt
+++ b/examples/stage-4/01-same-agent-two-frameworks/requirements.txt
@@ -1,5 +1,5 @@
-langgraph>=0.2,<1.0
-langchain-openai>=0.2,<1.0
-langchain-anthropic>=0.2,<1.0
-langchain-core>=0.3,<1.0
-crewai>=0.80,<1.0
+langgraph>=1.2,<2.0
+langchain-openai>=1.6,<2.0
+langchain-anthropic>=1.7,<2.0
+langchain-core>=1.6,<2.0
+crewai>=1.15,<2.0

--- a/examples/stage-4/01-same-agent-two-frameworks/starter.py
+++ b/examples/stage-4/01-same-agent-two-frameworks/starter.py
@@ -12,7 +12,7 @@
 驗證：
     python test.py
 
-預算：$0/run。對照 Anthropic 版見 starter_anthropic.py。
+模型 API 預算：$0（Ollama）；本機硬體與電力仍有成本。對照 Anthropic 版見 starter_anthropic.py。
 """
 
 from __future__ import annotations
@@ -63,7 +63,13 @@ def build_graph(llm: Any) -> Any:
         msg = state["messages"][-1]
         results = []
         for call in msg.tool_calls:
-            obs = search.invoke(call["args"])
+            name = call.get("name")
+            args = call.get("args")
+            if name != "search":
+                raise ValueError(f"Unknown tool: {name!r}")
+            if not isinstance(args, dict) or set(args) != {"query"} or not isinstance(args["query"], str):
+                raise ValueError("search needs exactly one string query.")
+            obs = search.invoke(args)
             results.append(ToolMessage(content=obs, tool_call_id=call["id"]))
         return {"messages": results}
 
@@ -86,7 +92,7 @@ def run(query: str, llm: Any = None) -> dict:
         model=MODEL, temperature=0,
     )
     graph = build_graph(llm)
-    final_state = graph.invoke({"messages": [HumanMessage(content=query)]})
+    final_state = graph.invoke({"messages": [HumanMessage(content=query)]}, config={"recursion_limit": 6})
     return {
         "final": final_state["messages"][-1].content,
         "steps": len(final_state["messages"]),
@@ -101,4 +107,5 @@ if __name__ == "__main__":
     print(f"✅ Final: {result['final']}")
     print(f"   Steps: {result['steps']}")
     assert result["final"], "expected non-empty summary"
-    print("✅ 練習 1 通過 — LangGraph + Ollama qwen2.5:3b、$0/run")
+    assert result["steps"] >= 2, "expected a visible graph trace"
+    print("✅ 練習 1 通過 — LangGraph + Ollama qwen2.5:3b、模型 API $0")

--- a/examples/stage-4/01-same-agent-two-frameworks/starter_anthropic.py
+++ b/examples/stage-4/01-same-agent-two-frameworks/starter_anthropic.py
@@ -23,7 +23,7 @@ from langchain_anthropic import ChatAnthropic
 
 from starter import run
 
-MODEL = os.environ.get("MODEL", "claude-haiku-4-5")
+MODEL = os.environ.get("MODEL", "claude-haiku-4-5-20251001")
 
 
 if __name__ == "__main__":
@@ -35,4 +35,5 @@ if __name__ == "__main__":
     print(f"✅ Final: {result['final']}")
     print(f"   Steps: {result['steps']}")
     assert result["final"], "expected non-empty summary"
-    print("✅ 練習 1 (Anthropic path) 通過 — LangGraph + claude-haiku-4-5、≈$0.001/run")
+    assert result["steps"] >= 2, "expected a visible graph trace"
+    print("✅ 練習 1 (Anthropic path) 通過 — LangGraph + 固定 Anthropic model ID；費用依 tokens 計算")

--- a/examples/stage-4/01-same-agent-two-frameworks/starter_crewai.py
+++ b/examples/stage-4/01-same-agent-two-frameworks/starter_crewai.py
@@ -9,9 +9,9 @@
     ollama serve
     python starter_crewai.py
 
-預算：$0/run。要切 Anthropic 改 LLM_PROVIDER env var（CrewAI 用 LiteLLM 底層）。
+模型 API 預算：$0（Ollama）；本機硬體與電力仍有成本。
 
-⚠️ 注意：CrewAI 對小 model（qwen2.5:3b）較吃力，可能會多繞幾步。Claude / sonnet 較穩。
+⚠️ 注意：模型、prompt 與工具描述都可能改變步數；用相同題組比較，不先假設哪個 backend 較穩。
 """
 
 from __future__ import annotations
@@ -25,12 +25,11 @@ if hasattr(sys.stdout, "reconfigure"):
 from crewai import Agent, Crew, Task
 from crewai.tools import tool
 
-MODEL = os.environ.get("MODEL", "ollama/qwen2.5:3b")  # LiteLLM 格式
+MODEL = os.environ.get("MODEL", "ollama/qwen2.5:3b")  # LiteLLM format
 OLLAMA_BASE = os.environ.get("OLLAMA_API_BASE", "http://localhost:11434")
 
 
-@tool("search")
-def search(query: str) -> str:
+def search_knowledge_base(query: str) -> str:
     """Search a (fake, offline) knowledge base for a topic."""
     db = {
         "taipei": "Taipei is the capital of Taiwan, population ~2.6M, known for night markets.",
@@ -39,7 +38,13 @@ def search(query: str) -> str:
     return db.get(query.strip().lower(), f"no entry for {query}")
 
 
-def build_crew(query: str) -> Crew:
+@tool("search")
+def search(query: str) -> str:
+    """Search the fixed offline knowledge base."""
+    return search_knowledge_base(query)
+
+
+def build_crew(query: str, llm_model: str = MODEL) -> Crew:
     """CrewAI 風格：一個 agent + 一個 task。"""
     os.environ["OPENAI_API_BASE"] = f"{OLLAMA_BASE}/v1"
     os.environ["OPENAI_API_KEY"] = "ollama"
@@ -49,7 +54,7 @@ def build_crew(query: str) -> Crew:
         goal="Find and summarize the requested topic.",
         backstory="You search a knowledge base and give concise summaries.",
         tools=[search],
-        llm=MODEL,
+        llm=llm_model,
         verbose=False,
     )
     task = Task(
@@ -60,8 +65,8 @@ def build_crew(query: str) -> Crew:
     return Crew(agents=[researcher], tasks=[task], verbose=False)
 
 
-def run(query: str) -> dict:
-    crew = build_crew(query)
+def run(query: str, llm_model: str = MODEL) -> dict:
+    crew = build_crew(query, llm_model=llm_model)
     result = crew.kickoff()
     return {"final": str(result), "steps": None}
 
@@ -73,5 +78,6 @@ if __name__ == "__main__":
     result = run(query)
     print(f"✅ Final: {result['final']}")
     assert result["final"], "expected non-empty summary"
-    print("✅ CrewAI 版本通過 — 同樣任務、不同 framework、$0/run")
+    assert result["steps"] is None
+    print("✅ CrewAI 版本通過 — 同樣任務、不同 framework、模型 API $0")
     print("   對照 starter.py（LangGraph）看程式碼風格差異")

--- a/examples/stage-4/01-same-agent-two-frameworks/test.py
+++ b/examples/stage-4/01-same-agent-two-frameworks/test.py
@@ -54,11 +54,31 @@ def test_run_skip_tool_when_known():
 
     result = run("what is Python", llm=llm)
     assert "Python" in result["final"]
+    assert result["steps"] == 2
     print("✅ test_run_skip_tool_when_known")
+
+
+def test_reject_unknown_tool_name():
+    """模型不能把未知名稱偷偷當成 search 執行。"""
+    llm = MagicMock()
+    llm.bind_tools.return_value = llm
+    llm.invoke.return_value = AIMessage(
+        content="",
+        tool_calls=[{"name": "delete_files", "args": {"query": "Taipei"}, "id": "call_bad", "type": "tool_call"}],
+    )
+
+    try:
+        run("summarize Taipei", llm=llm)
+    except ValueError as error:
+        assert "Unknown tool" in str(error)
+    else:
+        raise AssertionError("unknown tool name must be rejected")
+    print("✅ test_reject_unknown_tool_name")
 
 
 if __name__ == "__main__":
     test_search_tool_basic()
     test_run_with_mock_llm()
     test_run_skip_tool_when_known()
-    print("\n🎉 全部通過 — LangGraph + Ollama 邏輯正確")
+    test_reject_unknown_tool_name()
+    print("all pass")

--- a/examples/stage-4/01-same-agent-two-frameworks/test_anthropic.py
+++ b/examples/stage-4/01-same-agent-two-frameworks/test_anthropic.py
@@ -1,32 +1,35 @@
-"""Stage 4 練習 1 自我驗證 — Path B（Anthropic starter_anthropic.py）。
-
-starter_anthropic.py 只是換 LLM backend、不改 build_graph 邏輯，所以共用 test.py 的測試。
-這份只多驗：ChatAnthropic 可以被 build_graph 接受（不打 API、純 import 檢查）。
-"""
+"""Offline behavioral test for Path B; no Anthropic request is made."""
 
 from __future__ import annotations
 
 import sys
+import os
+from unittest.mock import MagicMock
 
 if hasattr(sys.stdout, "reconfigure"):
     sys.stdout.reconfigure(encoding="utf-8", errors="replace")
 
+from langchain_core.messages import AIMessage
+from starter import run
+from starter_anthropic import MODEL
 
-def test_anthropic_import_ok():
-    """ChatAnthropic import 通過、無需 API key（建構式不打 API）。"""
+
+def test_pinned_provider_and_shared_graph_behavior() -> None:
     from langchain_anthropic import ChatAnthropic
-    assert ChatAnthropic is not None
-    print("✅ test_anthropic_import_ok")
-
-
-def test_starter_anthropic_module_ok():
-    """starter_anthropic 模組可被 import、function 都存在。"""
-    import starter_anthropic
-    assert hasattr(starter_anthropic, "MODEL")
-    print("✅ test_starter_anthropic_module_ok")
+    assert MODEL == "claude-haiku-4-5-20251001"
+    os.environ.setdefault("ANTHROPIC_API_KEY", "offline-test-key")
+    assert ChatAnthropic(model=MODEL, temperature=0).model == MODEL
+    llm = MagicMock()
+    llm.bind_tools.return_value = llm
+    llm.invoke.side_effect = [
+        AIMessage(content="", tool_calls=[{"name": "search", "args": {"query": "Taipei"}, "id": "call_1", "type": "tool_call"}]),
+        AIMessage(content="Taipei is the capital of Taiwan.", tool_calls=[]),
+    ]
+    result = run("Summarize Taipei", llm=llm)
+    assert result["final"].startswith("Taipei")
+    assert result["steps"] >= 4
 
 
 if __name__ == "__main__":
-    test_anthropic_import_ok()
-    test_starter_anthropic_module_ok()
-    print("\n🎉 通過 — starter_anthropic.py 可載入（實際跑需要 ANTHROPIC_API_KEY）")
+    test_pinned_provider_and_shared_graph_behavior()
+    print("all pass")

--- a/examples/stage-4/01-same-agent-two-frameworks/test_crewai.py
+++ b/examples/stage-4/01-same-agent-two-frameworks/test_crewai.py
@@ -1,8 +1,4 @@
-"""Stage 4 練習 1 CrewAI 對照版自我驗證。
-
-只驗 import + tool function 邏輯。CrewAI 整個 Crew.kickoff() 太黑盒、不適合純 mock；
-要實測請跑 starter_crewai.py 配 Ollama。
-"""
+"""Offline CrewAI comparison checks; no crew kickoff or network call."""
 
 from __future__ import annotations
 
@@ -11,27 +7,18 @@ import sys
 if hasattr(sys.stdout, "reconfigure"):
     sys.stdout.reconfigure(encoding="utf-8", errors="replace")
 
-from starter_crewai import search
+from starter_crewai import build_crew, search_knowledge_base
 
 
-def test_search_tool_basic():
-    """CrewAI tool 包裝後仍可被 .run / .func 直接呼叫做單元測。"""
-    fn = getattr(search, "func", None) or getattr(search, "run", None)
-    if fn is None:
-        print("⚠ CrewAI tool 介面變動、跳過 unit test")
-        return
-    assert "Taipei" in fn("Taipei")
-    print("✅ test_search_tool_basic (CrewAI tool wrapper)")
-
-
-def test_crewai_module_ok():
-    import starter_crewai
-    assert hasattr(starter_crewai, "build_crew")
-    assert hasattr(starter_crewai, "MODEL")
-    print("✅ test_crewai_module_ok")
+def test_offline_search_and_visible_crewai_structure() -> None:
+    assert "Taipei" in search_knowledge_base("Taipei")
+    assert "no entry" in search_knowledge_base("unknown")
+    crew = build_crew("summarize Taipei")
+    assert [agent.role for agent in crew.agents] == ["Researcher"]
+    assert len(crew.tasks) == 1
+    assert crew.tasks[0].agent.role == "Researcher"
 
 
 if __name__ == "__main__":
-    test_search_tool_basic()
-    test_crewai_module_ok()
-    print("\n🎉 通過 — CrewAI 對照版可載入（實測需要 Ollama 跑著）")
+    test_offline_search_and_visible_crewai_structure()
+    print("all pass")

--- a/examples/stage-4/02-multi-agent-roles/README.en.md
+++ b/examples/stage-4/02-multi-agent-roles/README.en.md
@@ -1,5 +1,5 @@
 <div align="right">
-  <a href="./README.md">繁體中文</a> | <a href="./README.zh-Hans.md">简体中文</a> | <strong>English</strong>
+  <a href="./README.md">Traditional Chinese</a> | <a href="./README.zh-Hans.md">Simplified Chinese</a> | <strong>English</strong>
 </div>
 
 # Exercise 2: Multi-Agent Role Allocation (CrewAI)
@@ -22,39 +22,56 @@ Researcher → Writer → Critic
   (find facts)  (write)  (verify, PASS/ISSUES)
 ```
 
-Role-based pipelines are **CrewAI's sweet spot** — describe roles / goals / tasks, framework orchestrates.
+This is a **role-based pipeline**: describe each role, goal, and task, then CrewAI passes the result along in order.
 
 ## How to run — two paths
 
+> ⚠️ **Give each exercise its own Python 3.11 `.venv`.** Do not mix the five Stage 4 `requirements.txt` files.
+
 ### Path A (default, free, local)
 
-```bash
-pip install -r requirements.txt
+```powershell
+py -3.11 -m venv .venv
+.\.venv\Scripts\python.exe -m pip install -r requirements.txt
 ollama pull qwen2.5:3b
 ollama serve
-python starter.py
+.\.venv\Scripts\python.exe starter.py
 ```
 
-Budget: **$0**. Three agents sequential ≈ 30-90s on CPU with qwen2.5:3b.
+Budget: the model API costs **$0**. Runtime depends on your CPU, memory, model, and prompt, so measure it on your machine.
 
-### Path B (Anthropic, cloud-quality)
+### Path B (Anthropic, compare a cloud result)
+
+```powershell
+$env:ANTHROPIC_API_KEY="sk-ant-..."
+.\.venv\Scripts\python.exe starter_anthropic.py
+```
+
+Pinned default: `anthropic/claude-haiku-4-5-20251001`. One model request with 2,000 input + 1,000 output tokens costs `2,000 / 1,000,000 × $1 + 1,000 / 1,000,000 × $5 = $0.007`. Three roles may each call the model or retry, so set a provider spend limit of **$0.10**.
+
+<details markdown="1">
+<summary>macOS/Linux commands and verification information</summary>
 
 ```bash
-pip install -r requirements.txt
-export ANTHROPIC_API_KEY=sk-ant-...
-python starter_anthropic.py
+python3.11 -m venv .venv
+./.venv/bin/python -m pip install -r requirements.txt
+export ANTHROPIC_API_KEY="sk-ant-..."
+./.venv/bin/python test.py
 ```
 
-Budget: ~**$0.005-0.01** per run (3 agents × short outputs, claude-haiku-4-5).
+Official sources: [CrewAI docs](https://docs.crewai.com/) | [LiteLLM docs](https://docs.litellm.ai/) | [Anthropic pricing](https://platform.claude.com/docs/en/about-claude/pricing)
+
+<small>Packages, model IDs, prices, and official links verified: 2026-08-28 UTC.</small>
+</details>
 
 ## Validate the logic
 
-```bash
-python test.py             # tool logic + crew structure
-python test_anthropic.py   # starter_anthropic loads
+```powershell
+.\.venv\Scripts\python.exe test.py # roles, tasks, handoff, and stop condition
+.\.venv\Scripts\python.exe test_anthropic.py # Anthropic-path behavior
 ```
 
-CrewAI's `kickoff()` is too opaque for pure mock testing. These tests cover structure (3 agents + 3 tasks + sequential process + context dependencies) and tool logic. For full validation, run starter.py against Ollama.
+The offline tests do not call a real model, but they check three agents, three tasks, sequential process, context dependencies, handoff output, and an observable stop condition. Test model quality separately.
 
 ## Core CrewAI multi-agent concepts
 
@@ -82,7 +99,7 @@ research_task = Task(
 )
 ```
 
-**Key**: `expected_output` is the "passing template" the LLM sees — be specific. "A 2-sentence intro paragraph" is 10× better than "Some text".
+**Key**: `expected_output` is the passing example the LLM sees. "A two-sentence intro in active voice" is clearer than "Some text"; measure the improvement on your own task.
 
 ### Context dependency
 
@@ -100,37 +117,38 @@ Crew(..., process=Process.sequential)    # linear walk-through
 Crew(..., process=Process.hierarchical)  # manager + workers, needs manager_llm
 ```
 
-We use sequential (simplest, deterministic). Hierarchical lets a manager agent dispatch — useful for more complex tasks.
+This exercise uses sequential because its order is easy to see. Hierarchical lets a manager dispatch work; use it when you need dynamic assignment and already have evaluations and stop conditions.
 
 ## Observation across both paths
 
 | Observation | Anthropic Claude haiku | Ollama qwen2.5:3b |
 |---|---|---|
-| Researcher actually calls tool | Stable | Sometimes skips tool, makes things up |
-| Writer cites researcher's output | Stable | May go off-memory, deviate from search result |
-| Critic catches hallucinations | Sharper | Looser, may PASS when it shouldn't |
-| Speed | 10-30s | 30-90s |
-| Cost | $0.005-0.01 | $0 |
+| Researcher calls the tool | Verify in logs and output | Verify in logs and output |
+| Writer uses the research | Check with the same test cases | Check with the same test cases |
+| Critic catches an error | Do not assume success | Do not assume success |
+| Speed | Measure on your network and task | Measure on your hardware and model |
+| Model API cost | Calculate from tokens and calls | $0 |
 
-**Punchline**: multi-agent is more model-quality-sensitive than single-agent — each agent can drop a step, errors compound by the time you reach the critic. Production multi-agent systems almost always use large models (or carefully fine-tuned small ones).
+**Punchline**: multi-agent adds handoff points. If one role drops information, the mistake can travel forward. Model size is not the only answer; evaluate role prompts, tool results, handoffs, and stop conditions.
 
 ## Common pitfalls
 
-- **`expected_output` too generic**: "Some output" gives the LLM no guide. "A 2-sentence blog intro paragraph in active voice" is 10× better
+- **`expected_output` too generic**: "Some output" has no clear success condition. Change it to "A two-sentence blog intro in active voice," then compare with test cases
 - **Missing `context`**: writer without `context=[research_task]` doesn't see researcher's output — it'll hallucinate
-- **Small model + 3 agents**: qwen2.5:3b on 3-agent crews can take 1+ minute. Switch to `qwen2.5:7b` or Claude
+- **Small model + 3 agents**: it may run slowly or miss a step. Inspect the log first, then compare `qwen2.5:7b` or Claude if needed
 - **`allow_delegation=True` use cautiously**: enables agents to call others, easy to loop. Default `False` for prototypes
 
 ## Want smarter answers?
 
-```bash
-MODEL=anthropic/claude-sonnet-5 python starter_anthropic.py  # higher quality
-MODEL=ollama/qwen2.5:7b python starter.py                       # larger local model
+```powershell
+$env:MODEL="anthropic/claude-sonnet-5"; .\.venv\Scripts\python.exe starter_anthropic.py
+$env:MODEL="ollama/qwen2.5:7b"; .\.venv\Scripts\python.exe starter.py
 ```
 
 ## Extensions
 
 - **Add a manager**: `process=Process.hierarchical` + `manager_llm=...` for dynamic delegation
 - **Add memory**: CrewAI has `memory=True` for cross-task context
-- **Streaming**: `crew.kickoff_for_each(...)` or `crew.kickoff_async(...)`
-- **Human-in-the-loop**: see Exercise 3 (LangGraph) — CrewAI's HITL is weaker
+- **Batch or async execution**: `crew.kickoff_for_each(...)` handles a list of inputs; `crew.kickoff_async(...)` runs asynchronously. Neither one means streaming
+- **Streaming**: construct `Crew(..., stream=True)`, then call `crew.kickoff()`
+- **Human-in-the-loop**: Exercise 3 demonstrates LangGraph; CrewAI also provides its own human-feedback triggers

--- a/examples/stage-4/02-multi-agent-roles/README.md
+++ b/examples/stage-4/02-multi-agent-roles/README.md
@@ -22,39 +22,56 @@ Researcher → Writer → Critic
   (找資料) (寫稿) (審稿、PASS/ISSUES)
 ```
 
-這種「role-based pipeline」**CrewAI 最拿手**——你描述角色 / 目標 / 任務，框架自己 orchestrate。
+這是 **role-based pipeline（角色式流水線）**：你描述每個角色、目標與任務，CrewAI 依順序傳遞結果。
 
 ## 怎麼跑 — 兩條路徑
 
+> ⚠️ **每個練習都要有自己的 Python 3.11 `.venv`。** 不要把 Stage 4 五個 `requirements.txt` 混裝。
+
 ### Path A（默認、本機免費）
 
-```bash
-pip install -r requirements.txt
+```powershell
+py -3.11 -m venv .venv
+.\.venv\Scripts\python.exe -m pip install -r requirements.txt
 ollama pull qwen2.5:3b
 ollama serve
-python starter.py
+.\.venv\Scripts\python.exe starter.py
 ```
 
-預算：**$0**。3 agent sequential ≈ 30-90 秒（CPU、qwen2.5:3b）。
+預算：模型 API 是 **$0**；執行時間依 CPU、記憶體、模型與 prompt 而變，請在自己的電腦量測。
 
-### Path B（Anthropic、想看 cloud 高品質）
+### Path B（Anthropic、比較雲端結果）
+
+```powershell
+$env:ANTHROPIC_API_KEY="sk-ant-..."
+.\.venv\Scripts\python.exe starter_anthropic.py
+```
+
+預設固定型號：`anthropic/claude-haiku-4-5-20251001`。以 2,000 input + 1,000 output tokens 的單次模型請求為例：`2,000 / 1,000,000 × $1 + 1,000 / 1,000,000 × $5 = $0.007`。三個角色可能各呼叫一次或重試；本練習先設供應商支出上限 **$0.10**。
+
+<details markdown="1">
+<summary>macOS／Linux 指令與查核資訊</summary>
 
 ```bash
-pip install -r requirements.txt
-export ANTHROPIC_API_KEY=sk-ant-...
-python starter_anthropic.py
+python3.11 -m venv .venv
+./.venv/bin/python -m pip install -r requirements.txt
+export ANTHROPIC_API_KEY="sk-ant-..."
+./.venv/bin/python test.py
 ```
 
-預算：每次 ≈ **$0.005-0.01**（3 agent × 短輸出、claude-haiku-4-5）。
+官方來源：[CrewAI docs](https://docs.crewai.com/)｜[LiteLLM docs](https://docs.litellm.ai/)｜[Anthropic pricing](https://platform.claude.com/docs/en/about-claude/pricing)
+
+<small>套件、model ID、價格與官方連結查核：2026-08-28 UTC。</small>
+</details>
 
 ## 不花錢驗證程式邏輯
 
-```bash
-python test.py # tool 邏輯 + crew structure
-python test_anthropic.py # starter_anthropic 載入
+```powershell
+.\.venv\Scripts\python.exe test.py # 角色、任務、handoff 與停止條件
+.\.venv\Scripts\python.exe test_anthropic.py # Anthropic 路徑行為
 ```
 
-CrewAI 整個 `kickoff()` 太黑盒、純 mock 困難。這份 test 只驗結構（3 agent + 3 task + sequential process + context dependencies）跟 tool 邏輯。實測請跑 starter.py。
+離線測試不呼叫真模型，但會檢查 3 個 agent、3 個 task、sequential process、context dependency、handoff 與可觀察的停止條件。模型品質仍要另外實測。
 
 ## CrewAI multi-agent 核心觀念
 
@@ -82,7 +99,7 @@ research_task = Task(
 )
 ```
 
-**重點**：`expected_output` 是給 LLM 看的「合格範本」、寫越具體越好（譬如「A 2-sentence intro paragraph」比「Some text」好 10 倍）。
+**重點**：`expected_output` 是給 LLM 看的「合格範本」。寫成「兩句、主動語態的開場」比「一些文字」更清楚；改善幅度要用自己的任務評測。
 
 ### Context dependency
 
@@ -100,37 +117,38 @@ Crew(..., process=Process.sequential) # 線性走完
 Crew(..., process=Process.hierarchical) # 多個 manager+worker、需設 manager_llm
 ```
 
-這題用 sequential（最簡單、最 deterministic）。Hierarchical 是 ManagementAgent 派任務給其他 agent、適合更複雜場景。
+這題用 sequential，因為順序最容易看懂。Hierarchical 會由 manager 分派任務，適合需要動態分工、而且已有評測與停止條件的場景。
 
 ## 兩個 path 觀察重點
 
 | 觀察項 | Anthropic Claude haiku | Ollama qwen2.5:3b |
 |---|---|---|
-| Researcher 直接呼叫 tool | 穩 | 偶爾跳過 tool、自己編答案 |
-| Writer 引用 Researcher 結果 | 穩 | 可能憑印象寫、偏離 search result |
-| Critic 抓 hallucination | 較敏銳 | 較鬆、可能 PASS 過頭 |
-| 速度 | 10-30 秒 | 30-90 秒 |
-| 成本 | $0.005-0.01 | $0 |
+| Researcher 是否呼叫 tool | 看 log 與輸出驗證 | 看 log 與輸出驗證 |
+| Writer 是否使用研究結果 | 用測試案例檢查 | 用相同測試案例檢查 |
+| Critic 是否抓到錯誤 | 不預設一定成功 | 不預設一定成功 |
+| 速度 | 在自己的網路與任務量測 | 在自己的硬體與模型量測 |
+| 模型 API 成本 | 依 tokens 與呼叫次數計算 | $0 |
 
-**教學 punchline**：multi-agent 對 model 質量比 single-agent 敏感——每個 agent 都可能漏一步、錯誤會累積到 critic 那邊。Production 多 agent 系統幾乎必用大 model（或細調過的小 model）。
+**教學 punchline**：multi-agent 多了交接點；任何角色漏掉資訊，錯誤都可能往後傳。模型大小不是唯一答案，還要測角色 prompt、工具結果、handoff 與停止條件。
 
 ## 常見坑
 
-- **`expected_output` 太籠統**：寫「Some output」LLM 完全沒指引、隨便給。寫「A 2-sentence blog intro paragraph in active voice」效果差 10 倍
+- **`expected_output` 太籠統**：寫「Some output」沒有清楚成功條件。改成「A 2-sentence blog intro paragraph in active voice」，再用測試案例比較
 - **`context` 漏設**：Writer 沒設 `context=[research_task]`、就拿不到 researcher 結果、會憑空寫
-- **小 model + 3 agent**：qwen2.5:3b 跑 3-agent crew 可能 1 分鐘+。換 `qwen2.5:7b` 或 Claude
+- **小 model + 3 agent**：可能比較慢或漏步。先看 log；需要時再比較 `qwen2.5:7b` 或 Claude
 - **`allow_delegation=True` 慎用**：開啟後 agent 可以叫其他 agent 幫忙、容易 loop。雛形階段建議 `False`
 
 ## 想看更聰明的答案？
 
-```bash
-MODEL=anthropic/claude-sonnet-5 python starter_anthropic.py # 高品質
-MODEL=ollama/qwen2.5:7b python starter.py # 較大本機 model
+```powershell
+$env:MODEL="anthropic/claude-sonnet-5"; .\.venv\Scripts\python.exe starter_anthropic.py
+$env:MODEL="ollama/qwen2.5:7b"; .\.venv\Scripts\python.exe starter.py
 ```
 
 ## 延伸
 
 - **加 manager**：`process=Process.hierarchical` + `manager_llm=...`、讓 manager agent 動態分配
 - **加 memory**：CrewAI 有 `memory=True`、讓 agent 跨 task 記住 context
-- **改成 streaming**：`crew.kickoff_for_each(...)` 或 `crew.kickoff_async(...)`
-- **加 human-in-the-loop**：練習 3 用 LangGraph 做、CrewAI 對 HITL 較弱
+- **批次或非同步**：`crew.kickoff_for_each(...)` 是一批輸入，`crew.kickoff_async(...)` 是非同步執行；兩者都不是 streaming
+- **加 streaming**：建立 `Crew(..., stream=True)`，再呼叫 `crew.kickoff()`
+- **加 human-in-the-loop**：本題用練習 3 的 LangGraph 做示範；CrewAI 也有自己的 human-feedback triggers

--- a/examples/stage-4/02-multi-agent-roles/README.zh-Hans.md
+++ b/examples/stage-4/02-multi-agent-roles/README.zh-Hans.md
@@ -9,7 +9,7 @@
 
 > 📚 **想要 chapter-length 深入版？** 本 folder 的 starter 是 illustrative 版、聚焦核心 pattern + 两条 SDK path，不是进阶深度教材。深度教材推荐：
 > - [`datawhalechina/hello-agents`](https://github.com/datawhalechina/hello-agents) ⭐ 中文圈最完整、章节式 + 16 种 production 能力。**本练习对应 hello-agents 的 multi-agent roles / Crew 章节**
-> - [CrewAI Examples repo](https://github.com/crewAIInc/crewAI-examples)（官方 sequential / hierarchical 范本；⚠️ 已归档 2026-04、仍可当参考）
+> - [CrewAI Examples repo](https://github.com/crewAIInc/crewAI-examples)（官方 sequential / hierarchical 范本；⚠️ 已封存 2026-04、仍可当参考）
 > - 完整 references 见 [Stage 4 精选 Projects](../../../stages/04-agent-frameworks.zh-Hans.md#-精选-projects)
 
 
@@ -19,42 +19,59 @@
 
 ```
 Researcher → Writer → Critic
-  (找资料)    (写稿)    (审稿、PASS/ISSUES)
+  (找资料) (写稿) (审稿、PASS/ISSUES)
 ```
 
-这种“role-based pipeline”**CrewAI 最拿手**——你描述角色 / 目标 / 任务，框架自己 orchestrate。
+这是 **role-based pipeline（角色式流水线）**：你描述每个角色、目标与任务，CrewAI 依顺序传递结果。
 
 ## 怎么跑 — 两条路径
 
+> ⚠️ **每个练习都要有自己的 Python 3.11 `.venv`。** 不要把 Stage 4 五个 `requirements.txt` 混装。
+
 ### Path A（默认、本机免费）
 
-```bash
-pip install -r requirements.txt
+```powershell
+py -3.11 -m venv .venv
+.\.venv\Scripts\python.exe -m pip install -r requirements.txt
 ollama pull qwen2.5:3b
 ollama serve
-python starter.py
+.\.venv\Scripts\python.exe starter.py
 ```
 
-预算：**$0**。3 agent sequential ≈ 30-90 秒（CPU、qwen2.5:3b）。
+预算：模型 API 是 **$0**；执行时间依 CPU、记忆体、模型与 prompt 而变，请在自己的电脑量测。
 
-### Path B（Anthropic、想看 cloud 高质量）
+### Path B（Anthropic、比较云端结果）
+
+```powershell
+$env:ANTHROPIC_API_KEY="sk-ant-..."
+.\.venv\Scripts\python.exe starter_anthropic.py
+```
+
+预设固定型号：`anthropic/claude-haiku-4-5-20251001`。以 2,000 input + 1,000 output tokens 的单次模型请求为例：`2,000 / 1,000,000 × $1 + 1,000 / 1,000,000 × $5 = $0.007`。三个角色可能各调用一次或重试；本练习先设供应商支出上限 **$0.10**。
+
+<details markdown="1">
+<summary>macOS／Linux 指令与查核资讯</summary>
 
 ```bash
-pip install -r requirements.txt
-export ANTHROPIC_API_KEY=sk-ant-...
-python starter_anthropic.py
+python3.11 -m venv .venv
+./.venv/bin/python -m pip install -r requirements.txt
+export ANTHROPIC_API_KEY="sk-ant-..."
+./.venv/bin/python test.py
 ```
 
-预算：每次 ≈ **$0.005-0.01**（3 agent × 短输出、claude-haiku-4-5）。
+官方来源：[CrewAI docs](https://docs.crewai.com/)｜[LiteLLM docs](https://docs.litellm.ai/)｜[Anthropic pricing](https://platform.claude.com/docs/en/about-claude/pricing)
+
+<small>套件、model ID、价格与官方连结查核：2026-08-28 UTC。</small>
+</details>
 
 ## 不花钱验证程序逻辑
 
-```bash
-python test.py             # tool 逻辑 + crew structure
-python test_anthropic.py   # starter_anthropic 载入
+```powershell
+.\.venv\Scripts\python.exe test.py # 角色、任务、handoff 与停止条件
+.\.venv\Scripts\python.exe test_anthropic.py # Anthropic 路径行为
 ```
 
-CrewAI 整个 `kickoff()` 太黑盒、纯 mock 困难。这份 test 只验结构（3 agent + 3 task + sequential process + context dependencies）跟 tool 逻辑。实测请跑 starter.py。
+离线测试不调用真模型，但会检查 3 个 agent、3 个 task、sequential process、context dependency、handoff 与可观察的停止条件。模型质量仍要另外实测。
 
 ## CrewAI multi-agent 核心观念
 
@@ -63,8 +80,8 @@ CrewAI 整个 `kickoff()` 太黑盒、纯 mock 困难。这份 test 只验结构
 ```python
 researcher = Agent(
     role="Researcher",
-    goal="...",          # 一句话讲「成功」长什么样
-    backstory="...",     # 提供 persona context、影响 prompt
+    goal="...", # 一句话讲「成功」长什么样
+    backstory="...", # 提供 persona context、影响 prompt
     tools=[search],
     llm=MODEL,
 )
@@ -82,13 +99,13 @@ research_task = Task(
 )
 ```
 
-**重点**：`expected_output` 是给 LLM 看的“合格范本”、写越具体越好（譬如“A 2-sentence intro paragraph”比“Some text”好 10 倍）。
+**重点**：`expected_output` 是给 LLM 看的“合格范本”。写成“两句、主动语态的开场”比“一些文字”更清楚；改善幅度要用自己的任务评测。
 
 ### Context dependency
 
 ```python
-write_task = Task(..., context=[research_task])   # writer 看 researcher 结果
-critic_task = Task(..., context=[research_task, write_task])  # critic 同时看两个
+write_task = Task(..., context=[research_task]) # writer 看 researcher 结果
+critic_task = Task(..., context=[research_task, write_task]) # critic 同时看两个
 ```
 
 **重点**：`context` 是 CrewAI 的 dataflow 机制。`critic_task.context=[a, b]` 表示 critic 看到 a, b 两个 task 的 output。
@@ -96,41 +113,42 @@ critic_task = Task(..., context=[research_task, write_task])  # critic 同时看
 ### Sequential vs Hierarchical Process
 
 ```python
-Crew(..., process=Process.sequential)    # 线性走完
-Crew(..., process=Process.hierarchical)  # 多个 manager+worker、需设 manager_llm
+Crew(..., process=Process.sequential) # 线性走完
+Crew(..., process=Process.hierarchical) # 多个 manager+worker、需设 manager_llm
 ```
 
-这题用 sequential（最简单、最 deterministic）。Hierarchical 是 ManagementAgent 派任务给其他 agent、适合更复杂场景。
+这题用 sequential，因为顺序最容易看懂。Hierarchical 会由 manager 分派任务，适合需要动态分工、而且已有评测与停止条件的场景。
 
 ## 两个 path 观察重点
 
 | 观察项 | Anthropic Claude haiku | Ollama qwen2.5:3b |
 |---|---|---|
-| Researcher 直接调用 tool | 稳 | 偶尔跳过 tool、自己编答案 |
-| Writer 引用 Researcher 结果 | 稳 | 可能凭印象写、偏离 search result |
-| Critic 抓 hallucination | 较敏锐 | 较松、可能 PASS 过头 |
-| 速度 | 10-30 秒 | 30-90 秒 |
-| 成本 | $0.005-0.01 | $0 |
+| Researcher 是否调用 tool | 看 log 与输出验证 | 看 log 与输出验证 |
+| Writer 是否使用研究结果 | 用测试案例检查 | 用相同测试案例检查 |
+| Critic 是否抓到错误 | 不预设一定成功 | 不预设一定成功 |
+| 速度 | 在自己的网络与任务量测 | 在自己的硬体与模型量测 |
+| 模型 API 成本 | 依 tokens 与调用次数计算 | $0 |
 
-**教学 punchline**：multi-agent 对 model 质量比 single-agent 敏感——每个 agent 都可能漏一步、错误会累积到 critic 那边。Production 多 agent 系统几乎必用大 model（或细调过的小 model）。
+**教学 punchline**：multi-agent 多了交接点；任何角色漏掉资讯，错误都可能往后传。模型大小不是唯一答案，还要测角色 prompt、工具结果、handoff 与停止条件。
 
 ## 常见坑
 
-- **`expected_output` 太笼统**：写“Some output”LLM 完全没指引、随便给。写“A 2-sentence blog intro paragraph in active voice”效果差 10 倍
+- **`expected_output` 太笼统**：写“Some output”没有清楚成功条件。改成“A 2-sentence blog intro paragraph in active voice”，再用测试案例比较
 - **`context` 漏设**：Writer 没设 `context=[research_task]`、就拿不到 researcher 结果、会凭空写
-- **小 model + 3 agent**：qwen2.5:3b 跑 3-agent crew 可能 1 分钟+。换 `qwen2.5:7b` 或 Claude
+- **小 model + 3 agent**：可能比较慢或漏步。先看 log；需要时再比较 `qwen2.5:7b` 或 Claude
 - **`allow_delegation=True` 慎用**：开启后 agent 可以叫其他 agent 帮忙、容易 loop。雏形阶段建议 `False`
 
 ## 想看更聪明的答案？
 
-```bash
-MODEL=anthropic/claude-sonnet-5 python starter_anthropic.py  # 高品质
-MODEL=ollama/qwen2.5:7b python starter.py                       # 较大本机 model
+```powershell
+$env:MODEL="anthropic/claude-sonnet-5"; .\.venv\Scripts\python.exe starter_anthropic.py
+$env:MODEL="ollama/qwen2.5:7b"; .\.venv\Scripts\python.exe starter.py
 ```
 
 ## 延伸
 
 - **加 manager**：`process=Process.hierarchical` + `manager_llm=...`、让 manager agent 动态分配
 - **加 memory**：CrewAI 有 `memory=True`、让 agent 跨 task 记住 context
-- **改成 streaming**：`crew.kickoff_for_each(...)` 或 `crew.kickoff_async(...)`
-- **加 human-in-the-loop**：练习 3 用 LangGraph 做、CrewAI 对 HITL 较弱
+- **批次或异步执行**：`crew.kickoff_for_each(...)` 处理一批输入，`crew.kickoff_async(...)` 异步执行；两者都不是 streaming
+- **加 streaming**：创建 `Crew(..., stream=True)`，再调用 `crew.kickoff()`
+- **加 human-in-the-loop**：本题用练习 3 的 LangGraph 示范；CrewAI 也有自己的 human-feedback triggers

--- a/examples/stage-4/02-multi-agent-roles/requirements.txt
+++ b/examples/stage-4/02-multi-agent-roles/requirements.txt
@@ -1,2 +1,2 @@
-crewai>=0.80,<1.0
-litellm>=1.50,<2.0
+crewai[anthropic]>=1.15,<2.0
+litellm>=1.98,<2.0

--- a/examples/stage-4/02-multi-agent-roles/starter.py
+++ b/examples/stage-4/02-multi-agent-roles/starter.py
@@ -1,24 +1,24 @@
-"""Stage 4 練習 2：多 agent 角色分配 — CrewAI + Ollama（Path A、默認）。
+r"""Stage 4 練習 2：用 CrewAI + Ollama 做有界的三角色交接。
 
 3 個 agent 各有角色：
 - Researcher 找資料（用 search tool）
 - Writer 寫稿（拿 researcher 的結果寫成 blog 段落）
 - Critic 審稿（檢查 factual + tone）
 
-這個情境 CrewAI 最拿手——hierarchical / sequential delegation 是 CrewAI 的招牌。
+這裡使用 ``Process.sequential``，讓三個角色像接力一樣依序交接。
 
 跑法：
-    pip install -r requirements.txt
+    py -3.11 -m venv .venv
+    .\.venv\Scripts\python.exe -m pip install -r requirements.txt
     ollama pull qwen2.5:3b
     ollama serve
-    python starter.py
+    .\.venv\Scripts\python.exe starter.py
 
 驗證：
-    python test.py
+    .\.venv\Scripts\python.exe test.py
 
-預算：$0/run（Ollama）。對照 Anthropic 版見 starter_anthropic.py。
-
-⚠️ 注意：3 個 agent 走 sequential、qwen2.5:3b 可能會繞較久（30-90 秒）。
+模型 API 預算：$0（Ollama）。執行時間依硬體、模型與 prompt 而變。
+對照 Anthropic 版見 ``starter_anthropic.py``。
 """
 
 from __future__ import annotations
@@ -39,9 +39,8 @@ OLLAMA_BASE = os.environ.get("OLLAMA_API_BASE", "http://localhost:11434")
 
 # === Tool ===
 
-@tool("search")
-def search(query: str) -> str:
-    """Search a (fake, offline) knowledge base."""
+def search_knowledge_base(query: str) -> str:
+    """查詢固定的離線示範資料表，不代表真正的搜尋引擎。"""
     db = {
         "react": "ReAct (Reasoning+Acting, Yao et al. 2022) is the foundational agent pattern: think→act→observe loop.",
         "langgraph": "LangGraph is a graph-based agent orchestration framework by LangChain, focuses on state + checkpointing.",
@@ -50,9 +49,28 @@ def search(query: str) -> str:
     return db.get(query.strip().lower(), f"no entry for {query}")
 
 
+@tool("search")
+def search(query: str) -> str:
+    """Return one entry from the fixed offline knowledge base.
+
+    Args:
+        query: The lowercase topic key to look up, such as ``react``.
+    """
+    return search_knowledge_base(query)
+
+
+def simulate_handoff(topic: str) -> dict[str, str]:
+    """離線走完 Researcher → Writer → Critic，讓交接結果可以直接測試。"""
+    research = search_knowledge_base(topic)
+    draft = f"{topic.title()} matters for agent builders: {research}"
+    verdict = "PASS" if research != f"no entry for {topic}" and research in draft else "ISSUES: missing grounded research"
+    return {"input": topic, "research": research, "draft": draft, "verdict": verdict, "stop_condition": "Three fixed roles; each Agent has max_iter=4."}
+
+
 # === Crew 設計 ===
 
 def build_crew(topic: str, llm_model: str = MODEL) -> Crew:
+    """建立三個固定角色；每個 agent 最多迭代四次且不能自行委派。"""
     os.environ["OPENAI_API_BASE"] = f"{OLLAMA_BASE}/v1"
     os.environ["OPENAI_API_KEY"] = "ollama"
 
@@ -64,6 +82,7 @@ def build_crew(topic: str, llm_model: str = MODEL) -> Crew:
         llm=llm_model,
         verbose=False,
         allow_delegation=False,
+        max_iter=4,
     )
     writer = Agent(
         role="Writer",
@@ -72,6 +91,7 @@ def build_crew(topic: str, llm_model: str = MODEL) -> Crew:
         llm=llm_model,
         verbose=False,
         allow_delegation=False,
+        max_iter=4,
     )
     critic = Agent(
         role="Critic",
@@ -80,6 +100,7 @@ def build_crew(topic: str, llm_model: str = MODEL) -> Crew:
         llm=llm_model,
         verbose=False,
         allow_delegation=False,
+        max_iter=4,
     )
 
     research_task = Task(
@@ -110,9 +131,10 @@ def build_crew(topic: str, llm_model: str = MODEL) -> Crew:
 
 
 def run(topic: str, llm_model: str = MODEL) -> dict:
+    """執行 crew，並把最終結果與可觀察的停止條件一起回傳。"""
     crew = build_crew(topic, llm_model=llm_model)
     result = crew.kickoff()
-    return {"final": str(result), "topic": topic}
+    return {"final": str(result), "topic": topic, "stop_condition": "Three fixed roles; each Agent has max_iter=4."}
 
 
 if __name__ == "__main__":
@@ -123,4 +145,5 @@ if __name__ == "__main__":
     result = run(topic)
     print(f"✅ Final (critic's verdict):\n{result['final']}")
     assert result["final"], "expected critic to produce a verdict"
-    print("\n✅ 練習 2 通過 — 3-agent crew 跑完、$0/run")
+    assert "max_iter=4" in result["stop_condition"]
+    print("\n✅ 練習 2 通過 — 3-agent crew 跑完、模型 API $0")

--- a/examples/stage-4/02-multi-agent-roles/starter_anthropic.py
+++ b/examples/stage-4/02-multi-agent-roles/starter_anthropic.py
@@ -1,13 +1,13 @@
-"""Stage 4 練習 2：多 agent 角色分配 — CrewAI + Anthropic（Path B）。
+r"""Stage 4 練習 2 Path B：用 Anthropic 跑同一個三角色 CrewAI 流程。
 
-CrewAI 用 LiteLLM 底層、改成 "anthropic/claude-haiku-4-5" 字串即可切 backend。
+CrewAI 用 provider-prefixed model string 選擇後端；
+``crewai[anthropic]`` 會安裝 Anthropic provider，這份範例再固定 model ID。
 
 跑法：
-    pip install -r requirements.txt
-    export ANTHROPIC_API_KEY=sk-ant-...
-    python starter_anthropic.py
+    $env:ANTHROPIC_API_KEY="sk-ant-..."
+    .\.venv\Scripts\python.exe starter_anthropic.py
 
-預算：3 agent × 短輸出 ≈ $0.005-0.01/run。Claude 對 multi-agent 互動穩很多。
+實際費用依 tokens、呼叫次數與重試而變；README 提供公式與 $0.10 支出上限。
 """
 
 from __future__ import annotations
@@ -20,7 +20,7 @@ if hasattr(sys.stdout, "reconfigure"):
 
 from starter import run
 
-MODEL = os.environ.get("MODEL", "anthropic/claude-haiku-4-5")  # LiteLLM 格式
+MODEL = os.environ.get("MODEL", "anthropic/claude-haiku-4-5-20251001")  # provider-prefixed format
 
 
 if __name__ == "__main__":
@@ -31,4 +31,5 @@ if __name__ == "__main__":
     result = run(topic, llm_model=MODEL)
     print(f"✅ Final (critic's verdict):\n{result['final']}")
     assert result["final"], "expected critic to produce a verdict"
-    print("\n✅ 練習 2 (Anthropic path) 通過 — Claude 跑 3-agent crew、≈$0.005-0.01/run")
+    assert "max_iter=4" in result["stop_condition"]
+    print("\n✅ 練習 2 (Anthropic path) 通過 — 3-agent crew 已走到有界停止條件")

--- a/examples/stage-4/02-multi-agent-roles/test.py
+++ b/examples/stage-4/02-multi-agent-roles/test.py
@@ -1,9 +1,4 @@
-"""Stage 4 練習 2 自我驗證 — CrewAI 模組可載入 + tool 邏輯正確。
-
-CrewAI 整個 kickoff 太黑盒（內部走 LiteLLM、prompt 累積）、不適合純 mock。
-這份只驗：(1) 3 個 agent + 3 個 task 結構正確、(2) search tool 邏輯正確。
-要實測請跑 starter.py 配 Ollama。
-"""
+"""Offline Path A checks for the handoff behavior and real CrewAI structure."""
 
 from __future__ import annotations
 
@@ -12,33 +7,30 @@ import sys
 if hasattr(sys.stdout, "reconfigure"):
     sys.stdout.reconfigure(encoding="utf-8", errors="replace")
 
-from starter import build_crew, search
+from crewai import Process
+from starter import build_crew, simulate_handoff
 
 
-def test_search_basic():
-    fn = getattr(search, "func", None) or getattr(search, "run", None)
-    if fn is None:
-        print("⚠ CrewAI tool 介面變動、跳過")
-        return
-    assert "ReAct" in fn("react")
-    assert "no entry" in fn("nonexistent")
-    print("✅ test_search_basic")
+def test_offline_research_writer_critic_handoff() -> None:
+    result = simulate_handoff("react")
+    assert result["input"] == "react"
+    assert "ReAct" in result["research"]
+    assert result["research"] in result["draft"]
+    assert result["verdict"] == "PASS"
+    assert result["stop_condition"] == "Three fixed roles; each Agent has max_iter=4."
 
 
-def test_crew_structure():
-    """確認 build_crew 出來的 Crew 真有 3 個 agent + 3 個 task、process 是 sequential。"""
+def test_crewai_sequential_context_structure() -> None:
     crew = build_crew("react")
-    assert len(crew.agents) == 3, f"expected 3 agents, got {len(crew.agents)}"
-    roles = [a.role for a in crew.agents]
-    assert roles == ["Researcher", "Writer", "Critic"], f"unexpected roles: {roles}"
-    assert len(crew.tasks) == 3, f"expected 3 tasks, got {len(crew.tasks)}"
-    # critic_task 應該 context 包含 research_task 跟 write_task
-    critic_task = crew.tasks[2]
-    assert len(critic_task.context) == 2, "critic should depend on research + write"
-    print("✅ test_crew_structure")
+    assert crew.process == Process.sequential
+    assert [agent.role for agent in crew.agents] == ["Researcher", "Writer", "Critic"]
+    assert len(crew.tasks) == 3
+    assert crew.tasks[1].context == [crew.tasks[0]]
+    assert crew.tasks[2].context == [crew.tasks[0], crew.tasks[1]]
+    assert all(agent.max_iter == 4 for agent in crew.agents)
 
 
 if __name__ == "__main__":
-    test_search_basic()
-    test_crew_structure()
-    print("\n🎉 通過 — 3-agent crew 結構正確（實際 kickoff 需 Ollama 跑著）")
+    test_offline_research_writer_critic_handoff()
+    test_crewai_sequential_context_structure()
+    print("all pass")

--- a/examples/stage-4/02-multi-agent-roles/test_anthropic.py
+++ b/examples/stage-4/02-multi-agent-roles/test_anthropic.py
@@ -1,7 +1,4 @@
-"""Stage 4 練習 2 自我驗證 — Path B import + module-load check。
-
-CrewAI multi-agent kickoff 太黑盒、純 mock 困難。實測請跑 starter_anthropic.py 配 ANTHROPIC_API_KEY。
-"""
+"""Offline Path B checks for CrewAI's Anthropic provider and the same handoff."""
 
 from __future__ import annotations
 
@@ -10,22 +7,25 @@ import sys
 if hasattr(sys.stdout, "reconfigure"):
     sys.stdout.reconfigure(encoding="utf-8", errors="replace")
 
-
-def test_starter_anthropic_loadable():
-    import starter_anthropic
-    assert hasattr(starter_anthropic, "MODEL")
-    assert "anthropic/" in starter_anthropic.MODEL, f"預期 LiteLLM 格式 anthropic/...、得到 {starter_anthropic.MODEL}"
-    print("✅ test_starter_anthropic_loadable")
+from starter import build_crew, simulate_handoff
+from starter_anthropic import MODEL
 
 
-def test_run_function_imported():
-    """starter_anthropic 重用 starter.run，並注入 anthropic model name。"""
-    from starter_anthropic import run
-    assert callable(run)
-    print("✅ test_run_function_imported")
+def test_pinned_anthropic_provider_and_structure() -> None:
+    assert MODEL == "anthropic/claude-haiku-4-5-20251001"
+    crew = build_crew("react", llm_model=MODEL)
+    assert [agent.role for agent in crew.agents] == ["Researcher", "Writer", "Critic"]
+    assert len(crew.tasks[2].context) == 2
+
+
+def test_anthropic_path_offline_handoff_behavior() -> None:
+    result = simulate_handoff("langgraph")
+    assert "LangGraph" in result["research"]
+    assert result["verdict"] == "PASS"
+    assert "max_iter=4" in result["stop_condition"]
 
 
 if __name__ == "__main__":
-    test_starter_anthropic_loadable()
-    test_run_function_imported()
-    print("\n🎉 通過 — Anthropic path 可載入（實測需 ANTHROPIC_API_KEY）")
+    test_pinned_anthropic_provider_and_structure()
+    test_anthropic_path_offline_handoff_behavior()
+    print("all pass")

--- a/examples/stage-4/03-graph-workflow/README.en.md
+++ b/examples/stage-4/03-graph-workflow/README.en.md
@@ -1,5 +1,5 @@
 <div align="right">
-  <a href="./README.md">繁體中文</a> | <a href="./README.zh-Hans.md">简体中文</a> | <strong>English</strong>
+  <a href="./README.md">Traditional Chinese</a> | <a href="./README.zh-Hans.md">Simplified Chinese</a> | <strong>English</strong>
 </div>
 
 # Exercise 3: Graph Workflow (LangGraph conditional branching + HITL)
@@ -19,23 +19,56 @@ Pairs with [Stage 4 — Agent Frameworks](../../../stages/04-agent-frameworks.en
 
 - **`classify_node`**: decides `needs_search` from the query
 - **Conditional branch**: `needs_search=True` → `search`, otherwise `respond`
-- **HITL checkpoint**: after `respond`, interrupt — wait for a human to write `approved` into state
+- **HITL checkpoint**: `review_node` calls `interrupt()` and waits for a human answer
 - **`final_node`**: `approved=True` → PUBLISHED, else REJECTED
 
-This is **LangGraph's sweet spot**: graph state + checkpointing + `interrupt_before` is the signature combo. CrewAI's HITL support is weaker.
+This exercise uses **graph state**, a **checkpoint**, `interrupt()`, and `Command(resume=...)`. You can see where the graph pauses and how it resumes from the same `thread_id`.
 
-## How to run
+## How to run — two paths
 
-```bash
-pip install -r requirements.txt
-python starter.py
+> ⚠️ **Give each exercise its own Python 3.11 `.venv`.** Do not mix the five Stage 4 `requirements.txt` files.
+
+### Path A (Ollama, local)
+
+```powershell
+py -3.11 -m venv .venv
+.\.venv\Scripts\python.exe -m pip install -r requirements.txt
+ollama pull qwen2.5:3b
+ollama serve
+.\.venv\Scripts\python.exe starter.py
 ```
 
-Budget: **$0**. The nodes here are deterministic logic — no LLM calls. To wire in a real LLM, replace `respond_node` with `llm.invoke(...)`.
+Budget: the model API costs **$0**. Local hardware, electricity, and downloads still cost resources. This starter really asks Ollama to write the draft; the other nodes use predictable Python logic.
+
+### Path B (Anthropic, compare a cloud result)
+
+```powershell
+$env:ANTHROPIC_API_KEY="sk-ant-..."
+.\.venv\Scripts\python.exe starter_anthropic.py
+```
+
+Pinned default: `claude-haiku-4-5-20251001`. A request with 2,000 input + 1,000 output tokens costs `2,000 / 1,000,000 × $1 + 1,000 / 1,000,000 × $5 = $0.007`. A retry may add another call, so set a provider spend limit of **$0.05**.
+
+<details markdown="1">
+<summary>macOS/Linux commands and verification information</summary>
 
 ```bash
-python test.py             # 6 tests for routing + HITL
-python test_anthropic.py   # Path B concept demo
+python3.11 -m venv .venv
+./.venv/bin/python -m pip install -r requirements.txt
+export ANTHROPIC_API_KEY="sk-ant-..."
+./.venv/bin/python test.py
+```
+
+Official sources: [LangGraph interrupts](https://docs.langchain.com/oss/python/langgraph/interrupts) | [LangGraph persistence](https://docs.langchain.com/oss/python/langgraph/persistence) | [Anthropic pricing](https://platform.claude.com/docs/en/about-claude/pricing)
+
+<small>Packages, model IDs, prices, and official links verified: 2026-08-28 UTC.</small>
+</details>
+
+## Validate the logic without spending money
+
+```powershell
+.\.venv\Scripts\python.exe test.py # branch, interrupt, and resume behavior
+.\.venv\Scripts\python.exe test_anthropic.py # Anthropic setup + shared graph behavior
 ```
 
 ## LangGraph structure (condensed)
@@ -45,32 +78,32 @@ g = StateGraph(State)
 g.add_node("classify", classify_node)
 g.add_node("search", search_node)
 g.add_node("respond", respond_node)
+g.add_node("review", review_node)
 g.add_node("final", final_node)
 
 g.add_edge(START, "classify")
 g.add_conditional_edges("classify", should_search, {"search": "search", "respond": "respond"})
 g.add_edge("search", "respond")
-g.add_edge("respond", "final")
+g.add_edge("respond", "review")
+g.add_edge("review", "final")
 g.add_edge("final", END)
 
-graph = g.compile(checkpointer=InMemorySaver(), interrupt_before=["final"])
+graph = g.compile(checkpointer=InMemorySaver())
 ```
 
 ## How HITL works
 
 ```python
-# Phase 1: run up to (but not into) final — interrupt_before=["final"] pauses it
-state_before = graph.invoke({"query": ...}, config={"configurable": {"thread_id": "demo"}})
-# Show state_before["draft"] to a human and ask "publish?"
+# Phase 1: review_node calls interrupt(); the graph checkpoints and pauses
+config = {"configurable": {"thread_id": "demo"}}
+state_before = graph.invoke({"query": ...}, config=config)
+# state_before["__interrupt__"] carries the draft and the question
 
-# Human's decision: write `approved` into state
-graph.update_state(config, {"approved": True})
-
-# Phase 2: resume from final (None means "no new input, use checkpoint")
-state_after = graph.invoke(None, config=config)
+# Phase 2: resume with the answer and the same thread_id
+state_after = graph.invoke(Command(resume=True), config=config)
 ```
 
-**Key**: `interrupt_before=["final"]` tells the graph "stop before entering final". In production, wire this to a webhook / Slack / frontend button, and resume after the user approves.
+**Key**: `interrupt()` means "pause here." `Command(resume=True/False)` means "continue with the person's answer." A production app can connect that pause to a webhook, Slack, or a frontend button.
 
 ## Why this pattern matters
 
@@ -80,35 +113,45 @@ state_after = graph.invoke(None, config=config)
 | Agent changes prod config | Apply directly | Dry-run, wait for approval |
 | Agent issues refund | Auto-refund | Refund over $X waits for review |
 
-**Any production agent with side effects should include HITL.** LangGraph's `interrupt_before` is designed for this.
+For a **side effect**—an action that changes the outside world—judge the risk first. Sending email, issuing refunds, or changing production settings usually needs HITL, permission checks, and an audit log. A low-risk read-only action may not need approval every time.
 
 ## What to watch on each path
 
-Nodes are deterministic (no LLM), so Path A and Path B run identically. **The focus is the graph structure.** To wire in a real LLM:
+Both paths use the same graph. `classify`, the offline lookup, and routing are predictable Python; `respond` calls a different model to write the draft. **When comparing paths, change only the model—not the graph.**
+
+Inside the node, pause and use the person's answer to update state after resume:
 
 ```python
-# In respond_node:
-from langchain_openai import ChatOpenAI  # Path A
-# from langchain_anthropic import ChatAnthropic  # Path B
-llm = ChatOpenAI(base_url="http://localhost:11434/v1", api_key="ollama", model="qwen2.5:3b")
-draft = llm.invoke(state["query"]).content
-return {"draft": draft}
+from langgraph.types import interrupt
+
+def review_node(state):
+    approved = interrupt({"draft": state["draft"], "question": "Approve?"})
+    return {"approved": approved}
+```
+
+Outside the graph, the caller receives a real person's answer and resumes the same `thread_id`:
+
+```python
+from langgraph.types import Command
+
+human_answer = True
+result = graph.invoke(Command(resume=human_answer), config=config)
 ```
 
 ## Common pitfalls
 
-- **No `checkpointer`**: `graph.compile(interrupt_before=[...])` without a checkpointer raises. You need one to pause/resume
-- **`thread_id` mismatch**: phase-1 invoke + update_state + phase-2 invoke must share `config={"configurable": {"thread_id": "..."}}`; otherwise checkpoint not found
-- **`interrupt_before` vs `interrupt_after`**: before = pause entering the node; after = pause after the node finishes. **HITL usually wants `before`** (so the human sees full state)
+- **No `checkpointer`**: without one, the graph cannot reliably save pause/resume state
+- **`thread_id` mismatch**: the first `invoke` and `Command(resume=...)` must use the same config, or the original checkpoint cannot be found
+- **A side effect before `interrupt()`**: the node may run again when resumed. Put email/refund work after approval and use an idempotency key
 - **`conditional_edges` function must return a string**: `should_search`'s return value must be a key in the third dict of `add_conditional_edges` — can't return a literal node name
 
 ## Want smarter answers?
 
-Wire a real LLM into `respond_node`. Production setups also swap the checkpointer to SQLite / Redis (`SqliteSaver` / `RedisSaver`) for persistence.
+Compare another model, or replace the in-memory checkpointer with persistent storage that fits your deployment. Read the current persistence docs and test failure recovery before choosing a database.
 
 ## Extensions
 
 - **Add retry**: in `search_node` failures, retry via LangGraph's `error` edge
-- **Multiple HITL stops**: `interrupt_before=["draft", "publish"]`
+- **Multiple HITL stops**: call `interrupt()` in separate review nodes and define the data required for each approval
 - **Time-travel debug**: `graph.get_state_history(config)` gives all checkpoints — fork from any of them
 - **Streaming**: `for state in graph.stream(...)` to watch state evolve

--- a/examples/stage-4/03-graph-workflow/README.md
+++ b/examples/stage-4/03-graph-workflow/README.md
@@ -19,23 +19,56 @@
 
 - **`classify_node`**：看 query 決定 `needs_search`
 - **條件分支**：`needs_search=True` 走 `search` node、否則直接 `respond`
-- **HITL checkpoint**：`respond_node` 後 interrupt、等人類在 state 改 `approved`
+- **HITL checkpoint**：`review_node` 用 `interrupt()` 暫停，等待人類回答
 - **`final_node`**：`approved=True` → PUBLISHED、否則 REJECTED
 
-這題 **LangGraph 最拿手**：graph state + checkpointing + interrupt_before 是 LangGraph 招牌組合。CrewAI 對 HITL 支援較弱。
+這題用 LangGraph 示範 **graph state（圖狀態）**、**checkpoint（檢查點）**、`interrupt()` 與 `Command(resume=...)`。你可以看見流程停在哪裡，以及它如何從同一個 `thread_id` 繼續。
 
-## 怎麼跑
+## 怎麼跑 — 兩條路徑
 
-```bash
-pip install -r requirements.txt
-python starter.py
+> ⚠️ **每個練習都要有自己的 Python 3.11 `.venv`。** 不要把 Stage 4 五個 `requirements.txt` 混裝。
+
+### Path A（Ollama、本機）
+
+```powershell
+py -3.11 -m venv .venv
+.\.venv\Scripts\python.exe -m pip install -r requirements.txt
+ollama pull qwen2.5:3b
+ollama serve
+.\.venv\Scripts\python.exe starter.py
 ```
 
-預算：**$0**。這份 demo 的節點都是 deterministic 邏輯、不打 LLM；要實接 Claude / Ollama 在 `respond_node` 改成 `llm.invoke(...)` 即可。
+預算：模型 API 是 **$0**；本機硬體、電力與下載仍有成本。這份 starter 會真的請 Ollama 寫草稿，其他節點則使用可預測的 Python 邏輯。
+
+### Path B（Anthropic、比較雲端結果）
+
+```powershell
+$env:ANTHROPIC_API_KEY="sk-ant-..."
+.\.venv\Scripts\python.exe starter_anthropic.py
+```
+
+預設固定型號：`claude-haiku-4-5-20251001`。若一次請求用 2,000 input + 1,000 output tokens：`2,000 / 1,000,000 × $1 + 1,000 / 1,000,000 × $5 = $0.007`。本練習通常只需要短草稿，但仍可能重試；先設供應商支出上限 **$0.05**。
+
+<details markdown="1">
+<summary>macOS／Linux 指令與查核資訊</summary>
 
 ```bash
-python test.py # 6 個 test，驗 routing + HITL 邏輯
-python test_anthropic.py # Path B concept demo
+python3.11 -m venv .venv
+./.venv/bin/python -m pip install -r requirements.txt
+export ANTHROPIC_API_KEY="sk-ant-..."
+./.venv/bin/python test.py
+```
+
+官方來源：[LangGraph interrupts](https://docs.langchain.com/oss/python/langgraph/interrupts)｜[LangGraph persistence](https://docs.langchain.com/oss/python/langgraph/persistence)｜[Anthropic pricing](https://platform.claude.com/docs/en/about-claude/pricing)
+
+<small>套件、model ID、價格與官方連結查核：2026-08-28 UTC。</small>
+</details>
+
+## 不花錢驗證程式邏輯
+
+```powershell
+.\.venv\Scripts\python.exe test.py # 真正走分支、interrupt 與 resume
+.\.venv\Scripts\python.exe test_anthropic.py # Anthropic 設定 + 共用圖行為
 ```
 
 ## LangGraph 圖結構（精簡）
@@ -50,27 +83,26 @@ g.add_node("final", final_node)
 g.add_edge(START, "classify")
 g.add_conditional_edges("classify", should_search, {"search": "search", "respond": "respond"})
 g.add_edge("search", "respond")
-g.add_edge("respond", "final")
+g.add_edge("respond", "review")
+g.add_edge("review", "final")
 g.add_edge("final", END)
 
-graph = g.compile(checkpointer=InMemorySaver(), interrupt_before=["final"])
+graph = g.compile(checkpointer=InMemorySaver())
 ```
 
 ## HITL 怎麼運作
 
 ```python
-# 第一段：跑到 final 之前自動停（因為 interrupt_before=["final"]）
-state_before = graph.invoke({"query": ...}, config={"configurable": {"thread_id": "demo"}})
-# 此時可以印 state_before["draft"]、問人類「要 publish 嗎？」
+# 第一段：review_node 呼叫 interrupt()，圖就把資料存進 checkpoint 並停下來
+config = {"configurable": {"thread_id": "demo"}}
+state_before = graph.invoke({"query": ...}, config=config)
+# state_before["__interrupt__"] 會帶出草稿與問題
 
-# 人類決定：把 approved 寫進 state
-graph.update_state(config, {"approved": True})
-
-# 第二段：繼續從 final 跑（None 表示「不給新 input、用 checkpoint」）
-state_after = graph.invoke(None, config=config)
+# 第二段：人類回答後，用同一個 thread_id 恢復
+state_after = graph.invoke(Command(resume=True), config=config)
 ```
 
-**關鍵**：`interrupt_before=["final"]` 告訴 graph「跑到 final 之前停」。Production 把它接到 webhook / Slack / 前端 button、等使用者按 approve 才繼續。
+**關鍵**：`interrupt()` 是「先停一下」；`Command(resume=True/False)` 是「帶著人的回答繼續」。Production 可以把這個等待點接到 webhook、Slack 或前端按鈕。
 
 ## 為什麼這個 pattern 重要
 
@@ -80,35 +112,45 @@ state_after = graph.invoke(None, config=config)
 | Agent 改 production 設定 | 直接套用 | dry-run 後等核准 |
 | Agent 做退款 | 自動退 | 超過 $X 等審核 |
 
-**Production agent 凡是有 side effect 的、都該加 HITL**。LangGraph `interrupt_before` 就是為這個設計。
+有 **side effect（會改變外部世界的動作）** 時，先判斷風險；寄信、退款或改 production 設定通常需要 HITL、權限檢查與 audit log。低風險唯讀動作不一定要每次人工核准。
 
 ## 兩個 path 觀察重點
 
-本練習節點都是 deterministic 邏輯、不打 LLM、所以 Path A / Path B 跑出來一致。**重點是學圖結構本身**。要實接 LLM：
+兩個 path 共用同一張圖；`classify`、離線查詢與路由是可預測的 Python，`respond` 則真的呼叫不同模型寫草稿。**比較時只換模型，不要同時改 graph。**
+
+Node 裡只負責暫停，拿到人的答案後再更新 state：
 
 ```python
-# 在 respond_node 改：
-from langchain_openai import ChatOpenAI # Path A
-# from langchain_anthropic import ChatAnthropic # Path B
-llm = ChatOpenAI(base_url="http://localhost:11434/v1", api_key="ollama", model="qwen2.5:3b")
-draft = llm.invoke(state["query"]).content
-return {"draft": draft}
+from langgraph.types import interrupt
+
+def review_node(state):
+    approved = interrupt({"draft": state["draft"], "question": "Approve?"})
+    return {"approved": approved}
+```
+
+外面的 caller 收到真人答案後，才從同一個 `thread_id` 繼續：
+
+```python
+from langgraph.types import Command
+
+human_answer = True
+result = graph.invoke(Command(resume=human_answer), config=config)
 ```
 
 ## 常見坑
 
-- **`checkpointer` 沒設**：`graph.compile(interrupt_before=[...])` 沒帶 checkpointer 會 raise。必須有 checkpointer 才能 pause/resume
-- **`thread_id` 不一致**：第一段 invoke + update_state + 第二段 invoke 必須用同一個 `config={"configurable": {"thread_id": "..."}}`、否則 checkpoint 找不到
-- **`interrupt_before` vs `interrupt_after`**：before = 進這個 node 前停、after = 跑完這個 node 停。**HITL 通常用 before**（讓人類看完整 state 再決定）
+- **`checkpointer` 沒設**：沒有 checkpointer 就無法可靠地保存 pause/resume 狀態
+- **`thread_id` 不一致**：第一段 `invoke` 與 `Command(resume=...)` 必須用同一個設定，否則找不到原來的 checkpoint
+- **在 `interrupt()` 前做 side effect**：恢復時節點可能重新執行。把寄信或扣款放在核准後，並加入 idempotency key
 - **conditional_edges 函數要回 string**：`should_search` return value 必須是 `add_conditional_edges` 第三個參數 dict 的 key、不能 return literal value 直接當 node name
 
 ## 想看更聰明的答案？
 
-把 `respond_node` 接 LLM、用真的 model 寫 draft（不再用 template）。Production setup 還會把 checkpointer 換成 SQLite / Redis（`SqliteSaver` / `RedisSaver`）做持久化。
+比較另一個模型，或把記憶體 checkpointer 換成適合部署環境的持久化儲存。先確認官方 persistence 文件與失敗恢復行為，再選資料庫。
 
 ## 延伸
 
 - **加 retry**：在 `search_node` 失敗時 retry、用 LangGraph 的 `error` edge
-- **加多個 HITL**：`interrupt_before=["draft", "publish"]` 兩個地方都暫停
+- **加多個 HITL**：在不同 review node 呼叫 `interrupt()`，並替每個核准動作定義清楚資料
 - **time-travel debug**：`graph.get_state_history(config)` 拿到所有 checkpoint、可以回到任一步 fork 新 thread
 - **加 streaming**：`for state in graph.stream(...)` 邊跑邊看 state

--- a/examples/stage-4/03-graph-workflow/README.zh-Hans.md
+++ b/examples/stage-4/03-graph-workflow/README.zh-Hans.md
@@ -19,23 +19,56 @@
 
 - **`classify_node`**：看 query 决定 `needs_search`
 - **条件分支**：`needs_search=True` 走 `search` node、否则直接 `respond`
-- **HITL checkpoint**：`respond_node` 后 interrupt、等人类在 state 改 `approved`
+- **HITL checkpoint**：`review_node` 用 `interrupt()` 暂停，等待人类回答
 - **`final_node`**：`approved=True` → PUBLISHED、否则 REJECTED
 
-这题 **LangGraph 最拿手**：graph state + checkpointing + interrupt_before 是 LangGraph 招牌组合。CrewAI 对 HITL 支援较弱。
+这题用 LangGraph 示范 **graph state（图状态）**、**checkpoint（检查点）**、`interrupt()` 与 `Command(resume=...)`。你可以看见流程停在哪里，以及它如何从同一个 `thread_id` 继续。
 
-## 怎么跑
+## 怎么跑 — 两条路径
 
-```bash
-pip install -r requirements.txt
-python starter.py
+> ⚠️ **每个练习都要有自己的 Python 3.11 `.venv`。** 不要把 Stage 4 五个 `requirements.txt` 混装。
+
+### Path A（Ollama、本机）
+
+```powershell
+py -3.11 -m venv .venv
+.\.venv\Scripts\python.exe -m pip install -r requirements.txt
+ollama pull qwen2.5:3b
+ollama serve
+.\.venv\Scripts\python.exe starter.py
 ```
 
-预算：**$0**。这份 demo 的节点都是 deterministic 逻辑、不打 LLM；要实接 Claude / Ollama 在 `respond_node` 改成 `llm.invoke(...)` 即可。
+预算：模型 API 是 **$0**；本机硬体、电力与下载仍有成本。这份 starter 会真的请 Ollama 写草稿，其他节点则使用可预测的 Python 逻辑。
+
+### Path B（Anthropic、比较云端结果）
+
+```powershell
+$env:ANTHROPIC_API_KEY="sk-ant-..."
+.\.venv\Scripts\python.exe starter_anthropic.py
+```
+
+预设固定型号：`claude-haiku-4-5-20251001`。若一次请求用 2,000 input + 1,000 output tokens：`2,000 / 1,000,000 × $1 + 1,000 / 1,000,000 × $5 = $0.007`。本练习通常只需要短草稿，但仍可能重试；先设供应商支出上限 **$0.05**。
+
+<details markdown="1">
+<summary>macOS／Linux 指令与查核资讯</summary>
 
 ```bash
-python test.py             # 6 个 test，验 routing + HITL 逻辑
-python test_anthropic.py   # Path B concept demo
+python3.11 -m venv .venv
+./.venv/bin/python -m pip install -r requirements.txt
+export ANTHROPIC_API_KEY="sk-ant-..."
+./.venv/bin/python test.py
+```
+
+官方来源：[LangGraph interrupts](https://docs.langchain.com/oss/python/langgraph/interrupts)｜[LangGraph persistence](https://docs.langchain.com/oss/python/langgraph/persistence)｜[Anthropic pricing](https://platform.claude.com/docs/en/about-claude/pricing)
+
+<small>套件、model ID、价格与官方连结查核：2026-08-28 UTC。</small>
+</details>
+
+## 不花钱验证程序逻辑
+
+```powershell
+.\.venv\Scripts\python.exe test.py # 真正走分支、interrupt 与 resume
+.\.venv\Scripts\python.exe test_anthropic.py # Anthropic 设定 + 共用图行为
 ```
 
 ## LangGraph 图结构（精简）
@@ -50,27 +83,26 @@ g.add_node("final", final_node)
 g.add_edge(START, "classify")
 g.add_conditional_edges("classify", should_search, {"search": "search", "respond": "respond"})
 g.add_edge("search", "respond")
-g.add_edge("respond", "final")
+g.add_edge("respond", "review")
+g.add_edge("review", "final")
 g.add_edge("final", END)
 
-graph = g.compile(checkpointer=InMemorySaver(), interrupt_before=["final"])
+graph = g.compile(checkpointer=InMemorySaver())
 ```
 
 ## HITL 怎么运作
 
 ```python
-# 第一段：跑到 final 之前自动停（因为 interrupt_before=["final"]）
-state_before = graph.invoke({"query": ...}, config={"configurable": {"thread_id": "demo"}})
-# 此时可以印 state_before["draft"]、问人类「要 publish 吗？」
+# 第一段：review_node 呼叫 interrupt()，图就把资料存进 checkpoint 并停下来
+config = {"configurable": {"thread_id": "demo"}}
+state_before = graph.invoke({"query": ...}, config=config)
+# state_before["__interrupt__"] 会带出草稿与问题
 
-# 人类决定：把 approved 写进 state
-graph.update_state(config, {"approved": True})
-
-# 第二段：继续从 final 跑（None 表示「不给新 input、用 checkpoint」）
-state_after = graph.invoke(None, config=config)
+# 第二段：人类回答后，用同一个 thread_id 恢复
+state_after = graph.invoke(Command(resume=True), config=config)
 ```
 
-**关键**：`interrupt_before=["final"]` 告诉 graph“跑到 final 之前停”。Production 把它接到 webhook / Slack / 前端 button、等用户按 approve 才继续。
+**关键**：`interrupt()` 是“先停一下”；`Command(resume=True/False)` 是“带著人的回答继续”。Production 可以把这个等待点接到 webhook、Slack 或前端按钮。
 
 ## 为什么这个 pattern 重要
 
@@ -80,35 +112,45 @@ state_after = graph.invoke(None, config=config)
 | Agent 改 production 设定 | 直接套用 | dry-run 后等核准 |
 | Agent 做退款 | 自动退 | 超过 $X 等审核 |
 
-**Production agent 凡是有 side effect 的、都该加 HITL**。LangGraph `interrupt_before` 就是为这个设计。
+有 **side effect（会改变外部世界的动作）** 时，先判断风险；寄信、退款或改 production 设定通常需要 HITL、权限检查与 audit log。低风险唯读动作不一定要每次人工核准。
 
 ## 两个 path 观察重点
 
-本练习节点都是 deterministic 逻辑、不打 LLM、所以 Path A / Path B 跑出来一致。**重点是学图结构本身**。要实接 LLM：
+两个 path 共用同一张图；`classify`、离线查询与路由是可预测的 Python，`respond` 则真的调用不同模型写草稿。**比较时只换模型，不要同时改 graph。**
+
+Node 里只负责暂停，拿到人的答案后再更新 state：
 
 ```python
-# 在 respond_node 改：
-from langchain_openai import ChatOpenAI  # Path A
-# from langchain_anthropic import ChatAnthropic  # Path B
-llm = ChatOpenAI(base_url="http://localhost:11434/v1", api_key="ollama", model="qwen2.5:3b")
-draft = llm.invoke(state["query"]).content
-return {"draft": draft}
+from langgraph.types import interrupt
+
+def review_node(state):
+    approved = interrupt({"draft": state["draft"], "question": "Approve?"})
+    return {"approved": approved}
+```
+
+外面的 caller 收到真人答案后，才从同一个 `thread_id` 继续：
+
+```python
+from langgraph.types import Command
+
+human_answer = True
+result = graph.invoke(Command(resume=human_answer), config=config)
 ```
 
 ## 常见坑
 
-- **`checkpointer` 没设**：`graph.compile(interrupt_before=[...])` 没带 checkpointer 会 raise。必须有 checkpointer 才能 pause/resume
-- **`thread_id` 不一致**：第一段 invoke + update_state + 第二段 invoke 必须用同一个 `config={"configurable": {"thread_id": "..."}}`、否则 checkpoint 找不到
-- **`interrupt_before` vs `interrupt_after`**：before = 进这个 node 前停、after = 跑完这个 node 停。**HITL 通常用 before**（让人类看完整 state 再决定）
+- **`checkpointer` 没设**：没有 checkpointer 就无法可靠地保存 pause/resume 状态
+- **`thread_id` 不一致**：第一段 `invoke` 与 `Command(resume=...)` 必须用同一个设定，否则找不到原来的 checkpoint
+- **在 `interrupt()` 前做 side effect**：恢复时节点可能重新执行。把寄信或扣款放在核准后，并加入 idempotency key
 - **conditional_edges 函数要回 string**：`should_search` return value 必须是 `add_conditional_edges` 第三个参数 dict 的 key、不能 return literal value 直接当 node name
 
 ## 想看更聪明的答案？
 
-把 `respond_node` 接 LLM、用真的 model 写 draft（不再用 template）。Production setup 还会把 checkpointer 换成 SQLite / Redis（`SqliteSaver` / `RedisSaver`）做持久化。
+比较另一个模型，或把记忆体 checkpointer 换成适合部署环境的持久化储存。先确认官方 persistence 文件与失败恢复行为，再选资料库。
 
 ## 延伸
 
 - **加 retry**：在 `search_node` 失败时 retry、用 LangGraph 的 `error` edge
-- **加多个 HITL**：`interrupt_before=["draft", "publish"]` 两个地方都暂停
+- **加多个 HITL**：在不同 review node 调用 `interrupt()`，并替每个核准动作定义清楚资料
 - **time-travel debug**：`graph.get_state_history(config)` 拿到所有 checkpoint、可以回到任一步 fork 新 thread
 - **加 streaming**：`for state in graph.stream(...)` 边跑边看 state

--- a/examples/stage-4/03-graph-workflow/requirements.txt
+++ b/examples/stage-4/03-graph-workflow/requirements.txt
@@ -1,5 +1,4 @@
-langgraph>=0.2,<1.0
-typing-extensions>=4.10
-# starter_anthropic 概念展示用、不必裝；要實接 LLM 才裝下面
-# langchain-anthropic>=0.2,<1.0
-# langchain-openai>=0.2,<1.0
+langgraph>=1.2,<2.0
+langchain-core>=1.6,<2.0
+langchain-openai>=1.6,<2.0
+langchain-anthropic>=1.7,<2.0

--- a/examples/stage-4/03-graph-workflow/starter.py
+++ b/examples/stage-4/03-graph-workflow/starter.py
@@ -1,21 +1,8 @@
-"""Stage 4 練習 3：圖式 workflow — LangGraph + Ollama（Path A、默認）。
+"""Stage 4 練習 3：用 LangGraph 做條件分支與真正可暫停的 HITL。
 
-LangGraph 最拿手：條件分支 + human-in-the-loop + checkpointing。
-
-任務：「研究 → 寫稿 → 人類審核 → 發佈」
-- classify_node 看 query 決定 search_needed
-- 條件分支：need_search=True → search_node、否則直接 respond_node
-- HITL：respond_node 前 interrupt、等人類 approve
-- final_node 標記完成
-
-跑法：
-    pip install -r requirements.txt
-    ollama pull qwen2.5:3b
-    ollama serve
-    python starter.py
-
-驗證：
-    python test.py
+流程像一條有岔路的軌道：先判斷要不要查資料，再請模型寫草稿，
+接著用 ``interrupt()`` 停下來等人決定。只有收到 ``Command(resume=...)``
+之後，圖才會繼續走到發布或拒絕。Path A 使用 Ollama；Path B 共用同一張圖。
 """
 
 from __future__ import annotations
@@ -27,14 +14,16 @@ from typing import Any, Literal
 if hasattr(sys.stdout, "reconfigure"):
     sys.stdout.reconfigure(encoding="utf-8", errors="replace")
 
+from langchain_openai import ChatOpenAI
 from langgraph.checkpoint.memory import InMemorySaver
 from langgraph.graph import END, START, StateGraph
+from langgraph.types import Command, interrupt
 from typing_extensions import TypedDict
 
 MODEL = os.environ.get("MODEL", "qwen2.5:3b")
 
 
-class State(TypedDict):
+class State(TypedDict, total=False):
     query: str
     needs_search: bool
     search_result: str
@@ -43,95 +32,81 @@ class State(TypedDict):
     final: str
 
 
-# === Nodes ===
-
-def classify_node(state: State) -> dict:
-    """看 query 決定要不要 search。簡化邏輯：含關鍵字「人口 / 天氣 / 最新」就 search。"""
-    q = state["query"].lower()
-    needs = any(k in q for k in ["人口", "weather", "天氣", "latest", "最新", "current"])
-    return {"needs_search": needs}
+def classify_node(state: State) -> dict[str, bool]:
+    """用幾個示範關鍵字決定要不要先走離線查詢節點。"""
+    query = state["query"].lower()
+    return {"needs_search": any(word in query for word in ("population", "weather", "latest", "人口", "天氣", "最新"))}
 
 
-def search_node(state: State) -> dict:
-    db = {
-        "taipei": "Taipei population ~2.6M (2024)",
-        "台北": "Taipei population ~2.6M (2024)",
-        "weather": "sunny 25°C",
-        "天氣": "sunny 25°C",
-    }
-    q = state["query"].lower()
-    for k, v in db.items():
-        if k in q:
-            return {"search_result": v}
-    return {"search_result": "no data"}
-
-
-def respond_node(state: State) -> dict:
-    """寫 draft。實際用 LLM，這裡簡化用 template 演示流程。"""
-    if state.get("search_result"):
-        return {"draft": f"Based on search: {state['search_result']}"}
-    return {"draft": f"Direct answer to: {state['query']}"}
-
-
-def final_node(state: State) -> dict:
-    if state.get("approved"):
-        return {"final": f"PUBLISHED: {state['draft']}"}
-    return {"final": f"REJECTED (human said no): {state['draft']}"}
+def search_node(state: State) -> dict[str, str]:
+    """從很小的離線資料表取值；這裡不代表真正的搜尋引擎。"""
+    for key, value in {"taipei": "Taipei population: about 2.6 million.", "台北": "Taipei population: about 2.6 million.", "weather": "Demo weather: sunny, 25 C."}.items():
+        if key in state["query"].lower():
+            return {"search_result": value}
+    return {"search_result": "No matching entry in the offline knowledge base."}
 
 
 def should_search(state: State) -> Literal["search", "respond"]:
     return "search" if state["needs_search"] else "respond"
 
 
-# === Graph build ===
-
-def build_graph(checkpointer: Any = None) -> Any:
-    g = StateGraph(State)
-    g.add_node("classify", classify_node)
-    g.add_node("search", search_node)
-    g.add_node("respond", respond_node)
-    g.add_node("final", final_node)
-
-    g.add_edge(START, "classify")
-    g.add_conditional_edges("classify", should_search, {"search": "search", "respond": "respond"})
-    g.add_edge("search", "respond")
-    g.add_edge("respond", "final")
-    g.add_edge("final", END)
-
-    # HITL：在 final 之前 interrupt、讓人類在 state 改 approved
-    return g.compile(checkpointer=checkpointer, interrupt_before=["final"])
+def make_ollama_llm() -> ChatOpenAI:
+    """用 OpenAI-compatible 介面連到本機 Ollama。"""
+    return ChatOpenAI(model=MODEL, base_url="http://localhost:11434/v1", api_key="ollama", temperature=0)
 
 
-def run(query: str, approve: bool = True) -> dict:
-    """跑一輪含 HITL 的 workflow。`approve` 模擬人類審核決定。"""
-    checkpointer = InMemorySaver()
-    graph = build_graph(checkpointer=checkpointer)
-    config = {"configurable": {"thread_id": "demo"}}
+def build_graph(llm: Any, checkpointer: Any | None = None) -> Any:
+    """建立共用圖；呼叫端可放入 Ollama 或 Anthropic chat model。"""
+    def respond_node(state: State) -> dict[str, str]:
+        context = state.get("search_result", "No lookup was needed.")
+        message = llm.invoke(f"Write one cautious sentence for: {state['query']}\nOffline context: {context}")
+        draft = str(getattr(message, "content", message)).strip()
+        if not draft:
+            raise RuntimeError("The model returned an empty draft.")
+        return {"draft": draft}
 
-    # 第一段：跑到 final 之前停（interrupt_before=["final"]）
-    state_before = graph.invoke({"query": query, "approved": False}, config=config)
-    print(f"   draft（等待 approval）: {state_before.get('draft', '<none>')}")
+    def review_node(state: State) -> dict[str, bool]:
+        decision = interrupt({"action": "publish", "draft": state["draft"], "question": "Approve this draft?"})
+        if not isinstance(decision, bool):
+            raise ValueError("Human review must resume with true or false.")
+        return {"approved": decision}
 
-    # HITL：人類審核——更新 state.approved
-    graph.update_state(config, {"approved": approve})
+    def final_node(state: State) -> dict[str, str]:
+        prefix = "PUBLISHED" if state["approved"] else "REJECTED"
+        return {"final": f"{prefix}: {state['draft']}"}
 
-    # 第二段：繼續跑完
-    state_after = graph.invoke(None, config=config)
-    return state_after
+    graph = StateGraph(State)
+    graph.add_node("classify", classify_node)
+    graph.add_node("search", search_node)
+    graph.add_node("respond", respond_node)
+    graph.add_node("review", review_node)
+    graph.add_node("final", final_node)
+    graph.add_edge(START, "classify")
+    graph.add_conditional_edges("classify", should_search, {"search": "search", "respond": "respond"})
+    graph.add_edge("search", "respond")
+    graph.add_edge("respond", "review")
+    graph.add_edge("review", "final")
+    graph.add_edge("final", END)
+    return graph.compile(checkpointer=checkpointer or InMemorySaver())
+
+
+def run(query: str, approve: bool, llm: Any | None = None, thread_id: str = "stage4-demo") -> dict[str, Any]:
+    """先跑到人工審核點，再用同一個 ``thread_id`` 恢復執行。"""
+    graph = build_graph(llm or make_ollama_llm())
+    config = {"configurable": {"thread_id": thread_id}}
+    paused = graph.invoke({"query": query}, config=config)
+    if "__interrupt__" not in paused:
+        raise RuntimeError("Expected a human-review interrupt before publication.")
+    resumed = graph.invoke(Command(resume=approve), config=config)
+    if not resumed.get("final"):
+        raise RuntimeError("The workflow did not produce a final result after resume.")
+    return resumed
 
 
 if __name__ == "__main__":
-    print(f"❓ Workflow: classify → [search?] → respond → [HITL] → final（using {MODEL}）")
-    print("-" * 60)
-
-    print("\n[Case 1] query 含「台北人口」、需要 search、人類 approve=True")
-    r1 = run("台北人口是多少？", approve=True)
-    print(f"   final: {r1['final']}")
-    assert "PUBLISHED" in r1["final"]
-
-    print("\n[Case 2] query 不需 search、人類 approve=False")
-    r2 = run("解釋一下 Python 是什麼", approve=False)
-    print(f"   final: {r2['final']}")
-    assert "REJECTED" in r2["final"]
-
-    print("\n✅ 練習 3 通過 — LangGraph 圖式 workflow + HITL checkpoint、$0/run")
+    approved = run("What is the Taipei population?", approve=True)
+    rejected = run("Explain Python", approve=False, thread_id="stage4-reject")
+    print(approved["final"])
+    print(rejected["final"])
+    assert approved["final"].startswith("PUBLISHED:")
+    assert rejected["final"].startswith("REJECTED:")

--- a/examples/stage-4/03-graph-workflow/starter_anthropic.py
+++ b/examples/stage-4/03-graph-workflow/starter_anthropic.py
@@ -1,34 +1,29 @@
-"""Stage 4 練習 3：圖式 workflow — LangGraph（Path B、概念展示）。
+"""Stage 4 練習 3 Path B：把同一張 LangGraph 圖接到 ChatAnthropic。
 
-這個 starter 的 workflow 不打 LLM API（節點都是 deterministic 邏輯 / template）、
-所以 Path A 跟 Path B **跑出來一樣**。重點是「**圖結構 + checkpointing + HITL**
-邏輯本身**完全跨 backend**」。
-
-實際 production 把 `respond_node` 換成真的 LLM call 即可——`ChatAnthropic(model="claude-haiku-4-5")`
-或 `ChatOpenAI(base_url="...")` 都能塞進來。
-
-跑法：
-    pip install -r requirements.txt
-    python starter_anthropic.py
+流程、暫停點與人工核准規則都不變；只有負責寫草稿的模型不同。
 """
 
 from __future__ import annotations
 
+import os
 import sys
 
 if hasattr(sys.stdout, "reconfigure"):
     sys.stdout.reconfigure(encoding="utf-8", errors="replace")
 
+from langchain_anthropic import ChatAnthropic
 from starter import run
 
+MODEL = os.environ.get("MODEL", "claude-haiku-4-5-20251001")
+
+
+def make_anthropic_llm() -> ChatAnthropic:
+    """建立使用固定 model ID 的 Anthropic chat model。"""
+    return ChatAnthropic(model=MODEL, temperature=0)
+
+
 if __name__ == "__main__":
-    print("ℹ️ 這份 workflow 不打 LLM、純展示 LangGraph 圖結構 + HITL。")
-    print("   要在節點裡接 Anthropic Claude，把 respond_node 改成：")
-    print('     from langchain_anthropic import ChatAnthropic')
-    print('     llm = ChatAnthropic(model="claude-haiku-4-5")')
-    print('     draft = llm.invoke(state["query"]).content')
-    print("-" * 60)
-    r = run("台北人口", approve=True)
-    print(f"final: {r['final']}")
-    assert r["final"]
-    print("✅ 練習 3 (Anthropic concept) 通過 — 圖結構跨 backend 一致")
+    result = run("What is the Taipei population?", approve=True, llm=make_anthropic_llm())
+    print(result["final"])
+    assert result["final"].startswith("PUBLISHED:")
+    assert "Taipei" in result["final"]

--- a/examples/stage-4/03-graph-workflow/test.py
+++ b/examples/stage-4/03-graph-workflow/test.py
@@ -1,74 +1,43 @@
-"""Stage 4 練習 3 自我驗證 — LangGraph workflow（無 LLM、純圖邏輯）。
-
-跑法：
-    python test.py
-
-驗證內容：
-    - classify_node 正確判斷 needs_search
-    - 條件分支正確 routing（search vs respond 兩條路）
-    - HITL：interrupt_before=['final'] + update_state(approved=...) 起作用
-    - approve=True → PUBLISHED、approve=False → REJECTED
-"""
+"""Path A 離線行為測試：真的走分支、暫停與恢復，但不連網。"""
 
 from __future__ import annotations
 
 import sys
+from types import SimpleNamespace
 
 if hasattr(sys.stdout, "reconfigure"):
     sys.stdout.reconfigure(encoding="utf-8", errors="replace")
 
-from starter import classify_node, run, search_node, should_search
+from starter import build_graph, classify_node, run, should_search
 
 
-def test_classify_needs_search():
-    assert classify_node({"query": "台北人口"})["needs_search"] is True
-    assert classify_node({"query": "解釋一下 Python"})["needs_search"] is False
-    assert classify_node({"query": "current weather"})["needs_search"] is True
-    print("✅ test_classify_needs_search")
+class FakeLLM:
+    """只回固定格式的假模型，讓圖的行為可以重複驗證。"""
+    def invoke(self, prompt: str) -> SimpleNamespace:
+        return SimpleNamespace(content=f"Draft grounded in: {prompt.splitlines()[-1]}")
 
 
-def test_search_node():
-    out = search_node({"query": "taipei population"})
-    assert "2.6M" in out["search_result"]
-    out2 = search_node({"query": "unknown topic"})
-    assert "no data" in out2["search_result"]
-    print("✅ test_search_node")
-
-
-def test_should_search_routing():
-    assert should_search({"needs_search": True}) == "search"
+def test_branch_choice_and_interrupt_resume() -> None:
+    assert classify_node({"query": "latest Taipei population"})["needs_search"] is True
     assert should_search({"needs_search": False}) == "respond"
-    print("✅ test_should_search_routing")
+    graph = build_graph(FakeLLM())
+    config = {"configurable": {"thread_id": "offline-approve"}}
+    paused = graph.invoke({"query": "latest Taipei population"}, config=config)
+    assert "__interrupt__" in paused
+    checkpoint = graph.get_state(config)
+    assert "Taipei population" in checkpoint.values["draft"]
+    from langgraph.types import Command
+    result = graph.invoke(Command(resume=True), config=config)
+    assert result["final"].startswith("PUBLISHED:")
 
 
-def test_hitl_approve_true_publishes():
-    """搜尋路徑 + 人類 approve=True → PUBLISHED。"""
-    result = run("台北人口", approve=True)
-    assert "PUBLISHED" in result["final"]
-    assert "2.6M" in result["draft"]  # draft 引用了 search result
-    print("✅ test_hitl_approve_true_publishes")
-
-
-def test_hitl_approve_false_rejects():
-    """非搜尋路徑 + 人類 approve=False → REJECTED。"""
-    result = run("解釋 Python", approve=False)
-    assert "REJECTED" in result["final"]
-    assert "Direct answer" in result["draft"]
-    print("✅ test_hitl_approve_false_rejects")
-
-
-def test_branching_skips_search():
-    """非搜尋路徑時、search_result 應該不存在或空。"""
-    result = run("解釋 Python", approve=True)
-    assert not result.get("search_result"), f"預期無 search_result、得到 {result.get('search_result')}"
-    print("✅ test_branching_skips_search")
+def test_rejection_uses_a_separate_checkpoint_thread() -> None:
+    result = run("Explain Python", approve=False, llm=FakeLLM(), thread_id="offline-reject")
+    assert result["final"].startswith("REJECTED:")
+    assert "No lookup was needed" in result["draft"]
 
 
 if __name__ == "__main__":
-    test_classify_needs_search()
-    test_search_node()
-    test_should_search_routing()
-    test_hitl_approve_true_publishes()
-    test_hitl_approve_false_rejects()
-    test_branching_skips_search()
-    print("\n🎉 全部通過 — LangGraph 圖結構 + 條件分支 + HITL 邏輯正確")
+    test_branch_choice_and_interrupt_resume()
+    test_rejection_uses_a_separate_checkpoint_thread()
+    print("all pass")

--- a/examples/stage-4/03-graph-workflow/test_anthropic.py
+++ b/examples/stage-4/03-graph-workflow/test_anthropic.py
@@ -1,34 +1,38 @@
-"""Stage 4 練習 3 — Path B 概念展示：圖結構跨 backend 一致。
-
-跑法：python test_anthropic.py
-
-這份只是 starter.py / test.py 的 Path B variant 確認——workflow 不依賴 LLM SDK、
-所以兩條 path 跑出來一致。實際 production 在節點接 Claude 時、只改 respond_node。
-"""
+"""Path B 離線行為測試：檢查 Anthropic 設定，並用假模型跑共用圖。"""
 
 from __future__ import annotations
 
 import sys
+import os
+from types import SimpleNamespace
 
 if hasattr(sys.stdout, "reconfigure"):
     sys.stdout.reconfigure(encoding="utf-8", errors="replace")
 
-from starter_anthropic import run
+from starter import run
+from starter_anthropic import MODEL, make_anthropic_llm
 
 
-def test_concept_workflow_runs():
-    result = run("台北人口", approve=True)
-    assert "PUBLISHED" in result["final"]
-    print("✅ test_concept_workflow_runs")
+class FakeAnthropicLLM:
+    """不發出 API 請求，只提供可預測的 Anthropic-path 草稿。"""
+    def invoke(self, prompt: str) -> SimpleNamespace:
+        return SimpleNamespace(content="Anthropic-path offline draft")
 
 
-def test_starter_anthropic_module_ok():
-    import starter_anthropic
-    assert hasattr(starter_anthropic, "run")
-    print("✅ test_starter_anthropic_module_ok")
+def test_anthropic_provider_construction() -> None:
+    os.environ.setdefault("ANTHROPIC_API_KEY", "offline-test-key")
+    llm = make_anthropic_llm()
+    assert llm.model == MODEL
+    assert MODEL == "claude-haiku-4-5-20251001"
+
+
+def test_anthropic_path_graph_behavior() -> None:
+    result = run("Explain Python", approve=True, llm=FakeAnthropicLLM(), thread_id="anthropic-offline")
+    assert result["final"] == "PUBLISHED: Anthropic-path offline draft"
+    assert result["approved"] is True
 
 
 if __name__ == "__main__":
-    test_concept_workflow_runs()
-    test_starter_anthropic_module_ok()
-    print("\n🎉 通過 — Path B concept demo 跑通")
+    test_anthropic_provider_construction()
+    test_anthropic_path_graph_behavior()
+    print("all pass")

--- a/examples/stage-4/04-codeact-vs-json-tool/README.en.md
+++ b/examples/stage-4/04-codeact-vs-json-tool/README.en.md
@@ -1,5 +1,5 @@
 <div align="right">
-  <a href="./README.md">繁體中文</a> | <a href="./README.zh-Hans.md">简体中文</a> | <strong>English</strong>
+  <a href="./README.md">Traditional Chinese</a> | <a href="./README.zh-Hans.md">Simplified Chinese</a> | <strong>English</strong>
 </div>
 
 # Exercise 4: CodeAct vs JSON tool (Smolagents)
@@ -24,33 +24,58 @@ Pairs with [Stage 4 — Agent Frameworks](../../../stages/04-agent-frameworks.en
 
 ## How to run — two paths
 
+> ⚠️ **Give each exercise its own Python 3.11 `.venv`.** This one also requires Docker. Never run model-generated code directly on the host. This teaching container may still access the network, so do not put secrets or private data inside it.
+
 ### Path A (default, free, local)
 
-```bash
-pip install -r requirements.txt
+```powershell
+py -3.11 -m venv .venv
+.\.venv\Scripts\python.exe -m pip install -r requirements.txt
 ollama pull qwen2.5:3b
 ollama serve
-python starter.py
+docker version
+.\.venv\Scripts\python.exe test_docker_smoke.py
+.\.venv\Scripts\python.exe starter.py
 ```
 
-Budget: **$0**. CodeAct is hard on small models — qwen2.5:3b sometimes produces syntax errors and iterates to fix.
+Budget: the model API costs **$0**. Local hardware, electricity, and Docker resources still have a cost. A smaller model may need correction steps, so the starter limits `max_steps` to 4.
 
-### Path B (Anthropic, cloud-quality)
+### Path B (Anthropic, compare a cloud result)
+
+```powershell
+$env:ANTHROPIC_API_KEY="sk-ant-..."
+.\.venv\Scripts\python.exe starter_anthropic.py
+```
+
+Pinned default: `anthropic/claude-haiku-4-5-20251001`. A request with 2,000 input + 1,000 output tokens costs **$0.007**. CodeAct can make several requests, so set a provider spend limit of **$0.10**. Actual cost depends on tokens and steps.
+
+<details markdown="1">
+<summary>macOS/Linux commands and verification information</summary>
 
 ```bash
-pip install -r requirements.txt
-export ANTHROPIC_API_KEY=sk-ant-...
-python starter_anthropic.py
+python3.11 -m venv .venv
+./.venv/bin/python -m pip install -r requirements.txt
+export ANTHROPIC_API_KEY="sk-ant-..."
+docker version
+./.venv/bin/python test.py
+./.venv/bin/python test_docker_smoke.py
 ```
 
-Budget: ~**$0.005-0.02** per run (CodeAct typically multi-step, claude-haiku-4-5). Claude writes correct Python far more reliably than qwen2.5:3b.
+Price formula: `input_tokens / 1,000,000 × $1 + output_tokens / 1,000,000 × $5`.
+
+Official sources: [Secure code execution](https://huggingface.co/docs/smolagents/tutorials/secure_code_execution) | [Python executors](https://huggingface.co/docs/smolagents/reference/python_executors) | [Docker port publishing](https://docs.docker.com/engine/network/port-publishing/) | [Anthropic pricing](https://platform.claude.com/docs/en/about-claude/pricing)
+
+<small>Packages, model IDs, prices, and official links verified: 2026-08-28 UTC.</small>
+</details>
 
 ## Validate the logic
 
-```bash
-python test.py             # tool function + agent structure
-python test_anthropic.py   # Path B import check
+```powershell
+.\.venv\Scripts\python.exe test.py # AST, JSON allowlist, loopback control port, and resource limits
+.\.venv\Scripts\python.exe test_anthropic.py # Anthropic setup + the same safe boundary
 ```
+
+These two offline tests **do not** execute model-generated code and do not need a Docker daemon. `test_docker_smoke.py` is a separate manual smoke test: it starts the Jupyter executor, proves the host control channel works, and confirms the control port is bound only to `127.0.0.1`. Run it only after `docker version` succeeds. It does not pretend the container has no network access.
 
 ## How CodeAct works
 
@@ -70,7 +95,7 @@ print(ratio)
 (Smolagents runs the code in a sandbox and feeds the print output back to the LLM)
 ````
 
-The framework provides a sandboxed Python interpreter; the agent imports tools, writes code, sees stdout, continues.
+This example explicitly uses a Docker executor. The Jupyter control port is bound only to host `127.0.0.1`; Linux capabilities are dropped, privilege escalation and pickle are blocked, and memory, process count, and agent steps are limited. A normal Docker bridge **may still let the container reach external networks or host services**. This is therefore a controlled teaching example, not a production sandbox. Untrusted code also needs real egress and host-access firewalling, or a remote sandbox with documented isolation boundaries.
 
 ## CodeAct vs JSON tool
 
@@ -82,7 +107,7 @@ The framework provides a sandboxed Python interpreter; the agent imports tools, 
 | Tokens per round | Fewer | More (code is longer) |
 | Small-model friendliness | Better (stable JSON) | Worse (must produce valid Python) |
 | Debug | Inspect tool calls | Inspect code execution log |
-| Safety | Tool args validated | Sandboxed Python (watch eval/exec limits) |
+| Safety | Allowlist + argument validation | Untrusted code: isolate it and limit permissions/resources |
 | Best for | Single-step, clear boundaries | Multi-step computation, intermediate variables |
 
 **HuggingFace's stance**: CodeAct is closer to how humans solve problems — use a variable for intermediate results, don't re-fetch each step.
@@ -91,31 +116,31 @@ The framework provides a sandboxed Python interpreter; the agent imports tools, 
 
 | Observation | Anthropic Claude haiku | Ollama qwen2.5:3b |
 |---|---|---|
-| Valid Python syntax | Stable | Occasional syntax errors, iterates to fix |
-| Variable naming / reuse | Natural | Tends to re-call tools instead of using vars |
-| Correct multi-step ratio | High | Medium |
-| Total steps | 1-2 | 3-5 (iterating fixes) |
-| Cost | $0.005-0.02 | $0 |
+| Executable Python | Measure with the same cases | Measure with the same cases |
+| Variable naming / reuse | Inspect the execution log | Inspect the execution log |
+| Correct ratio | Validate the final value | Validate the final value |
+| Total steps | Limited by `max_steps=4` | Limited by `max_steps=4` |
+| Model API cost | Depends on tokens and steps | $0 |
 
-**Punchline**: CodeAct is **model-quality-sensitive** — the LLM has to write Python that's solid enough for production. **Small models favor JSON-tool over CodeAct** (Exercise 6 of Stage 3 confirms a similar pattern at the schema layer).
+**Punchline**: CodeAct adds an "execute code" risk surface that JSON tools do not have. Do not assume a model or path wins; compare success rate, steps, cost, and safety boundaries on the same tasks.
 
 ## Common pitfalls
 
 - **`@tool` function docstring is part of the prompt**: Smolagents passes the docstring to the LLM as the tool description. **Bad docstring = LLM doesn't know when to use it.**
-- **CodeAct sandbox**: by default Smolagents bans `import os`, `open`, etc. To allow specific modules, set `additional_authorized_imports=[...]`
-- **`max_steps` too low**: CodeAct iterates; `max_steps=4` may not be enough. But too high = infinite loops. 4-8 is the empirical range
-- **Small models produce syntax errors**: Smolagents feeds the error back to the LLM, but you waste tokens. Production wants a larger model
+- **Treating Docker as a complete sandbox**: it is not. This starter reduces privileges and binds the control port to loopback; deployment still needs image, permission, egress, host-access, resource, and logging review
+- **`max_steps` too low**: inspect which step failed before raising the limit; a higher number increases cost and loop risk
+- **Model code has a syntax error**: Smolagents can return the error for correction, but that adds steps. Change models only after checking evaluation results
 
 ## Want smarter answers?
 
-```bash
-MODEL=anthropic/claude-sonnet-5 python starter_anthropic.py  # most stable
-MODEL=qwen2.5:7b python starter.py                              # larger local model
+```powershell
+$env:MODEL="anthropic/claude-sonnet-5"; .\.venv\Scripts\python.exe starter_anthropic.py
+$env:MODEL="qwen2.5:7b"; .\.venv\Scripts\python.exe starter.py
 ```
 
 ## Extensions
 
 - **More tools**: just `@tool`-decorate; Smolagents auto-extracts docstring as description
 - **Try `ToolCallingAgent`**: Smolagents also offers JSON-tool-style agents. Compare side-by-side
-- **Hugging Face Hub**: `HfApiModel` for HF inference (no need for local Ollama)
-- **Read [Anthropic — Building Effective Agents](https://www.anthropic.com/engineering/building-effective-agents)**: Anthropic argues both paradigms are valid; pick by task
+- **Hugging Face Hub**: use the current `InferenceClientModel` for HF inference (no local Ollama required)
+- **Read [Anthropic — Building Effective Agents](https://www.anthropic.com/engineering/building-effective-agents)**: both shapes can be useful; choose based on the task

--- a/examples/stage-4/04-codeact-vs-json-tool/README.md
+++ b/examples/stage-4/04-codeact-vs-json-tool/README.md
@@ -24,33 +24,58 @@
 
 ## 怎麼跑 — 兩條路徑
 
+> ⚠️ **每個練習都要有自己的 Python 3.11 `.venv`。** 這題還需要 Docker；不要把模型產生的程式碼直接放到主機執行。這個示範容器仍可能連網，所以裡面不要放密碼或私密資料。
+
 ### Path A（默認、本機免費）
 
-```bash
-pip install -r requirements.txt
+```powershell
+py -3.11 -m venv .venv
+.\.venv\Scripts\python.exe -m pip install -r requirements.txt
 ollama pull qwen2.5:3b
 ollama serve
-python starter.py
+docker version
+.\.venv\Scripts\python.exe test_docker_smoke.py
+.\.venv\Scripts\python.exe starter.py
 ```
 
-預算：**$0**。CodeAct 對小 model 比較吃力——qwen2.5:3b 可能會產 syntax error、agent 自己迭代修。
+預算：模型 API 是 **$0**；本機硬體、電力與 Docker 資源仍有成本。小模型可能需要更多修正步驟，所以程式把 `max_steps` 限制為 4。
 
-### Path B（Anthropic、想看 cloud 高品質）
+### Path B（Anthropic、比較雲端結果）
+
+```powershell
+$env:ANTHROPIC_API_KEY="sk-ant-..."
+.\.venv\Scripts\python.exe starter_anthropic.py
+```
+
+預設固定型號：`anthropic/claude-haiku-4-5-20251001`。單次 2,000 input + 1,000 output tokens 的例子為 `$0.007`；CodeAct 可能多輪呼叫，因此先設供應商支出上限 **$0.10**。實際費用看 tokens 與步數。
+
+<details markdown="1">
+<summary>macOS／Linux 指令與查核資訊</summary>
 
 ```bash
-pip install -r requirements.txt
-export ANTHROPIC_API_KEY=sk-ant-...
-python starter_anthropic.py
+python3.11 -m venv .venv
+./.venv/bin/python -m pip install -r requirements.txt
+export ANTHROPIC_API_KEY="sk-ant-..."
+docker version
+./.venv/bin/python test.py
+./.venv/bin/python test_docker_smoke.py
 ```
 
-預算：每次 ≈ **$0.005-0.02**（CodeAct 通常多步、claude-haiku-4-5）。Claude 寫 Python code 比 qwen2.5:3b 穩很多。
+價格公式：`input_tokens / 1,000,000 × $1 + output_tokens / 1,000,000 × $5`。
+
+官方來源：[Secure code execution](https://huggingface.co/docs/smolagents/tutorials/secure_code_execution)｜[Python executors](https://huggingface.co/docs/smolagents/reference/python_executors)｜[Docker port publishing](https://docs.docker.com/engine/network/port-publishing/)｜[Anthropic pricing](https://platform.claude.com/docs/en/about-claude/pricing)
+
+<small>套件、model ID、價格與官方連結查核：2026-08-28 UTC。</small>
+</details>
 
 ## 不花錢驗證程式邏輯
 
-```bash
-python test.py # tool function + agent 結構
-python test_anthropic.py # Path B 可載入檢查
+```powershell
+.\.venv\Scripts\python.exe test.py # AST、JSON allowlist、loopback 控制埠與資源限制
+.\.venv\Scripts\python.exe test_anthropic.py # Anthropic 設定 + 相同安全邊界
 ```
+
+這兩個離線測試**不會**執行模型產生的程式碼，也不需要 Docker daemon。`test_docker_smoke.py` 是另外一個手動 smoke test：它真的啟動 Jupyter executor，確認主機控制通道可用，而且控制埠只綁在 `127.0.0.1`；先讓 `docker version` 成功再跑。它不會假裝容器不能連網。
 
 ## CodeAct 是怎麼運作的
 
@@ -70,7 +95,7 @@ print(ratio)
 （Smolagents 執行這段 code、把 print 結果接回去給 LLM 繼續）
 ````
 
-Framework 提供 sandboxed Python interpreter、agent 在裡面 import tool、寫 code、看 print 結果繼續。
+這份範例明確使用 Docker executor。Jupyter 控制埠只綁到主機的 `127.0.0.1`，並移除 Linux capabilities、禁止提權與 pickle，再限制記憶體、process 數與 agent 步數。一般 Docker bridge **仍可能讓容器連到外部網路或主機服務**，所以這只是受控教學示範，不是 production sandbox。需要執行不可信程式碼時，還要加真正的 egress／host 防火牆，或改用有正式隔離邊界的遠端 sandbox。
 
 ## CodeAct vs JSON tool 對照
 
@@ -82,7 +107,7 @@ Framework 提供 sandboxed Python interpreter、agent 在裡面 import tool、�
 | 一輪 token 數 | 較少 | 較多（code 較長） |
 | 對小 model | 較友善（穩定的 JSON） | 較吃力（要產正確 Python） |
 | Debug 友善 | tool call 看得清楚 | 看 code execution log |
-| 安全考量 | tool args validated | Sandboxed Python（注意 eval/exec 限制） |
+| 安全考量 | allowlist + 參數驗證 | 不可信程式碼，必須隔離、限權、限資源 |
 | 哪些題目擅長 | 單步、邊界明確 | 多步運算、需要中間 variable |
 
 **HuggingFace 的觀點**：CodeAct 更貼近「人類怎麼解問題」——你也是用變數記中間結果、不是每步都重新查。
@@ -91,31 +116,31 @@ Framework 提供 sandboxed Python interpreter、agent 在裡面 import tool、�
 
 | 觀察項 | Anthropic Claude haiku | Ollama qwen2.5:3b |
 |---|---|---|
-| 產正確 Python syntax | 穩 | 偶爾 syntax error、會自己迭代修 |
-| 變數命名 / 重用 | 自然 | 容易重複呼叫 tool 而非用 variable |
-| 多步 ratio 算對 | 高機率 | 中機率 |
-| 步數 | 1-2 步 | 3-5 步（迭代修錯） |
-| 成本 | $0.005-0.02 | $0 |
+| 產出可執行 Python | 用相同測試題量測 | 用相同測試題量測 |
+| 變數命名 / 重用 | 看 execution log | 看 execution log |
+| 比例是否算對 | 驗證最終值 | 驗證最終值 |
+| 步數 | 由 `max_steps=4` 限制 | 由 `max_steps=4` 限制 |
+| 模型 API 成本 | 依 tokens 與步數 | $0 |
 
-**punchline**：CodeAct 是 **model 質量敏感** pattern——LLM 要會寫能在 production 跑的 Python。**小 model 在 JSON tool 路線比 CodeAct 路線優**（Stage 3 練習 6 也驗證過這點）。
+**punchline**：CodeAct 比 JSON tool 多了一個「執行程式碼」的風險面。不要先假設哪個模型或路線較好；用相同任務比較成功率、步數、成本與安全邊界。
 
 ## 常見坑
 
 - **`@tool` 函式 docstring 是 prompt 的一部分**：Smolagents 把 docstring 當 tool description 給 LLM 看。**docstring 沒寫好、LLM 不知道何時用這 tool**
-- **CodeAct sandbox**：Smolagents 預設禁 `import os`、`open` 等危險操作。要放行特定 module、設 `additional_authorized_imports=[...]`
-- **`max_steps` 不夠**：CodeAct 跑多步、`max_steps=4` 可能不夠。但太大又會無限迴圈。經驗值 4-8
-- **小 model 寫的 code 有 syntax error**：Smolagents 會把 error 接回去讓 LLM 修、但會浪費 token。Production 用大 model 比較划算
+- **把 Docker 當完整 sandbox**：錯。這份範例只縮小權限並把控制埠綁在 loopback；上線前還要做映像、權限、egress、host access、資源與記錄審查
+- **`max_steps` 不夠**：先看錯在哪一步，不要只把數字調大；較大上限會增加費用與 loop 風險
+- **模型程式碼有 syntax error**：Smolagents 可以把錯誤接回模型修正，但會增加步數；是否換模型要看評測結果
 
 ## 想看更聰明的答案？
 
-```bash
-MODEL=anthropic/claude-sonnet-5 python starter_anthropic.py # 最穩
-MODEL=qwen2.5:7b python starter.py # 較大本機 model
+```powershell
+$env:MODEL="anthropic/claude-sonnet-5"; .\.venv\Scripts\python.exe starter_anthropic.py
+$env:MODEL="qwen2.5:7b"; .\.venv\Scripts\python.exe starter.py
 ```
 
 ## 延伸
 
 - **加更多 tools**：`@tool` 裝飾函式即自動 wrap、Smolagents 自動拿 docstring 當 description
 - **改 ToolCallingAgent**：Smolagents 也有非 CodeAct 的 `ToolCallingAgent`、用 JSON tool 路線。對照看
-- **接 Hugging Face Hub**：`HfApiModel` 直接打 HF inference（不必本機 ollama）
+- **接 Hugging Face Hub**：用現行 `InferenceClientModel` 呼叫 HF inference（不必本機 Ollama）
 - **看 [Anthropic Building Effective Agents](https://www.anthropic.com/engineering/building-effective-agents)**：Anthropic 的觀點是兩條路線都合理、看任務

--- a/examples/stage-4/04-codeact-vs-json-tool/README.zh-Hans.md
+++ b/examples/stage-4/04-codeact-vs-json-tool/README.zh-Hans.md
@@ -24,33 +24,58 @@
 
 ## 怎么跑 — 两条路径
 
+> ⚠️ **每个练习都要有自己的 Python 3.11 `.venv`。** 这题还需要 Docker；不要把模型产生的程序码直接放到主机执行。这个教学容器仍可能连网，所以里面不要放密码或私密数据。
+
 ### Path A（默认、本机免费）
 
-```bash
-pip install -r requirements.txt
+```powershell
+py -3.11 -m venv .venv
+.\.venv\Scripts\python.exe -m pip install -r requirements.txt
 ollama pull qwen2.5:3b
 ollama serve
-python starter.py
+docker version
+.\.venv\Scripts\python.exe test_docker_smoke.py
+.\.venv\Scripts\python.exe starter.py
 ```
 
-预算：**$0**。CodeAct 对小 model 比较吃力——qwen2.5:3b 可能会产 syntax error、agent 自己迭代修。
+预算：模型 API 是 **$0**；本机硬体、电力与 Docker 资源仍有成本。小模型可能需要更多修正步骤，所以程序把 `max_steps` 限制为 4。
 
-### Path B（Anthropic、想看 cloud 高质量）
+### Path B（Anthropic、比较云端结果）
+
+```powershell
+$env:ANTHROPIC_API_KEY="sk-ant-..."
+.\.venv\Scripts\python.exe starter_anthropic.py
+```
+
+预设固定型号：`anthropic/claude-haiku-4-5-20251001`。单次 2,000 input + 1,000 output tokens 的例子为 `$0.007`；CodeAct 可能多轮调用，因此先设供应商支出上限 **$0.10**。实际费用看 tokens 与步数。
+
+<details markdown="1">
+<summary>macOS／Linux 指令与查核资讯</summary>
 
 ```bash
-pip install -r requirements.txt
-export ANTHROPIC_API_KEY=sk-ant-...
-python starter_anthropic.py
+python3.11 -m venv .venv
+./.venv/bin/python -m pip install -r requirements.txt
+export ANTHROPIC_API_KEY="sk-ant-..."
+docker version
+./.venv/bin/python test.py
+./.venv/bin/python test_docker_smoke.py
 ```
 
-预算：每次 ≈ **$0.005-0.02**（CodeAct 通常多步、claude-haiku-4-5）。Claude 写 Python code 比 qwen2.5:3b 稳很多。
+价格公式：`input_tokens / 1,000,000 × $1 + output_tokens / 1,000,000 × $5`。
+
+官方来源：[Secure code execution](https://huggingface.co/docs/smolagents/tutorials/secure_code_execution)｜[Python executors](https://huggingface.co/docs/smolagents/reference/python_executors)｜[Docker port publishing](https://docs.docker.com/engine/network/port-publishing/)｜[Anthropic pricing](https://platform.claude.com/docs/en/about-claude/pricing)
+
+<small>套件、model ID、价格与官方连结查核：2026-08-28 UTC。</small>
+</details>
 
 ## 不花钱验证程序逻辑
 
-```bash
-python test.py             # tool function + agent 结构
-python test_anthropic.py   # Path B 可载入检查
+```powershell
+.\.venv\Scripts\python.exe test.py # AST、JSON allowlist、loopback 控制端口与资源限制
+.\.venv\Scripts\python.exe test_anthropic.py # Anthropic 设定 + 相同安全边界
 ```
+
+这两个离线测试**不会**执行模型产生的程序码，也不需要 Docker daemon。`test_docker_smoke.py` 是另一个手动 smoke test：它真的启动 Jupyter executor，确认主机控制通道可用，而且控制端口只绑定到 `127.0.0.1`；先让 `docker version` 成功再运行。它不会假装容器不能连网。
 
 ## CodeAct 是怎么运作的
 
@@ -61,16 +86,16 @@ LLM 不回 JSON、而是**回 Python code block**：
 
 （LLM 回应）
 ```python
-pop_taipei = lookup_fact(query="Taipei population")  # 2602000
-pop_nyc = lookup_fact(query="New York population")   # 8336000
-ratio = calculator(expression=f"{pop_taipei}/{pop_nyc}")  # 0.3122
+pop_taipei = lookup_fact(query="Taipei population") # 2602000
+pop_nyc = lookup_fact(query="New York population") # 8336000
+ratio = calculator(expression=f"{pop_taipei}/{pop_nyc}") # 0.3122
 print(ratio)
 ```
 
 （Smolagents 执行这段 code、把 print 结果接回去给 LLM 继续）
 ````
 
-Framework 提供 sandboxed Python interpreter、agent 在里面 import tool、写 code、看 print 结果继续。
+这份示例明确使用 Docker executor。Jupyter 控制端口只绑定到主机的 `127.0.0.1`，并移除 Linux capabilities、禁止提权与 pickle，再限制内存、process 数与 agent 步数。一般 Docker bridge **仍可能让容器连接外部网络或主机服务**，所以这只是受控教学示例，不是 production sandbox。需要执行不可信程序码时，还要加真正的 egress／host 防火墙，或改用有正式隔离边界的远程 sandbox。
 
 ## CodeAct vs JSON tool 对照
 
@@ -82,7 +107,7 @@ Framework 提供 sandboxed Python interpreter、agent 在里面 import tool、�
 | 一轮 token 数 | 较少 | 较多（code 较长） |
 | 对小 model | 较友善（稳定的 JSON） | 较吃力（要产正确 Python） |
 | Debug 友善 | tool call 看得清楚 | 看 code execution log |
-| 安全考量 | tool args validated | Sandboxed Python（注意 eval/exec 限制） |
+| 安全考量 | allowlist + 参数验证 | 不可信程序码，必须隔离、限权、限资源 |
 | 哪些题目擅长 | 单步、边界明确 | 多步运算、需要中间 variable |
 
 **HuggingFace 的观点**：CodeAct 更贴近“人类怎么解问题”——你也是用变数记中间结果、不是每步都重新查。
@@ -91,31 +116,31 @@ Framework 提供 sandboxed Python interpreter、agent 在里面 import tool、�
 
 | 观察项 | Anthropic Claude haiku | Ollama qwen2.5:3b |
 |---|---|---|
-| 产正确 Python syntax | 稳 | 偶尔 syntax error、会自己迭代修 |
-| 变数命名 / 重用 | 自然 | 容易重复调用 tool 而非用 variable |
-| 多步 ratio 算对 | 高机率 | 中机率 |
-| 步数 | 1-2 步 | 3-5 步（迭代修错） |
-| 成本 | $0.005-0.02 | $0 |
+| 产出可执行 Python | 用相同测试题量测 | 用相同测试题量测 |
+| 变数命名 / 重用 | 看 execution log | 看 execution log |
+| 比例是否算对 | 验证最终值 | 验证最终值 |
+| 步数 | 由 `max_steps=4` 限制 | 由 `max_steps=4` 限制 |
+| 模型 API 成本 | 依 tokens 与步数 | $0 |
 
-**punchline**：CodeAct 是 **model 质量敏感** pattern——LLM 要会写能在 production 跑的 Python。**小 model 在 JSON tool 路线比 CodeAct 路线优**（Stage 3 练习 6 也验证过这点）。
+**punchline**：CodeAct 比 JSON tool 多了一个“执行程序码”的风险面。不要先假设哪个模型或路线较好；用相同任务比较成功率、步数、成本与安全边界。
 
 ## 常见坑
 
 - **`@tool` 函数 docstring 是 prompt 的一部分**：Smolagents 把 docstring 当 tool description 给 LLM 看。**docstring 没写好、LLM 不知道何时用这 tool**
-- **CodeAct sandbox**：Smolagents 预设禁 `import os`、`open` 等危险操作。要放行特定 module、设 `additional_authorized_imports=[...]`
-- **`max_steps` 不够**：CodeAct 跑多步、`max_steps=4` 可能不够。但太大又会无限循环。经验值 4-8
-- **小 model 写的 code 有 syntax error**：Smolagents 会把 error 接回去让 LLM 修、但会浪费 token。Production 用大 model 比较划算
+- **把 Docker 当完整 sandbox**：错。这份示例只缩小权限并把控制端口绑定到 loopback；上线前还要做镜像、权限、egress、host access、资源与记录审查
+- **`max_steps` 不够**：先看错在哪一步，不要只把数字调大；较大上限会增加费用与 loop 风险
+- **模型程序码有 syntax error**：Smolagents 可以把错误接回模型修正，但会增加步数；是否换模型要看评测结果
 
 ## 想看更聪明的答案？
 
-```bash
-MODEL=anthropic/claude-sonnet-5 python starter_anthropic.py  # 最稳
-MODEL=qwen2.5:7b python starter.py                              # 较大本机 model
+```powershell
+$env:MODEL="anthropic/claude-sonnet-5"; .\.venv\Scripts\python.exe starter_anthropic.py
+$env:MODEL="qwen2.5:7b"; .\.venv\Scripts\python.exe starter.py
 ```
 
 ## 延伸
 
 - **加更多 tools**：`@tool` 装饰函数即自动 wrap、Smolagents 自动拿 docstring 当 description
 - **改 ToolCallingAgent**：Smolagents 也有非 CodeAct 的 `ToolCallingAgent`、用 JSON tool 路线。对照看
-- **接 Hugging Face Hub**：`HfApiModel` 直接打 HF inference（不必本机 ollama）
+- **接 Hugging Face Hub**：使用现行 `InferenceClientModel` 调用 HF inference（不需要本机 Ollama）
 - **看 [Anthropic Building Effective Agents](https://www.anthropic.com/engineering/building-effective-agents)**：Anthropic 的观点是两条路线都合理、看任务

--- a/examples/stage-4/04-codeact-vs-json-tool/requirements.txt
+++ b/examples/stage-4/04-codeact-vs-json-tool/requirements.txt
@@ -1,2 +1,2 @@
-smolagents>=1.0,<2.0
-litellm>=1.50,<2.0
+smolagents[docker]>=1.26,<2.0
+litellm>=1.98,<2.0

--- a/examples/stage-4/04-codeact-vs-json-tool/starter.py
+++ b/examples/stage-4/04-codeact-vs-json-tool/starter.py
@@ -1,27 +1,14 @@
-"""Stage 4 練習 4：CodeAct（Smolagents）vs JSON tool — Path A（Ollama 默認）。
+"""Stage 4 練習 4：比較有界 CodeAct 與安全的 JSON tool 算術路徑。
 
-CodeAct pattern：agent 產生 Python 程式碼當 action（不是 JSON tool call）。
-HuggingFace Smolagents 是這條路線的代表——LLM 寫 `result = calculator(...)` 一句一句執行。
-
-跟練習 1 / 3 用的 JSON tool 路線對照：
-- JSON tool: LLM 回 `{"name": "calculator", "arguments": {"expression": "..."}}`
-- CodeAct:   LLM 回 ```python\nresult = calculator(expression="...")\nprint(result)\n```
-
-跑法：
-    pip install -r requirements.txt
-    ollama pull qwen2.5:3b
-    ollama serve
-    python starter.py
-
-驗證：
-    python test.py
-
-⚠️ 注意：Smolagents 對小 model 比較吃力（要產正確 Python syntax）。
-qwen2.5:3b 可能會產出有 syntax error 的 code、agent 自己迭代修。Claude 較穩。
+JSON tool 只允許固定工具與固定參數；算式先轉成 AST，再逐節點檢查。
+CodeAct 會執行模型產生的 Python，所以只在受限制的 Docker 容器裡示範。
+Jupyter 控制埠只綁到主機的 127.0.0.1；容器仍可能連網，因此這不是 production
+sandbox。兩條路都設有步數與輸入邊界。
 """
 
 from __future__ import annotations
 
+import ast
 import os
 import sys
 from typing import Any
@@ -29,65 +16,117 @@ from typing import Any
 if hasattr(sys.stdout, "reconfigure"):
     sys.stdout.reconfigure(encoding="utf-8", errors="replace")
 
-from smolagents import CodeAgent, OpenAIServerModel, tool
+from smolagents import CodeAgent, OpenAIServerModel, ToolCallingAgent, tool
 
 MODEL = os.environ.get("MODEL", "qwen2.5:3b")
 OLLAMA_BASE = os.environ.get("OLLAMA_API_BASE", "http://localhost:11434/v1")
+MAX_AST_NODES = 40
+MAX_NUMBER = 1_000_000
 
 
-# === Tools ===
+def evaluate_arithmetic(expression: str) -> float:
+    """只計算小型算術 AST；模型文字不會交給 ``eval`` 或 ``exec``。"""
+    if not isinstance(expression, str) or len(expression) > 120:
+        raise ValueError("Expression must be a string of at most 120 characters.")
+    tree = ast.parse(expression, mode="eval")
+    if sum(1 for _ in ast.walk(tree)) > MAX_AST_NODES:
+        raise ValueError("Expression is too complex.")
+
+    def visit(node: ast.AST) -> float:
+        if isinstance(node, ast.Expression):
+            return visit(node.body)
+        if isinstance(node, ast.Constant) and type(node.value) in (int, float):
+            value = float(node.value)
+            if abs(value) > MAX_NUMBER:
+                raise ValueError("Number magnitude is too large.")
+            return value
+        if isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.UAdd, ast.USub)):
+            return visit(node.operand) if isinstance(node.op, ast.UAdd) else -visit(node.operand)
+        if isinstance(node, ast.BinOp) and isinstance(node.op, (ast.Add, ast.Sub, ast.Mult, ast.Div)):
+            left, right = visit(node.left), visit(node.right)
+            if isinstance(node.op, ast.Add): return left + right
+            if isinstance(node.op, ast.Sub): return left - right
+            if isinstance(node.op, ast.Mult): return left * right
+            if right == 0: raise ValueError("Division by zero is not allowed.")
+            return left / right
+        raise ValueError(f"Unsupported arithmetic syntax: {type(node).__name__}")
+
+    value = visit(tree)
+    if abs(value) > MAX_NUMBER:
+        raise ValueError("Result magnitude is too large.")
+    return value
+
 
 @tool
 def calculator(expression: str) -> str:
-    """Safe arithmetic calculator (whitelist + - * / parentheses).
+    """Return a guarded arithmetic result for a small expression.
 
     Args:
-        expression: Arithmetic expression to evaluate, e.g. '2 + 3 * (4 - 1)'.
+        expression: Digits, parentheses, and the +, -, *, / operators only.
     """
-    allowed = set("0123456789.+-*/() ")
-    if any(c not in allowed for c in expression):
-        return "error: only basic arithmetic allowed"
     try:
-        return str(eval(expression, {"__builtins__": {}}, {}))  # noqa: S307
-    except Exception as e:  # noqa: BLE001
-        return f"error: {e}"
+        return str(evaluate_arithmetic(expression))
+    except (SyntaxError, ValueError) as error:
+        return f"error: {error}"
 
 
 @tool
 def lookup_fact(query: str) -> str:
-    """Look up a fact (population / physical constants, etc.).
+    """Return one fixed offline fact from a tiny allowlist.
 
     Args:
-        query: Fact key to look up, e.g. 'taipei population' or 'speed of light'.
+        query: Either ``Taipei population`` or ``New York population``.
     """
-    db = {
-        "taipei population": "2602000",
-        "new york population": "8336000",
-        "speed of light": "299792458",
+    facts = {"taipei population": "2602000", "new york population": "8336000"}
+    return facts.get(query.strip().lower(), f"unknown: {query}")
+
+
+def run_json_tool_call(call: dict[str, Any]) -> str:
+    """JSON tool 邊界：工具名、參數形狀與算式都要先通過檢查。"""
+    if not isinstance(call, dict) or set(call) != {"name", "arguments"}:
+        raise ValueError("A JSON tool call needs exactly name and arguments.")
+    if call["name"] != "calculator" or not isinstance(call["arguments"], dict) or set(call["arguments"]) != {"expression"}:
+        raise ValueError("Only calculator(expression=...) is allowed.")
+    return calculator.forward(expression=call["arguments"]["expression"])
+
+
+def codeact_executor_config() -> dict[str, Any]:
+    """縮小示範容器權限，並把 Jupyter 控制埠只綁到本機。"""
+    return {
+        "allow_pickle": False,
+        "host": "127.0.0.1",
+        "container_run_kwargs": {
+            "network_mode": "bridge",
+            "mem_limit": "256m",
+            "pids_limit": 64,
+            "cap_drop": ["ALL"],
+            "security_opt": ["no-new-privileges"],
+        },
     }
-    return db.get(query.strip().lower(), f"unknown: {query}")
 
 
-def build_agent(model: Any = None) -> CodeAgent:
-    model = model or OpenAIServerModel(
-        model_id=MODEL, api_base=OLLAMA_BASE, api_key="ollama",
-    )
-    return CodeAgent(tools=[calculator, lookup_fact], model=model, max_steps=4)
+def build_codeact_agent(model: Any | None = None, executor_type: str = "docker") -> CodeAgent:
+    """建立最多走四步、且預設只在 Docker 裡執行程式碼的 agent。"""
+    model = model or OpenAIServerModel(model_id=MODEL, api_base=OLLAMA_BASE, api_key="ollama")
+    executor_kwargs = codeact_executor_config() if executor_type == "docker" else {}
+    return CodeAgent(tools=[calculator, lookup_fact], model=model, max_steps=4, additional_authorized_imports=[], executor_type=executor_type, executor_kwargs=executor_kwargs)
 
 
-def run(question: str, model: Any = None) -> dict:
-    agent = build_agent(model=model)
-    result = agent.run(question)
-    return {"final": str(result)}
+def build_json_agent(model: Any) -> ToolCallingAgent:
+    """建立同工具集合的 JSON tool 對照組。"""
+    return ToolCallingAgent(tools=[calculator, lookup_fact], model=model, max_steps=4)
+
+
+def run(question: str, model: Any | None = None) -> dict[str, str]:
+    agent = build_codeact_agent(model=model)
+    try:
+        return {"final": str(agent.run(question))}
+    finally:
+        agent.cleanup()
 
 
 if __name__ == "__main__":
-    question = "Find Taipei population, divide by New York population, give the ratio."
-    print(f"❓ Question: {question}（using Smolagents + Ollama {MODEL}）")
-    print("   CodeAct pattern: agent will WRITE PYTHON CODE that calls tools")
-    print("-" * 60)
-    result = run(question)
-    print(f"\n✅ Final: {result['final']}")
-    assert result["final"], "expected non-empty answer"
-    print("✅ 練習 4 通過 — Smolagents CodeAct、$0/run")
-    print("   對照練習 1 / 3 的 JSON tool 寫法、看兩種路線怎麼解同題")
+    result = run("Find Taipei population, divide it by New York population, and report the ratio.")
+    print(result["final"])
+    assert result["final"]
+    assert run_json_tool_call({"name": "calculator", "arguments": {"expression": "2 + 3 * 4"}}) == "14.0"

--- a/examples/stage-4/04-codeact-vs-json-tool/starter_anthropic.py
+++ b/examples/stage-4/04-codeact-vs-json-tool/starter_anthropic.py
@@ -1,14 +1,6 @@
-"""Stage 4 練習 4：CodeAct（Smolagents）— Path B（Anthropic Claude via LiteLLM）。
+"""Stage 4 練習 4 Path B：用 LiteLLM 的固定 Anthropic model ID 跑 CodeAct。
 
-Smolagents 的 LiteLLMModel 可以打 Claude，model_id 用 LiteLLM 格式。
-
-跑法：
-    pip install -r requirements.txt
-    export ANTHROPIC_API_KEY=sk-ant-...
-    python starter_anthropic.py
-
-預算：CodeAct 通常多步、每次 ≈ $0.005-0.02（claude-haiku-4-5）。
-Claude 寫 Python code 比 qwen2.5:3b 穩很多。
+它和 Path A 共用同一組工具、Docker 邊界與最多四步的限制。
 """
 
 from __future__ import annotations
@@ -20,18 +12,18 @@ if hasattr(sys.stdout, "reconfigure"):
     sys.stdout.reconfigure(encoding="utf-8", errors="replace")
 
 from smolagents import LiteLLMModel
-
 from starter import run
 
-MODEL = os.environ.get("MODEL", "anthropic/claude-haiku-4-5")
+MODEL = os.environ.get("MODEL", "anthropic/claude-haiku-4-5-20251001")
+
+
+def make_anthropic_model() -> LiteLLMModel:
+    """建立 Smolagents 可識別的 Anthropic LiteLLM model。"""
+    return LiteLLMModel(model_id=MODEL)
 
 
 if __name__ == "__main__":
-    question = "Find Taipei population, divide by New York population, give the ratio."
-    print(f"❓ Question: {question}（using Smolagents + Anthropic {MODEL}）")
-    print("-" * 60)
-    model = LiteLLMModel(model_id=MODEL)
-    result = run(question, model=model)
-    print(f"\n✅ Final: {result['final']}")
+    result = run("Find Taipei population divided by New York population.", model=make_anthropic_model())
+    print(result["final"])
     assert result["final"]
-    print("✅ 練習 4 (Anthropic path) 通過 — Claude 寫 Python code 比小 model 穩很多")
+    assert MODEL.startswith("anthropic/")

--- a/examples/stage-4/04-codeact-vs-json-tool/test.py
+++ b/examples/stage-4/04-codeact-vs-json-tool/test.py
@@ -1,10 +1,4 @@
-"""Stage 4 練習 4 自我驗證 — CodeAct tool 邏輯 + agent 建構。
-
-Smolagents 整個 agent.run() 會實際執行 Python code、純 mock 困難。
-這份只驗：(1) tool function 邏輯、(2) build_agent 可建構、(3) max_steps 等預設正確。
-
-要實測請跑 starter.py 配 Ollama。
-"""
+"""Path A 離線行為測試：不呼叫 CodeAgent.run，也不執行模型程式碼。"""
 
 from __future__ import annotations
 
@@ -13,53 +7,36 @@ import sys
 if hasattr(sys.stdout, "reconfigure"):
     sys.stdout.reconfigure(encoding="utf-8", errors="replace")
 
-from starter import build_agent, calculator, lookup_fact
+from starter import MAX_NUMBER, codeact_executor_config, evaluate_arithmetic, run_json_tool_call
 
 
-def test_calculator_basic():
-    fn = getattr(calculator, "func", None) or getattr(calculator, "forward", None) or calculator
-    # Smolagents @tool decorator wraps; the underlying callable can be reached via .forward or direct call
-    try:
-        result = fn("2 + 3") if callable(fn) and fn is not calculator else calculator("2 + 3")
-    except TypeError:
-        # If tool wrapper expects dict
-        result = calculator(expression="2 + 3")
-    assert "5" in str(result), f"expected 5, got {result}"
-    print("✅ test_calculator_basic")
+def test_json_tool_and_ast_evaluator() -> None:
+    assert run_json_tool_call({"name": "calculator", "arguments": {"expression": "2 + 3 * (4 - 1)"}}) == "11.0"
+    assert evaluate_arithmetic("-4 / 2") == -2.0
 
 
-def test_calculator_rejects_injection():
-    try:
-        out = calculator(expression="__import__('os').system('ls')")
-    except TypeError:
-        out = calculator("__import__('os').system('ls')")
-    assert "error" in str(out)
-    print("✅ test_calculator_rejects_injection")
+def test_ast_guards_reject_code_and_unsafe_values() -> None:
+    for expression in ("__import__('os')", "2 / 0", f"{MAX_NUMBER + 1}"):
+        try:
+            evaluate_arithmetic(expression)
+        except (SyntaxError, ValueError):
+            pass
+        else:
+            raise AssertionError(f"Expected guarded evaluator to reject {expression!r}")
 
 
-def test_lookup_fact_basic():
-    try:
-        out = lookup_fact(query="Taipei population")
-    except TypeError:
-        out = lookup_fact("Taipei population")
-    assert "2602000" in str(out)
-    print("✅ test_lookup_fact_basic")
-
-
-def test_build_agent_ok():
-    """確認 build_agent 能組出 CodeAgent、且 max_steps 預設合理。"""
-    # 不真打 API：傳一個 mock model
-    class FakeModel:
-        def __call__(self, *a, **kw): return ""
-    agent = build_agent(model=FakeModel())
-    assert hasattr(agent, "run"), "expected CodeAgent.run method"
-    assert agent.max_steps == 4, f"expected max_steps=4, got {agent.max_steps}"
-    print("✅ test_build_agent_ok")
+def test_codeact_uses_loopback_control_and_limits() -> None:
+    config = codeact_executor_config()
+    assert "additional_imports" not in config
+    assert config["allow_pickle"] is False
+    assert config["host"] == "127.0.0.1"
+    assert config["container_run_kwargs"]["network_mode"] == "bridge"
+    assert config["container_run_kwargs"]["cap_drop"] == ["ALL"]
+    assert config["container_run_kwargs"]["security_opt"] == ["no-new-privileges"]
 
 
 if __name__ == "__main__":
-    test_calculator_basic()
-    test_calculator_rejects_injection()
-    test_lookup_fact_basic()
-    test_build_agent_ok()
-    print("\n🎉 通過 — Smolagents tool + agent 結構正確（實測需 Ollama）")
+    test_json_tool_and_ast_evaluator()
+    test_ast_guards_reject_code_and_unsafe_values()
+    test_codeact_uses_loopback_control_and_limits()
+    print("all pass")

--- a/examples/stage-4/04-codeact-vs-json-tool/test_anthropic.py
+++ b/examples/stage-4/04-codeact-vs-json-tool/test_anthropic.py
@@ -1,7 +1,4 @@
-"""Stage 4 練習 4 — Path B 載入檢查。
-
-Smolagents 整個 CodeAct 太重、純 mock 困難。實測請跑 starter_anthropic.py 配 ANTHROPIC_API_KEY。
-"""
+"""Path B 離線行為測試：不呼叫模型，也不執行模型產生的程式碼。"""
 
 from __future__ import annotations
 
@@ -10,21 +7,27 @@ import sys
 if hasattr(sys.stdout, "reconfigure"):
     sys.stdout.reconfigure(encoding="utf-8", errors="replace")
 
-
-def test_litellm_model_importable():
-    from smolagents import LiteLLMModel
-    assert LiteLLMModel is not None
-    print("✅ test_litellm_model_importable")
+from starter import run_json_tool_call
+from starter_anthropic import MODEL, make_anthropic_model
 
 
-def test_starter_anthropic_loadable():
-    import starter_anthropic
-    assert hasattr(starter_anthropic, "MODEL")
-    assert "anthropic/" in starter_anthropic.MODEL
-    print("✅ test_starter_anthropic_loadable")
+def test_litellm_provider_configuration() -> None:
+    model = make_anthropic_model()
+    assert MODEL == "anthropic/claude-haiku-4-5-20251001"
+    assert model.model_id == MODEL
+
+
+def test_anthropic_path_uses_the_same_safe_json_boundary() -> None:
+    assert run_json_tool_call({"name": "calculator", "arguments": {"expression": "8 / 2"}}) == "4.0"
+    try:
+        run_json_tool_call({"name": "shell", "arguments": {"command": "whoami"}})
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("Unexpected tool names must be rejected.")
 
 
 if __name__ == "__main__":
-    test_litellm_model_importable()
-    test_starter_anthropic_loadable()
-    print("\n🎉 通過 — Path B 可載入（實測需 ANTHROPIC_API_KEY）")
+    test_litellm_provider_configuration()
+    test_anthropic_path_uses_the_same_safe_json_boundary()
+    print("all pass")

--- a/examples/stage-4/04-codeact-vs-json-tool/test_docker_smoke.py
+++ b/examples/stage-4/04-codeact-vs-json-tool/test_docker_smoke.py
@@ -1,0 +1,44 @@
+"""Manual Docker smoke test for Smolagents' host control channel.
+
+Run this only after ``docker version`` succeeds. It builds/starts the official
+Jupyter executor, proves the host can execute one tiny statement, and confirms
+the control port is published only on loopback. The normal offline tests do not call it.
+"""
+
+from __future__ import annotations
+
+import sys
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+from smolagents import DockerExecutor
+from smolagents.monitoring import AgentLogger, LogLevel
+
+from starter import codeact_executor_config
+
+
+def test_docker_control_channel() -> None:
+    config = codeact_executor_config()
+    executor = None
+    try:
+        executor = DockerExecutor(
+            additional_imports=[],
+            logger=AgentLogger(level=LogLevel.ERROR),
+            build_new_image=True,
+            **config,
+        )
+        output = executor.run_code_raise_errors("print(2 + 2)")
+        assert "4" in output.logs
+        executor.container.reload()
+        bindings = executor.container.attrs["NetworkSettings"]["Ports"]["8888/tcp"]
+        assert bindings
+        assert all(binding["HostIp"] == "127.0.0.1" for binding in bindings)
+    finally:
+        if executor is not None:
+            executor.cleanup()
+
+
+if __name__ == "__main__":
+    test_docker_control_channel()
+    print("docker smoke pass")

--- a/examples/stage-4/05-typed-agent/README.en.md
+++ b/examples/stage-4/05-typed-agent/README.en.md
@@ -1,5 +1,5 @@
 <div align="right">
-  <a href="./README.md">繁體中文</a> | <a href="./README.zh-Hans.md">简体中文</a> | <strong>English</strong>
+  <a href="./README.md">Traditional Chinese</a> | <a href="./README.zh-Hans.md">Simplified Chinese</a> | <strong>English</strong>
 </div>
 
 # Exercise 5: Type-Safe Agent (Pydantic AI structured output)
@@ -24,39 +24,56 @@ class AnswerWithConfidence(BaseModel):
     sources: list[str]
 ```
 
-Pydantic AI lifts schema validation from the prompt layer (Stage 3 Exercise 6) **to the type layer** — if the LLM violates the schema, the framework auto-retries. Production teams use this to fight hallucination.
+Pydantic AI puts **schema validation**—rules about data shape—into the program. If the LLM violates the schema, the framework can reject or retry it. This checks the shape; it **does not prove the answer is true**.
 
 ## How to run — two paths
 
+> ⚠️ **Give each exercise its own Python 3.11 `.venv`.** Do not mix this Pydantic requirement set with the CrewAI exercises.
+
 ### Path A (default, free, local)
 
-```bash
-pip install -r requirements.txt
+```powershell
+py -3.11 -m venv .venv
+.\.venv\Scripts\python.exe -m pip install -r requirements.txt
 ollama pull qwen2.5:3b
 ollama serve
-python starter.py
+.\.venv\Scripts\python.exe starter.py
 ```
 
-Budget: **$0**. But qwen2.5:3b may retry several times to satisfy the schema, raising total token usage.
+Budget: the model API costs **$0**. Local hardware, electricity, and retry time still have a cost.
 
-### Path B (Anthropic, cloud-quality)
+### Path B (Anthropic, compare a cloud result)
+
+```powershell
+$env:ANTHROPIC_API_KEY="sk-ant-..."
+.\.venv\Scripts\python.exe starter_anthropic.py
+```
+
+Pinned default: `claude-haiku-4-5-20251001`. A request with 2,000 input + 1,000 output tokens costs `2,000 / 1,000,000 × $1 + 1,000 / 1,000,000 × $5 = $0.007`. Validation failure can cause a retry, so set a provider spend limit of **$0.05**.
+
+<details markdown="1">
+<summary>macOS/Linux commands and verification information</summary>
 
 ```bash
-pip install -r requirements.txt
-export ANTHROPIC_API_KEY=sk-ant-...
-python starter_anthropic.py
+python3.11 -m venv .venv
+./.venv/bin/python -m pip install -r requirements.txt
+export ANTHROPIC_API_KEY="sk-ant-..."
+./.venv/bin/python test.py
 ```
 
-Budget: ~**$0.001** per run (claude-haiku-4-5, usually one shot, no retry).
+Official sources: [Pydantic AI output](https://ai.pydantic.dev/output/) | [Pydantic AI testing](https://ai.pydantic.dev/testing/) | [Anthropic pricing](https://platform.claude.com/docs/en/about-claude/pricing)
+
+<small>Packages, model IDs, prices, and official links verified: 2026-08-28 UTC.</small>
+</details>
 
 ## Validate the logic
 
-```bash
-python test.py             # Pydantic schema validation + agent structure
-python test_anthropic.py   # Path B import check
+```powershell
+.\.venv\Scripts\python.exe test.py # official TestModel + schema boundaries
+.\.venv\Scripts\python.exe test_anthropic.py # Anthropic setup + the same output contract
 ```
 
-`test.py` directly verifies `AnswerWithConfidence` raises `ValidationError` on invalid data (confidence > 1.0, wrong type, sources not a list) — no LLM calls, pure type-layer testing.
+`test.py` uses Pydantic AI's official `TestModel` and verifies that `AnswerWithConfidence` rejects out-of-range confidence, wrong types, blank answers, and empty sources. It makes no LLM call.
 
 ## Why type-safe agents matter
 
@@ -66,7 +83,8 @@ Stage 3 Exercise 6: schema = JSON Schema in the prompt
 
 Stage 4 Exercise 5: schema = Pydantic model in code
     LLM violates → framework auto-raises → retry / fix
-    Final output is guaranteed to conform (runtime guarantee)
+    A successful output has passed runtime shape checks
+    Factual truth still needs a separate check
 ```
 
 For production:
@@ -76,9 +94,9 @@ For production:
 | LLM drops a field | Your downstream code needs try/except | Auto-retry until conformant |
 | Wrong type (confidence="high") | Downstream crash | Pydantic ValidationError, retry |
 | Out of bound (confidence=1.5) | Downstream gets bad data | Reject, retry |
-| LLM hallucinates extra fields | Silently accepted | Default ignore (configurable to strict) |
+| Extra fields | Depends on your parser | Handled by the Pydantic model's configuration |
 
-**Bottom line**: production agents must use type-safe output. Stage 3 Exercise 6 teaches schema design; Stage 4 Exercise 5 teaches turning that schema into a runtime contract.
+**Bottom line**: typed output is useful when downstream code needs fixed fields. Stage 3 Exercise 6 teaches schema design; this exercise turns a schema into a runtime contract and reminds you to add fact checking.
 
 ## Core Pydantic AI concepts
 
@@ -94,7 +112,7 @@ result = agent.run_sync(question)
 answer: AnswerWithConfidence = result.output   # validated object
 ```
 
-**Key**: behind the scenes, the framework converts the Pydantic schema into structured-output instructions for the LLM, validates the response, and retries on failure.
+**Key**: the framework converts the Pydantic schema into structured-output instructions, validates the response, and retries according to your settings. A successful retry means the format passed—not that the content is true.
 
 ### Field constraints
 
@@ -116,31 +134,31 @@ When Pydantic AI sees a ValidationError, it appends the error message back into 
 
 | Observation | Anthropic Claude haiku | Ollama qwen2.5:3b |
 |---|---|---|
-| One-shot schema correct | 90%+ | 50-70% |
-| Average retries | 0-1 | 1-3 |
-| Confidence bound respected | Stable | Occasional 1.5 / negative (rejected, retry) |
-| Sources is a list | Stable | Occasional string (rejected) |
-| Total token cost | Low (few retries) | High (multiple retries) |
+| First-attempt schema pass | Measure with the same cases | Measure with the same cases |
+| Retry count | Record the actual result | Record the actual result |
+| Confidence bounds | Enforced by Pydantic | Enforced by Pydantic |
+| Sources is a list | Enforced by Pydantic | Enforced by Pydantic |
+| Cost | Depends on tokens and retries | Model API $0 |
 
-**Counterintuitive**: Path B (Claude) can actually have **lower total token cost** than Path A (qwen) — retries add up. Looking at the full bill, production teams pick the larger model.
+**Teaching point**: when comparing models, record pass rate, retries, latency, and cost together. Do not look only at per-token price, and do not assume a larger model is always cheaper.
 
 ## Common pitfalls
 
-- **`output_type` too complex**: deeply nested models are hard for the LLM to produce in one shot. Aim for flat, ≤5 top-level fields
+- **`output_type` too complex**: deep nesting is harder to generate and maintain. Start with the minimum fields, then use evaluations to decide whether to split it
 - **Missing `description`**: `Field(...)` without `description=` leaves the LLM guessing what the field is for
-- **`retries=0`**: failure raises immediately, no chance to fix. Empirically `retries=1-3` works well
+- **`retries=0`**: failure raises immediately. Choose a bounded retry count from your cost, latency, and failure patterns
 - **Small model + deep nesting**: qwen2.5:3b may retry many times and still fail. Upgrade or flatten
 
 ## Want smarter answers?
 
-```bash
-MODEL=claude-sonnet-5 python starter_anthropic.py    # highest one-shot rate
-MODEL=qwen2.5:7b python starter.py                      # larger local model
+```powershell
+$env:MODEL="claude-sonnet-5"; .\.venv\Scripts\python.exe starter_anthropic.py
+$env:MODEL="qwen2.5:7b"; .\.venv\Scripts\python.exe starter.py
 ```
 
 ## Extensions
 
 - **Add tools**: Pydantic AI agents can have tools + structured output simultaneously via `@agent.tool`
 - **Stream typed output**: `agent.run_stream(...)` validates as it streams
-- **Cross-model comparison**: same schema across Claude / GPT / Gemini / local — see who's most stable
-- **Production wiring**: Pydantic AI integrates with FastAPI; output doubles as your API response model
+- **Cross-model comparison**: run the same schema across Claude / GPT / Gemini / local models; compare pass rate, retries, and cost
+- **Production wiring**: Pydantic AI integrates with FastAPI; a validated output can become an API response model

--- a/examples/stage-4/05-typed-agent/README.md
+++ b/examples/stage-4/05-typed-agent/README.md
@@ -24,36 +24,53 @@ class AnswerWithConfidence(BaseModel):
     sources: list[str]
 ```
 
-Pydantic AI 把 schema validation 從 prompt 層（Stage 3 練習 6）**提升到 type 層**——LLM 不照 schema、framework 自動 retry。Production team 用這個防 hallucinate。
+Pydantic AI 把 **schema validation（格式規則檢查）** 放進程式：LLM 不照 schema 時，framework 可以拒絕或重試。它能檢查形狀，**不能證明答案內容是真的**。
 
 ## 怎麼跑 — 兩條路徑
 
+> ⚠️ **每個練習都要有自己的 Python 3.11 `.venv`。** 不要把這題的 Pydantic 需求與 CrewAI 練習混裝。
+
 ### Path A（默認、本機免費）
 
-```bash
-pip install -r requirements.txt
+```powershell
+py -3.11 -m venv .venv
+.\.venv\Scripts\python.exe -m pip install -r requirements.txt
 ollama pull qwen2.5:3b
 ollama serve
-python starter.py
+.\.venv\Scripts\python.exe starter.py
 ```
 
-預算：**$0**。但 qwen2.5:3b 可能 retry 多次才產對 schema、總 token 較高。
+預算：模型 API 是 **$0**；本機硬體、電力與重試時間仍有成本。
 
-### Path B（Anthropic、想看 cloud 高品質）
+### Path B（Anthropic、比較雲端結果）
+
+```powershell
+$env:ANTHROPIC_API_KEY="sk-ant-..."
+.\.venv\Scripts\python.exe starter_anthropic.py
+```
+
+預設固定型號：`claude-haiku-4-5-20251001`。若一次請求用 2,000 input + 1,000 output tokens：`2,000 / 1,000,000 × $1 + 1,000 / 1,000,000 × $5 = $0.007`。驗證失敗可能重試；先設供應商支出上限 **$0.05**。
+
+<details markdown="1">
+<summary>macOS／Linux 指令與查核資訊</summary>
 
 ```bash
-pip install -r requirements.txt
-export ANTHROPIC_API_KEY=sk-ant-...
-python starter_anthropic.py
+python3.11 -m venv .venv
+./.venv/bin/python -m pip install -r requirements.txt
+export ANTHROPIC_API_KEY="sk-ant-..."
+./.venv/bin/python test.py
 ```
 
-預算：每次 ≈ **$0.001**（claude-haiku-4-5、通常一次過、無 retry）。
+官方來源：[Pydantic AI output](https://ai.pydantic.dev/output/)｜[Pydantic AI testing](https://ai.pydantic.dev/testing/)｜[Anthropic pricing](https://platform.claude.com/docs/en/about-claude/pricing)
+
+<small>套件、model ID、價格與官方連結查核：2026-08-28 UTC。</small>
+</details>
 
 ## 不花錢驗證程式邏輯
 
-```bash
-python test.py # Pydantic schema 驗證 + agent 結構
-python test_anthropic.py # Path B 載入檢查
+```powershell
+.\.venv\Scripts\python.exe test.py # 官方 TestModel + schema 邊界
+.\.venv\Scripts\python.exe test_anthropic.py # Anthropic 設定 + 相同輸出契約
 ```
 
 `test.py` 直接驗 `AnswerWithConfidence` 對非法資料（confidence > 1.0、type 不對、sources 不是 list）的 ValidationError——不需要打 LLM、純 type 層測試。
@@ -66,7 +83,8 @@ Stage 3 練習 6：schema = JSON Schema in prompt
 
 Stage 4 練習 5：schema = Pydantic model in code
     LLM 違反 → framework 自動 raise → retry / 修
-    最終 output 一定 conform（runtime 保證）
+    成功回傳的 output 已通過 runtime 格式檢查
+    內容是否正確仍要另外驗證
 ```
 
 對 production：
@@ -76,9 +94,9 @@ Stage 4 練習 5：schema = Pydantic model in code
 | LLM 偶爾少欄位 | 你的下游 code 要 try/except | 自動 retry 直到符合 |
 | 型別錯（confidence="high"） | 下游 crash | Pydantic ValidationError、retry |
 | 邊界錯（confidence=1.5） | 下游用錯誤值 | 拒絕、retry |
-| LLM hallucinate 多餘欄位 | 接收 silently | 預設 ignore（可調 strict） |
+| 多餘欄位 | 依你的 parser 而定 | 依 Pydantic model 設定處理 |
 
-**結論**：production agent 必用 type-safe output。Stage 3 練習 6 教 schema 設計、Stage 4 練習 5 教把 schema 變成 runtime contract。
+**結論**：下游程式需要固定欄位時，typed output 很有用。Stage 3 練習 6 教 schema 設計；這題把 schema 變成 runtime contract，再提醒你補上事實查核。
 
 ## Pydantic AI 核心觀念
 
@@ -94,7 +112,7 @@ result = agent.run_sync(question)
 answer: AnswerWithConfidence = result.output # 已驗證的物件
 ```
 
-**重點**：framework 在背後把 Pydantic schema 轉成 LLM 的 structured output instruction、執行 validation、failure 時 retry。
+**重點**：framework 把 Pydantic schema 轉成 structured output 指示，執行 validation，失敗時依設定重試。重試成功只表示格式合格。
 
 ### Field constraints
 
@@ -116,31 +134,31 @@ Pydantic AI 看到 ValidationError、會把錯誤訊息塞回 prompt、要求 LL
 
 | 觀察項 | Anthropic Claude haiku | Ollama qwen2.5:3b |
 |---|---|---|
-| 一次產對 schema | 90%+ | 50-70% |
-| 平均 retry 次數 | 0-1 | 1-3 |
-| confidence 邊界遵守 | 穩 | 偶爾 1.5 / 負值（會被 reject + retry） |
-| sources 是 list | 穩 | 偶爾 string、被 reject |
-| 總 token 成本 | 低（少 retry） | 高（多 retry） |
+| 一次產對 schema | 用相同題組量測 | 用相同題組量測 |
+| retry 次數 | 記錄實際結果 | 記錄實際結果 |
+| confidence 邊界 | 由 Pydantic 驗證 | 由 Pydantic 驗證 |
+| sources 是 list | 由 Pydantic 驗證 | 由 Pydantic 驗證 |
+| 成本 | 依 tokens 與重試次數 | 模型 API $0 |
 
-**反直覺結論**：Path B（Claude）的實際 token cost **可能比 Path A（qwen）低**——retry 成本累計起來。Production team 算總帳會選大 model。
+**教學重點**：比較模型時要一起記錄成功率、重試次數、延遲與費用；不要只看單次 token 價格，也不要先假設大模型一定比較省。
 
 ## 常見坑
 
-- **`output_type` 太複雜**：nested model 深、LLM 難一次寫對。production 建議扁平化、≤5 個 top-level 欄位
+- **`output_type` 太複雜**：nested model 越深越難產生與維護。先用最少必要欄位，再用評測決定是否拆分
 - **缺 `description`**：`Field(...)` 沒寫 `description=`、LLM 看不到欄位用途、易誤填
-- **`retries=0`**：失敗就 raise、不給 LLM 修的機會。經驗值 `retries=1-3`
+- **`retries=0`**：失敗就 raise。重試次數要依費用、延遲與失敗模式設定，並保留上限
 - **小 model + 深 nested**：qwen2.5:3b 可能 retry 多次仍不對。換大 model 或扁平 schema
 
 ## 想看更聰明的答案？
 
-```bash
-MODEL=claude-sonnet-5 python starter_anthropic.py # 一次過機率最高
-MODEL=qwen2.5:7b python starter.py # 較大本機 model
+```powershell
+$env:MODEL="claude-sonnet-5"; .\.venv\Scripts\python.exe starter_anthropic.py
+$env:MODEL="qwen2.5:7b"; .\.venv\Scripts\python.exe starter.py
 ```
 
 ## 延伸
 
 - **加 tools**：Pydantic AI agent 可以同時有 tools + structured output、`@agent.tool` 裝飾函式
 - **stream typed output**：`agent.run_stream(...)` 邊跑邊驗
-- **跨 model 比較**：同一個 schema 跑 Claude / GPT / Gemini / 本機 model、看誰最穩
+- **跨 model 比較**：同一個 schema 跑 Claude / GPT / Gemini / 本機 model，比較通過率、重試與成本
 - **接 production**：Pydantic AI 跟 FastAPI 整合很好、output 直接當 API response model

--- a/examples/stage-4/05-typed-agent/README.zh-Hans.md
+++ b/examples/stage-4/05-typed-agent/README.zh-Hans.md
@@ -20,43 +20,60 @@ Agent 回问题、**强制** return `AnswerWithConfidence`：
 ```python
 class AnswerWithConfidence(BaseModel):
     answer: str
-    confidence: float = Field(ge=0.0, le=1.0)  # runtime 验证 0-1
+    confidence: float = Field(ge=0.0, le=1.0) # runtime 验证 0-1
     sources: list[str]
 ```
 
-Pydantic AI 把 schema validation 从 prompt 层（Stage 3 练习 6）**提升到 type 层**——LLM 不照 schema、framework 自动 retry。Production team 用这个防 hallucinate。
+Pydantic AI 把 **schema validation（格式规则检查）** 放进程序：LLM 不照 schema 时，framework 可以拒绝或重试。它能检查形状，**不能证明答案内容是真的**。
 
 ## 怎么跑 — 两条路径
 
+> ⚠️ **每个练习都要有自己的 Python 3.11 `.venv`。** 不要把这题的 Pydantic 需求与 CrewAI 练习混装。
+
 ### Path A（默认、本机免费）
 
-```bash
-pip install -r requirements.txt
+```powershell
+py -3.11 -m venv .venv
+.\.venv\Scripts\python.exe -m pip install -r requirements.txt
 ollama pull qwen2.5:3b
 ollama serve
-python starter.py
+.\.venv\Scripts\python.exe starter.py
 ```
 
-预算：**$0**。但 qwen2.5:3b 可能 retry 多次才产对 schema、总 token 较高。
+预算：模型 API 是 **$0**；本机硬体、电力与重试时间仍有成本。
 
-### Path B（Anthropic、想看 cloud 高质量）
+### Path B（Anthropic、比较云端结果）
+
+```powershell
+$env:ANTHROPIC_API_KEY="sk-ant-..."
+.\.venv\Scripts\python.exe starter_anthropic.py
+```
+
+预设固定型号：`claude-haiku-4-5-20251001`。若一次请求用 2,000 input + 1,000 output tokens：`2,000 / 1,000,000 × $1 + 1,000 / 1,000,000 × $5 = $0.007`。验证失败可能重试；先设供应商支出上限 **$0.05**。
+
+<details markdown="1">
+<summary>macOS／Linux 指令与查核资讯</summary>
 
 ```bash
-pip install -r requirements.txt
-export ANTHROPIC_API_KEY=sk-ant-...
-python starter_anthropic.py
+python3.11 -m venv .venv
+./.venv/bin/python -m pip install -r requirements.txt
+export ANTHROPIC_API_KEY="sk-ant-..."
+./.venv/bin/python test.py
 ```
 
-预算：每次 ≈ **$0.001**（claude-haiku-4-5、通常一次过、无 retry）。
+官方来源：[Pydantic AI output](https://ai.pydantic.dev/output/)｜[Pydantic AI testing](https://ai.pydantic.dev/testing/)｜[Anthropic pricing](https://platform.claude.com/docs/en/about-claude/pricing)
+
+<small>套件、model ID、价格与官方连结查核：2026-08-28 UTC。</small>
+</details>
 
 ## 不花钱验证程序逻辑
 
-```bash
-python test.py             # Pydantic schema 验证 + agent 结构
-python test_anthropic.py   # Path B 载入检查
+```powershell
+.\.venv\Scripts\python.exe test.py # 官方 TestModel + schema 边界
+.\.venv\Scripts\python.exe test_anthropic.py # Anthropic 设定 + 相同输出契约
 ```
 
-`test.py` 直接验 `AnswerWithConfidence` 对非法数据（confidence > 1.0、type 不对、sources 不是 list）的 ValidationError——不需要打 LLM、纯 type 层测试。
+`test.py` 直接验 `AnswerWithConfidence` 对非法资料（confidence > 1.0、type 不对、sources 不是 list）的 ValidationError——不需要打 LLM、纯 type 层测试。
 
 ## 为什么 type-safe agent 重要
 
@@ -66,19 +83,20 @@ Stage 3 练习 6：schema = JSON Schema in prompt
 
 Stage 4 练习 5：schema = Pydantic model in code
     LLM 违反 → framework 自动 raise → retry / 修
-    最终 output 一定 conform（runtime 保证）
+    成功回传的 output 已通过 runtime 格式检查
+    内容是否正确仍要另外验证
 ```
 
 对 production：
 
 | 需求 | 纯 prompt schema | Pydantic AI |
 |---|---|---|
-| LLM 偶尔少字段 | 你的下游 code 要 try/except | 自动 retry 直到符合 |
-| 类型错（confidence="high"） | 下游 crash | Pydantic ValidationError、retry |
+| LLM 偶尔少栏位 | 你的下游 code 要 try/except | 自动 retry 直到符合 |
+| 型别错（confidence="high"） | 下游 crash | Pydantic ValidationError、retry |
 | 边界错（confidence=1.5） | 下游用错误值 | 拒绝、retry |
-| LLM hallucinate 多余字段 | 接收 silently | 预设 ignore（可调 strict） |
+| 多余栏位 | 依你的 parser 而定 | 依 Pydantic model 设定处理 |
 
-**结论**：production agent 必用 type-safe output。Stage 3 练习 6 教 schema 设计、Stage 4 练习 5 教把 schema 变成 runtime contract。
+**结论**：下游程序需要固定栏位时，typed output 很有用。Stage 3 练习 6 教 schema 设计；这题把 schema 变成 runtime contract，再提醒你补上事实查核。
 
 ## Pydantic AI 核心观念
 
@@ -87,14 +105,14 @@ Stage 4 练习 5：schema = Pydantic model in code
 ```python
 agent = Agent(
     model=...,
-    output_type=AnswerWithConfidence,   # ← 强制 LLM 回这个 shape
+    output_type=AnswerWithConfidence, # ← 强制 LLM 回这个 shape
     system_prompt="..."
 )
 result = agent.run_sync(question)
-answer: AnswerWithConfidence = result.output   # 已验证的物件
+answer: AnswerWithConfidence = result.output # 已验证的物件
 ```
 
-**重点**：framework 在背后把 Pydantic schema 转成 LLM 的 structured output instruction、执行 validation、failure 时 retry。
+**重点**：framework 把 Pydantic schema 转成 structured output 指示，执行 validation，失败时依设定重试。重试成功只表示格式合格。
 
 ### Field constraints
 
@@ -107,7 +125,7 @@ confidence: float = Field(ge=0.0, le=1.0, description="...")
 ### 自动 retry
 
 ```python
-Agent(..., retries=3)  # default 1，可调
+Agent(..., retries=3) # default 1，可调
 ```
 
 Pydantic AI 看到 ValidationError、会把错误讯息塞回 prompt、要求 LLM 重产。
@@ -116,31 +134,31 @@ Pydantic AI 看到 ValidationError、会把错误讯息塞回 prompt、要求 LL
 
 | 观察项 | Anthropic Claude haiku | Ollama qwen2.5:3b |
 |---|---|---|
-| 一次产对 schema | 90%+ | 50-70% |
-| 平均 retry 次数 | 0-1 | 1-3 |
-| confidence 边界遵守 | 稳 | 偶尔 1.5 / 负值（会被 reject + retry） |
-| sources 是 list | 稳 | 偶尔 string、被 reject |
-| 总 token 成本 | 低（少 retry） | 高（多 retry） |
+| 一次产对 schema | 用相同题组量测 | 用相同题组量测 |
+| retry 次数 | 记录实际结果 | 记录实际结果 |
+| confidence 边界 | 由 Pydantic 验证 | 由 Pydantic 验证 |
+| sources 是 list | 由 Pydantic 验证 | 由 Pydantic 验证 |
+| 成本 | 依 tokens 与重试次数 | 模型 API $0 |
 
-**反直觉结论**：Path B（Claude）的实际 token cost **可能比 Path A（qwen）低**——retry 成本累计起来。Production team 算总帐会选大 model。
+**教学重点**：比较模型时要一起记录成功率、重试次数、延迟与费用；不要只看单次 token 价格，也不要先假设大模型一定比较省。
 
 ## 常见坑
 
-- **`output_type` 太复杂**：nested model 深、LLM 难一次写对。production 建议扁平化、≤5 个 top-level 字段
-- **缺 `description`**：`Field(...)` 没写 `description=`、LLM 看不到字段用途、易误填
-- **`retries=0`**：失败就 raise、不给 LLM 修的机会。经验值 `retries=1-3`
+- **`output_type` 太复杂**：nested model 越深越难产生与维护。先用最少必要栏位，再用评测决定是否拆分
+- **缺 `description`**：`Field(...)` 没写 `description=`、LLM 看不到栏位用途、易误填
+- **`retries=0`**：失败就 raise。重试次数要依费用、延迟与失败模式设定，并保留上限
 - **小 model + 深 nested**：qwen2.5:3b 可能 retry 多次仍不对。换大 model 或扁平 schema
 
 ## 想看更聪明的答案？
 
-```bash
-MODEL=claude-sonnet-5 python starter_anthropic.py    # 一次过机率最高
-MODEL=qwen2.5:7b python starter.py                      # 较大本机 model
+```powershell
+$env:MODEL="claude-sonnet-5"; .\.venv\Scripts\python.exe starter_anthropic.py
+$env:MODEL="qwen2.5:7b"; .\.venv\Scripts\python.exe starter.py
 ```
 
 ## 延伸
 
 - **加 tools**：Pydantic AI agent 可以同时有 tools + structured output、`@agent.tool` 装饰函数
 - **stream typed output**：`agent.run_stream(...)` 边跑边验
-- **跨 model 比较**：同一个 schema 跑 Claude / GPT / Gemini / 本机 model、看谁最稳
+- **跨 model 比较**：同一个 schema 跑 Claude / GPT / Gemini / 本机 model，比较通过率、重试与成本
 - **接 production**：Pydantic AI 跟 FastAPI 整合很好、output 直接当 API response model

--- a/examples/stage-4/05-typed-agent/requirements.txt
+++ b/examples/stage-4/05-typed-agent/requirements.txt
@@ -1,2 +1,2 @@
-pydantic-ai>=0.0.20,<2.0
-pydantic>=2.6,<3.0
+pydantic-ai>=2.35,<3.0
+pydantic>=2.13,<3.0

--- a/examples/stage-4/05-typed-agent/starter.py
+++ b/examples/stage-4/05-typed-agent/starter.py
@@ -1,23 +1,7 @@
-"""Stage 4 練習 5：型別安全 agent — Pydantic AI + Ollama（Path A、默認）。
+"""Stage 4 練習 5：用 Pydantic AI ``output_type`` 檢查輸出形狀。
 
-Pydantic AI 把「structured output」變成型別系統的一級成員：
-- Agent 回傳必須 conform to Pydantic model
-- runtime validation 自動跑（譬如 confidence 必須是 float、不是 string）
-- 失敗時 LLM 會被告知 schema、retry 再 produce
-
-任務：問問題、agent 回 `{"answer": str, "confidence": float, "sources": [str]}`。
-
-跑法：
-    pip install -r requirements.txt
-    ollama pull qwen2.5:3b
-    ollama serve
-    python starter.py
-
-驗證：
-    python test.py
-
-⚠️ 注意：Pydantic AI 對 model 的 instruction following 要求高。
-qwen2.5:3b 可能多 retry 才產對 schema、Claude haiku 通常一次過。
+型別檢查像表格的格子：它能確保欄位存在、種類正確、數字在範圍內，
+但不能證明內容是真的。真實性仍要靠可信來源與額外的語意檢查。
 """
 
 from __future__ import annotations
@@ -29,59 +13,64 @@ from typing import Any
 if hasattr(sys.stdout, "reconfigure"):
     sys.stdout.reconfigure(encoding="utf-8", errors="replace")
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from pydantic_ai import Agent
-from pydantic_ai.models.openai import OpenAIModel
+from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.providers.openai import OpenAIProvider
 
 MODEL = os.environ.get("MODEL", "qwen2.5:3b")
 OLLAMA_BASE = os.environ.get("OLLAMA_API_BASE", "http://localhost:11434/v1")
 
 
-# === Schema：agent 強制要回這個 shape ===
-
 class AnswerWithConfidence(BaseModel):
-    """Structured answer the agent must produce."""
-    answer: str = Field(description="The actual answer text.")
-    confidence: float = Field(ge=0.0, le=1.0, description="Confidence score 0-1.")
-    sources: list[str] = Field(description="Sources or references used.")
+    """已驗證的資料形狀；它不是答案為真的證據。"""
+    answer: str = Field(min_length=1, description="A non-empty, cautious answer.")
+    confidence: float = Field(ge=0.0, le=1.0, description="Confidence from 0.0 through 1.0.")
+    sources: list[str] = Field(min_length=1, description="At least one non-empty source label.")
+
+    @field_validator("answer")
+    @classmethod
+    def answer_is_not_blank(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("answer must not be blank")
+        return value.strip()
+
+    @field_validator("sources")
+    @classmethod
+    def sources_are_nonempty_labels(cls, value: list[str]) -> list[str]:
+        if not all(isinstance(item, str) and item.strip() for item in value):
+            raise ValueError("sources must contain non-empty strings")
+        return [item.strip() for item in value]
 
 
-def build_agent(model: Any = None) -> Agent:
-    if model is None:
-        model = OpenAIModel(
-            MODEL,
-            provider=OpenAIProvider(base_url=OLLAMA_BASE, api_key="ollama"),
-        )
+def make_ollama_model() -> OpenAIChatModel:
+    """用目前 Pydantic AI 的 OpenAIChatModel 連到本機 Ollama。"""
+    return OpenAIChatModel(MODEL, provider=OpenAIProvider(base_url=OLLAMA_BASE, api_key="ollama"))
+
+
+def build_agent(model: Any | None = None) -> Agent:
+    """建立會重試兩次、並要求 AnswerWithConfidence 的 agent。"""
     return Agent(
-        model=model,
+        model or make_ollama_model(),
         output_type=AnswerWithConfidence,
-        system_prompt=(
-            "You answer questions. ALWAYS return a structured answer with "
-            "an 'answer' text, a 'confidence' float (0.0 to 1.0), and a list of 'sources'. "
-            "If you don't know, set confidence low and explain in answer."
+        retries=2,
+        instructions=(
+            "Return a cautious AnswerWithConfidence. Use a non-empty answer, a confidence between 0 and 1, "
+            "and at least one source label. A valid schema does not establish semantic truth."
         ),
     )
 
 
-def run(question: str, model: Any = None) -> AnswerWithConfidence:
-    agent = build_agent(model=model)
-    result = agent.run_sync(question)
-    return result.output
+def run(question: str, model: Any | None = None) -> AnswerWithConfidence:
+    """執行 agent，並在回傳前再檢查本練習的結果契約。"""
+    output = build_agent(model).run_sync(question).output
+    if not output.answer or not output.sources or not 0.0 <= output.confidence <= 1.0:
+        raise RuntimeError("Validated output did not meet the exercise's result contract.")
+    return output
 
 
 if __name__ == "__main__":
-    question = "What is the population of Taipei?"
-    print(f"❓ Q: {question}（using Pydantic AI + Ollama {MODEL}）")
-    print("-" * 60)
-    answer = run(question)
-    print(f"  answer:     {answer.answer}")
-    print(f"  confidence: {answer.confidence}")
-    print(f"  sources:    {answer.sources}")
-
-    # Pydantic 已經保證 type 正確、這裡只 sanity check
-    assert isinstance(answer.confidence, float)
+    answer = run("What is the population of Taipei?")
+    print(answer.model_dump())
     assert 0.0 <= answer.confidence <= 1.0
-    assert isinstance(answer.sources, list)
-    print("\n✅ 練習 5 通過 — Pydantic AI 強制 structured output、$0/run")
-    print("   schema validation 在 runtime 自動跑、LLM 不能偷懶")
+    assert answer.answer and answer.sources

--- a/examples/stage-4/05-typed-agent/starter_anthropic.py
+++ b/examples/stage-4/05-typed-agent/starter_anthropic.py
@@ -1,15 +1,4 @@
-"""Stage 4 練習 5：型別安全 agent — Pydantic AI + Anthropic（Path B）。
-
-Pydantic AI 對 Anthropic 是一級支援、用 'anthropic:claude-haiku-4-5' 字串即可建 model。
-
-跑法：
-    pip install -r requirements.txt
-    export ANTHROPIC_API_KEY=sk-ant-...
-    python starter_anthropic.py
-
-預算：每次 ≈ $0.001（claude-haiku-4-5）。Claude 對 structured output 穩很多——
-schema validation retry 機率小、實際 token 成本通常比 qwen2.5:3b 還少。
-"""
+"""Stage 4 練習 5 Path B：用固定 Anthropic model ID 跑同一個輸出契約。"""
 
 from __future__ import annotations
 
@@ -20,20 +9,18 @@ if hasattr(sys.stdout, "reconfigure"):
     sys.stdout.reconfigure(encoding="utf-8", errors="replace")
 
 from pydantic_ai.models.anthropic import AnthropicModel
-
 from starter import run
 
-MODEL = os.environ.get("MODEL", "claude-haiku-4-5")
+MODEL = os.environ.get("MODEL", "claude-haiku-4-5-20251001")
+
+
+def make_anthropic_model() -> AnthropicModel:
+    """建立 Pydantic AI 目前支援的 Anthropic model 物件。"""
+    return AnthropicModel(MODEL)
 
 
 if __name__ == "__main__":
-    question = "What is the population of Taipei?"
-    print(f"❓ Q: {question}（using Pydantic AI + Anthropic {MODEL}）")
-    print("-" * 60)
-    model = AnthropicModel(MODEL)
-    answer = run(question, model=model)
-    print(f"  answer:     {answer.answer}")
-    print(f"  confidence: {answer.confidence}")
-    print(f"  sources:    {answer.sources}")
-    assert isinstance(answer.confidence, float)
-    print("\n✅ 練習 5 (Anthropic path) 通過 — Claude structured output 穩、≈$0.001/run")
+    answer = run("What is the population of Taipei?", model=make_anthropic_model())
+    print(answer.model_dump())
+    assert answer.answer and answer.sources
+    assert 0.0 <= answer.confidence <= 1.0

--- a/examples/stage-4/05-typed-agent/test.py
+++ b/examples/stage-4/05-typed-agent/test.py
@@ -1,13 +1,4 @@
-"""Stage 4 練習 5 自我驗證 — Pydantic AI schema 邏輯 + 型別約束。
-
-跑法：
-    python test.py
-
-驗證內容：
-    - AnswerWithConfidence schema：必填欄位、confidence 邊界、type 約束
-    - Pydantic 對非法資料會 raise ValidationError
-    - build_agent 接受 mock model、Agent 物件結構正確
-"""
+"""Path A 離線行為測試：使用 Pydantic AI 官方 TestModel，不連網。"""
 
 from __future__ import annotations
 
@@ -16,69 +7,35 @@ import sys
 if hasattr(sys.stdout, "reconfigure"):
     sys.stdout.reconfigure(encoding="utf-8", errors="replace")
 
-import pytest
 from pydantic import ValidationError
-
-from starter import AnswerWithConfidence, build_agent
-
-
-def test_valid_answer_constructs():
-    a = AnswerWithConfidence(answer="Taipei pop is 2.6M", confidence=0.9, sources=["wiki"])
-    assert a.confidence == 0.9
-    assert a.sources == ["wiki"]
-    print("✅ test_valid_answer_constructs")
+from pydantic_ai.models.test import TestModel
+from starter import AnswerWithConfidence, run
 
 
-def test_confidence_out_of_range_rejected():
-    """confidence > 1.0 應該被 Pydantic 拒絕。"""
-    try:
-        AnswerWithConfidence(answer="...", confidence=1.5, sources=[])
-    except ValidationError:
-        print("✅ test_confidence_out_of_range_rejected")
-        return
-    raise AssertionError("expected ValidationError for confidence=1.5")
+def test_official_test_model_produces_valid_typed_output() -> None:
+    model = TestModel(custom_output_args={"answer": "Offline answer", "confidence": 0.6, "sources": ["offline fixture"]})
+    answer = run("Test question", model=model)
+    assert answer.answer == "Offline answer"
+    assert answer.sources == ["offline fixture"]
 
 
-def test_confidence_must_be_float():
-    """confidence 傳 string 應被 Pydantic 拒絕（schema validation 的核心）。"""
-    try:
-        AnswerWithConfidence(answer="...", confidence="high", sources=[])  # type: ignore
-    except ValidationError:
-        print("✅ test_confidence_must_be_float")
-        return
-    raise AssertionError("expected ValidationError for confidence='high'")
-
-
-def test_sources_must_be_list():
-    try:
-        AnswerWithConfidence(answer="...", confidence=0.5, sources="wiki")  # type: ignore
-    except ValidationError:
-        print("✅ test_sources_must_be_list")
-        return
-    raise AssertionError("expected ValidationError for sources='wiki'")
-
-
-def test_build_agent_ok():
-    """build_agent 帶 mock model 可建構、output_type 正確。"""
-    class FakeModel:
-        pass
-    try:
-        agent = build_agent(model=FakeModel())  # pydantic-ai 不會在這裡打 API
-    except Exception as e:
-        # 某些版本 build 時就 validate model、放寬：能 import + AnswerWithConfidence 是 output_type 即可
-        from starter import AnswerWithConfidence as AWC
-        print(f"⚠ build_agent 在某些版本需要 real model（{type(e).__name__}）、僅驗 schema 結構")
-        assert AWC.model_fields  # pydantic v2 API
-        print("✅ test_build_agent_ok (schema-only check)")
-        return
-    assert agent is not None
-    print("✅ test_build_agent_ok")
+def test_invalid_contract_values_are_rejected() -> None:
+    invalid = [
+        {"answer": "ok", "confidence": 1.1, "sources": ["source"]},
+        {"answer": "ok", "confidence": 0.5, "sources": "source"},
+        {"answer": " ", "confidence": 0.5, "sources": ["source"]},
+        {"answer": "ok", "confidence": 0.5, "sources": []},
+    ]
+    for payload in invalid:
+        try:
+            AnswerWithConfidence.model_validate(payload)
+        except ValidationError:
+            pass
+        else:
+            raise AssertionError(f"Expected validation failure for {payload!r}")
 
 
 if __name__ == "__main__":
-    test_valid_answer_constructs()
-    test_confidence_out_of_range_rejected()
-    test_confidence_must_be_float()
-    test_sources_must_be_list()
-    test_build_agent_ok()
-    print("\n🎉 全部通過 — Pydantic schema validation 邏輯正確")
+    test_official_test_model_produces_valid_typed_output()
+    test_invalid_contract_values_are_rejected()
+    print("all pass")

--- a/examples/stage-4/05-typed-agent/test_anthropic.py
+++ b/examples/stage-4/05-typed-agent/test_anthropic.py
@@ -1,30 +1,33 @@
-"""Stage 4 練習 5 — Path B 載入檢查。
-
-實測請跑 starter_anthropic.py 配 ANTHROPIC_API_KEY。
-"""
+"""Path B 離線行為測試：檢查 Anthropic 設定，再用官方 TestModel 執行。"""
 
 from __future__ import annotations
 
 import sys
+import os
 
 if hasattr(sys.stdout, "reconfigure"):
     sys.stdout.reconfigure(encoding="utf-8", errors="replace")
 
-
-def test_anthropic_model_importable():
-    from pydantic_ai.models.anthropic import AnthropicModel
-    assert AnthropicModel is not None
-    print("✅ test_anthropic_model_importable")
+from pydantic_ai.models.test import TestModel
+from starter import run
+from starter_anthropic import MODEL, make_anthropic_model
 
 
-def test_starter_anthropic_loadable():
-    import starter_anthropic
-    assert hasattr(starter_anthropic, "MODEL")
-    assert "claude" in starter_anthropic.MODEL
-    print("✅ test_starter_anthropic_loadable")
+def test_anthropic_provider_construction() -> None:
+    os.environ.setdefault("ANTHROPIC_API_KEY", "offline-test-key")
+    model = make_anthropic_model()
+    assert MODEL == "claude-haiku-4-5-20251001"
+    assert model.model_name == MODEL
+
+
+def test_path_b_behavior_with_official_offline_model() -> None:
+    offline = TestModel(custom_output_args={"answer": "Offline Anthropic-path answer", "confidence": 0.4, "sources": ["fixture"]})
+    answer = run("Test question", model=offline)
+    assert answer.answer.startswith("Offline Anthropic")
+    assert answer.confidence == 0.4
 
 
 if __name__ == "__main__":
-    test_anthropic_model_importable()
-    test_starter_anthropic_loadable()
-    print("\n🎉 通過 — Path B 可載入（實測需 ANTHROPIC_API_KEY）")
+    test_anthropic_provider_construction()
+    test_path_b_behavior_with_official_offline_model()
+    print("all pass")

--- a/resources/style-guide.en.md
+++ b/resources/style-guide.en.md
@@ -252,7 +252,7 @@ Time, cost, code, expected output, and troubleshooting.
 
 </details>
 
-Every runnable folder must provide copy-ready PowerShell commands first, followed by a closed `<details>` block with the macOS/Linux alternative; it must also provide Path A and Path B scripts plus offline mock tests. Bound SDK dependencies to major versions and use a pinned cloud model ID; validate untrusted tool names and arguments before execution. Describe cloud cost as a token formula with a verification date, rather than assuming a fixed amount.
+Every runnable folder must provide copy-ready PowerShell commands first, followed by a closed `<details>` block with the macOS/Linux alternative; it must also provide Path A and Path B scripts plus offline mock tests. Bound SDK dependencies to major versions and use a pinned cloud model ID; validate untrusted tool names and arguments before execution. Describe cloud cost as a token formula with a verification date, rather than assuming a fixed amount. Give examples for different frameworks separate Python 3.11 `.venv` environments; do not combine their requirements. Tests must exercise the core behavior—an import-only check does not pass.
 
 [3-5 hands-on exercise items]
 

--- a/resources/style-guide.md
+++ b/resources/style-guide.md
@@ -250,7 +250,7 @@ PR 之前請先讀完本文。專案維護者也會用這份指南做 review。
 
 </details>
 
-可執行資料夾必須先提供可直接複製的 PowerShell 指令，再用預設收合的 `<details>` 提供 macOS/Linux 替代指令；同時提供 Path A 與 Path B 腳本，以及不打 API 的 offline mock tests。SDK 依賴要限制 major version，cloud model 要使用釘住的 model ID；執行前必須驗證不受信任的工具名稱與參數。Cloud 成本寫成 token 公式並標示核對日期，不要假設一個固定金額。
+可執行資料夾必須先提供可直接複製的 PowerShell 指令，再用預設收合的 `<details>` 提供 macOS/Linux 替代指令；同時提供 Path A 與 Path B 腳本，以及不打 API 的 offline mock tests。SDK 依賴要限制 major version，cloud model 要使用釘住的 model ID；執行前必須驗證不受信任的工具名稱與參數。Cloud 成本寫成 token 公式並標示核對日期，不要假設一個固定金額。不同 framework 的範例各自建立 Python 3.11 `.venv`，不要合併 requirements。測試必須走過核心行為；只驗 import 成功不算通過。
 
 [3-5 個動手練習 items]
 

--- a/resources/style-guide.zh-Hans.md
+++ b/resources/style-guide.zh-Hans.md
@@ -253,7 +253,7 @@ PR 之前请先读完本文。项目维护者也会用这份指南做 review。
 
 </details>
 
-可运行文件夹必须先提供可直接复制的 PowerShell 指令，再用默认收合的 `<details>` 提供 macOS/Linux 替代指令；同时提供 Path A 和 Path B 脚本，以及不调用 API 的 offline mock tests。SDK 依赖要限制 major version，cloud model 要使用钉住的 model ID；执行前必须验证不受信任的工具名称和参数。Cloud 成本写成 token 公式并标注核对日期，不要假设一个固定金额。
+可运行文件夹必须先提供可直接复制的 PowerShell 指令，再用默认收合的 `<details>` 提供 macOS/Linux 替代指令；同时提供 Path A 和 Path B 脚本，以及不调用 API 的 offline mock tests。SDK 依赖要限制 major version，cloud model 要使用钉住的 model ID；执行前必须验证不受信任的工具名称和参数。Cloud 成本写成 token 公式并标注核对日期，不要假设一个固定金额。不同 framework 的示例各自创建 Python 3.11 `.venv`，不要合并 requirements。测试必须走过核心行为；只验证 import 成功不算通过。
 
 [3-5 个动手练习 items]
 

--- a/scripts/test_stage04_examples.py
+++ b/scripts/test_stage04_examples.py
@@ -1,0 +1,157 @@
+"""Structural regression gate for the five current Stage 4 runnable examples."""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+STAGE = ROOT / "examples" / "stage-4"
+README_NAMES = ("README.md", "README.en.md", "README.zh-Hans.md")
+ENTRY_NAMES = ("starter.py", "starter_anthropic.py", "test.py", "test_anthropic.py")
+SPECS = {
+    "01-same-agent-two-frameworks": {
+        "requirements": {
+            "langgraph>=1.2,<2.0", "langchain-openai>=1.6,<2.0", "langchain-anthropic>=1.7,<2.0",
+            "langchain-core>=1.6,<2.0", "crewai>=1.15,<2.0",
+        },
+        "primary_urls": {"https://docs.langchain.com/oss/python/langgraph/overview", "https://docs.crewai.com/", "https://platform.claude.com/docs/en/about-claude/pricing"},
+        "literals": ("StateGraph", "Crew", "claude-haiku-4-5-20251001"),
+        "budget_cap": "$0.05",
+        "model_id": "claude-haiku-4-5-20251001",
+    },
+    "02-multi-agent-roles": {
+        "requirements": {"crewai[anthropic]>=1.15,<2.0", "litellm>=1.98,<2.0"},
+        "primary_urls": {"https://docs.crewai.com/", "https://docs.litellm.ai/", "https://platform.claude.com/docs/en/about-claude/pricing"},
+        "literals": ("Process.sequential", "max_iter=4", "anthropic/claude-haiku-4-5-20251001"),
+        "budget_cap": "$0.10",
+        "model_id": "anthropic/claude-haiku-4-5-20251001",
+    },
+    "03-graph-workflow": {
+        "requirements": {"langgraph>=1.2,<2.0", "langchain-core>=1.6,<2.0", "langchain-openai>=1.6,<2.0", "langchain-anthropic>=1.7,<2.0"},
+        "primary_urls": {"https://docs.langchain.com/oss/python/langgraph/interrupts", "https://docs.langchain.com/oss/python/langgraph/persistence", "https://platform.claude.com/docs/en/about-claude/pricing"},
+        "literals": ("interrupt(", "Command(resume", "ChatAnthropic", "thread_id"),
+        "budget_cap": "$0.05",
+        "model_id": "claude-haiku-4-5-20251001",
+    },
+    "04-codeact-vs-json-tool": {
+        "requirements": {"smolagents[docker]>=1.26,<2.0", "litellm>=1.98,<2.0"},
+        "primary_urls": {
+            "https://huggingface.co/docs/smolagents/tutorials/secure_code_execution",
+            "https://huggingface.co/docs/smolagents/reference/python_executors",
+            "https://docs.docker.com/engine/network/port-publishing/",
+            "https://platform.claude.com/docs/en/about-claude/pricing",
+        },
+        "literals": ("ast.parse", 'executor_type: str = "docker"', '"host": "127.0.0.1"', '"network_mode": "bridge"', '"cap_drop": ["ALL"]', '"no-new-privileges"', "max_steps=4", "anthropic/claude-haiku-4-5-20251001"),
+        "budget_cap": "$0.10",
+        "model_id": "anthropic/claude-haiku-4-5-20251001",
+    },
+    "05-typed-agent": {
+        "requirements": {"pydantic-ai>=2.35,<3.0", "pydantic>=2.13,<3.0"},
+        "primary_urls": {"https://ai.pydantic.dev/output/", "https://ai.pydantic.dev/testing/", "https://platform.claude.com/docs/en/about-claude/pricing"},
+        "literals": ("output_type", "TestModel", "claude-haiku-4-5-20251001", "Field(min_length=1"),
+        "budget_cap": "$0.05",
+        "model_id": "claude-haiku-4-5-20251001",
+    },
+}
+FORBIDDEN = (r"\beval\s*\(", r"\bexec\s*\(", r"pytest\.skip", r"api[- ]?drift.{0,32}(skip|fallback)")
+README_FORBIDDEN = (
+    "90%+", "50-70%", "10-30 秒", "30-90 秒", "效果差 10 倍", "一次過機率最高",
+    "10-30s", "30-90s", "10× better", "highest one-shot", "cloud-quality",
+    "production agent 必用", "Production 多 agent 系統幾乎必用", "production agents must use",
+    "almost always use large models", "最穩", "最稳", "most stable", "interrupt_before", "update_state",
+    "HfApiModel", "crew.kickoff(stream=True)", "**改成 streaming**：`crew.kickoff_for_each", "**Streaming**: `crew.kickoff_for_each",
+)
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def urls_in(text: str) -> tuple[str, ...]:
+    return tuple(re.findall(r"https?://[^)\s]+", text))
+
+
+def test_stage_shape_and_dependencies() -> None:
+    directories = {path.name for path in STAGE.iterdir() if path.is_dir()}
+    require(directories == set(SPECS), f"Expected exactly {sorted(SPECS)}, found {sorted(directories)}")
+    for name, spec in SPECS.items():
+        folder = STAGE / name
+        require(all((folder / entry).is_file() for entry in ENTRY_NAMES), f"{name}: missing required Python entry file")
+        require(all((folder / readme).is_file() for readme in README_NAMES), f"{name}: missing README mirror")
+        requirements = {line.strip() for line in (folder / "requirements.txt").read_text(encoding="utf-8").splitlines() if line.strip()}
+        require(requirements == spec["requirements"], f"{name}: current-major requirements drifted: {requirements}")
+    require((STAGE / "01-same-agent-two-frameworks" / "starter_crewai.py").is_file(), "exercise 1: CrewAI comparison starter missing")
+    require((STAGE / "01-same-agent-two-frameworks" / "test_crewai.py").is_file(), "exercise 1: CrewAI comparison test missing")
+    require((STAGE / "04-codeact-vs-json-tool" / "test_docker_smoke.py").is_file(), "exercise 4: daemon-gated Docker smoke test missing")
+
+
+def test_python_safety_and_behavioral_entrypoints() -> None:
+    for name, spec in SPECS.items():
+        folder = STAGE / name
+        all_python = list(folder.glob("*.py"))
+        for path in all_python:
+            text = path.read_text(encoding="utf-8")
+            ast.parse(text, filename=str(path))
+            for pattern in FORBIDDEN:
+                require(not re.search(pattern, text, flags=re.IGNORECASE | re.DOTALL), f"{path}: forbidden {pattern}")
+        for test_name in ("test.py", "test_anthropic.py"):
+            text = (folder / test_name).read_text(encoding="utf-8")
+            require("def test_" in text and 'if __name__ == "__main__"' in text, f"{name}/{test_name}: needs a directly executable behavioral test")
+            require("all pass" in text, f"{name}/{test_name}: must report a direct test result")
+            require("importable" not in text.lower() and "loadable" not in text.lower(), f"{name}/{test_name}: import-only acceptance is not behavioral")
+        starter_text = "\n".join((folder / entry).read_text(encoding="utf-8") for entry in ("starter.py", "starter_anthropic.py"))
+        require(all(literal in starter_text or literal in "\n".join(path.read_text(encoding="utf-8") for path in all_python) for literal in spec["literals"]), f"{name}: missing required API or safety literal")
+
+
+def test_readme_mirrors_and_reader_contract() -> None:
+    for name, spec in SPECS.items():
+        texts = [(STAGE / name / readme).read_text(encoding="utf-8") for readme in README_NAMES]
+        canonical_urls = urls_in(texts[0])
+        parity_values = ("Python 3.11", "$0", "$0.007", spec["budget_cap"], "2026-08-28 UTC", spec["model_id"])
+        for readme, text in zip(README_NAMES, texts):
+            require("py -3.11 -m venv .venv" in text, f"{name}/{readme}: Python 3.11 venv creation missing")
+            require(r".\.venv\Scripts\python.exe -m pip install -r requirements.txt" in text, f"{name}/{readme}: PowerShell-first isolated install missing")
+            require(text.index(r".\.venv\Scripts\python.exe -m pip install -r requirements.txt") < text.index(r".\.venv\Scripts\python.exe test.py"), f"{name}/{readme}: install must precede offline test")
+            require(text.count(".venv") >= 5 and "requirements.txt" in text, f"{name}/{readme}: per-folder environment guidance missing")
+            require("<details markdown=\"1\">" in text and "<details markdown=\"1\" open>" not in text, f"{name}/{readme}: details must be closed")
+            require("<small>" in text and "2026-08-28 UTC" in text, f"{name}/{readme}: checked date must be inside the detail")
+            require(all(value in text for value in parity_values), f"{name}/{readme}: budget/model parity drift")
+            require(urls_in(text) == canonical_urls, f"{name}/{readme}: ordered URL mirror drift")
+            require(spec["primary_urls"].issubset(set(urls_in(text))), f"{name}/{readme}: required primary source missing")
+            require(not any(phrase in text for phrase in README_FORBIDDEN), f"{name}/{readme}: unsupported fixed-performance claim remains")
+        require(all(texts[0].count(value) == text.count(value) for text in texts[1:] for value in parity_values), f"{name}: key number mirror parity drift")
+
+
+def test_exercise_specific_reader_safety() -> None:
+    all_text = "\n".join(path.read_text(encoding="utf-8") for path in STAGE.glob("*/README*.md"))
+    require("interrupt_before" not in all_text and "update_state" not in all_text, "obsolete LangGraph HITL API remains")
+    require("Command(resume=" in all_text and "interrupt()" in all_text, "current LangGraph HITL explanation missing")
+    exercise1 = (STAGE / "01-same-agent-two-frameworks" / "starter.py").read_text(encoding="utf-8")
+    require('name != "search"' in exercise1 and "Unknown tool" in exercise1, "exercise 1 must reject unknown tool names")
+    codeact = (STAGE / "04-codeact-vs-json-tool" / "starter.py").read_text(encoding="utf-8")
+    docker_smoke = (STAGE / "04-codeact-vs-json-tool" / "test_docker_smoke.py").read_text(encoding="utf-8")
+    require("Docker" in all_text and '"host": "127.0.0.1"' in codeact and '"network_mode": "bridge"' in codeact, "CodeAct loopback control boundary missing")
+    require('"network_mode": "none"' not in codeact, "Docker none network breaks Smolagents' host control channel")
+    require("internal bridge" not in all_text.lower() and "internal network" not in all_text.lower(), "CodeAct must not claim unsupported internal-network isolation")
+    require('"HostIp"' in docker_smoke and '"127.0.0.1"' in docker_smoke, "Docker smoke must inspect the real loopback port binding")
+    require('"additional_imports"' not in codeact, "CodeAct must not duplicate DockerExecutor's positional additional_imports argument")
+    locale_contracts = {
+        "README.md": ("interrupt()", "Command(resume=", "Docker", "不能證明"),
+        "README.en.md": ("interrupt()", "Command(resume=", "Docker", "does not prove"),
+        "README.zh-Hans.md": ("interrupt()", "Command(resume=", "Docker", "不能证明"),
+    }
+    for readme, terms in locale_contracts.items():
+        joined = "\n".join((STAGE / name / readme).read_text(encoding="utf-8") for name in SPECS)
+        require(all(term in joined for term in terms), f"{readme}: HITL, CodeAct, or semantic-truth explanation drifted")
+
+
+if __name__ == "__main__":
+    test_stage_shape_and_dependencies()
+    test_python_safety_and_behavioral_entrypoints()
+    test_readme_mirrors_and_reader_contract()
+    test_exercise_specific_reader_safety()
+    print("Stage 4 structural gate: all pass")

--- a/stages/DESIGN.md
+++ b/stages/DESIGN.md
@@ -152,6 +152,8 @@ Stage 4 的時間、環境、完整閱讀、研究證據、進階 tool patterns�
 
 Stage 4 使用兩層 stacked PR：第一層只定稿三語教材、官方事實包、圖、資源表與 reader-UX gate；第二層才更新五個 `examples/stage-4/` 資料夾的 current-major SDK、Ollama／Anthropic 雙路徑、安全邊界與離線測試。這讓閱讀設計和 executable API migration 可以各自回溯、review 與驗證。
 
+Stage 4 的五個可執行資料夾必須各自建立 Python 3.11 `.venv`，不能把不同 framework 的 `requirements.txt` 合併安裝。每題的 Path A 與 Path B 測試都要實際走過核心行為；只確認 import 成功不算驗收。LangGraph 要測分支、checkpoint、`interrupt()` 與 `Command(resume=...)`；CrewAI 要測角色、handoff 與有界停止；CodeAct 只在受限 Docker executor 示範模型程式碼，Jupyter 控制埠只綁 loopback，並明說一般 bridge 仍可對外連線、不是 production sandbox；typed output 要明說格式正確不等於內容真實。
+
 ```
 1. 1-2 句核心問題
 2. ## 📌 學習目標


### PR DESCRIPTION
## PR 類型 / Type
- [x] 🔧 修正錯誤（Fix error: stale link / wrong info）
- [x] 📝 內容改善（Content improvement）
- [x] 🎨 風格 / 結構（Style / structure）

## 影響範圍 / Affected files
Stage 4 的五個 runnable examples、三語 example 索引、三語 style guide、Stage DESIGN、結構 regression、執行計畫與 CHANGELOG。

## 摘要 / Summary
把五個 Stage 4 framework 範例更新到查核日 current SDK major，改成每題自己的 Python 3.11 `.venv`，並將 Path A／B 從 import-only 改為可觀察的離線行為測試。三語 README 保留原有深度閱讀與五星推薦，修正 LangGraph HITL、CrewAI streaming、Smolagents model API、Pydantic AI typed output、成本與安全邊界。

CodeAct 的 Jupyter 控制埠只綁到 `127.0.0.1`，但正文明說一般 Docker bridge 仍可能連到外網或 host service，不能當 production sandbox。`test_docker_smoke.py` 會實際核對 loopback port binding；本機 Docker daemon 未啟動，所以本 PR 不宣稱 live smoke 已通過。

## Stacked PR
- Base layer: #152 (`codex/stage00-04-copy-polish`)
- This PR only contains Stage 04B example hardening.
- Do not merge until the user explicitly approves the stack.

## 驗證 / Verification
- 11/11 direct offline entrypoints passed in five isolated Python 3.11 environments
- 5/5 `pip check` passed
- `compileall` and `scripts/test_stage04_examples.py` passed
- stage template, strict anchors, slug parity, mirror, locale, Hans, image, duplicate-repo, freshness, and reader-UX gates passed
- `python -m pytest scripts -q`: 323 passed
- `python -m mkdocs build`: trilingual build passed
- independent code-reviewer: PASS on SHA-256 `ff0691ea0500746127c52a534f31fda32efb71252a625d870d61761e4bebd9f0`

## style-guide check
- [x] 繁中與簡中用詞分開驗證
- [x] 移除固定成功率、速度與無來源的最佳化主張
- [x] 三語 URL、model ID、價格、日期與安全語意一致
- [x] 既有深度內容與 editorial star ratings 保留

## 額外說明 / Additional notes
未新增 project。Docker live smoke 需要可用 daemon，保留為使用者可手動執行的驗收，不以離線 mock 冒充。