### PR TITLE
Add SandBase CLI to Track A router examples

### DIFF
--- a/tracks/cli/A1-cli-intro.en.md
+++ b/tracks/cli/A1-cli-intro.en.md
@@ -158,7 +158,8 @@ Editorial ratings are learning-map guidance, not GitHub stars or an overall rank
 <tr><td><a href="https://github.com/NousResearch/hermes-agent">NousResearch/hermes-agent</a></td><td>⭐⭐⭐⭐⭐</td><td>People using one agent in terminal, desktop, or chat</td><td>Enable provider, Skill, and MCP permissions one at a time</td></tr>
 </tbody>
 <tbody>
-<tr><th scope="rowgroup" rowspan="2">Router / local engine</th><td><a href="https://openrouter.ai/docs/faq">OpenRouter</a></td><td>⭐⭐⭐⭐</td><td>People switching providers through one API</td><td>It is a Router and still needs an agent</td></tr>
+<tr><th scope="rowgroup" rowspan="3">Router / local engine</th><td><a href="https://openrouter.ai/docs/faq">OpenRouter</a></td><td>⭐⭐⭐⭐</td><td>People switching providers through one API</td><td>It is a Router and still needs an agent</td></tr>
+<tr><td><a href="https://github.com/sandbaseai/cli">sandbaseai/cli</a></td><td>⭐⭐⭐⭐</td><td>People connecting multiple CLI clients to multiple providers</td><td>It is a local CLI/MCP bridge; start in a demo repo with least privilege and reversible settings</td></tr>
 <tr><td><a href="https://github.com/ollama/ollama">ollama/ollama</a></td><td>⭐⭐⭐⭐⭐</td><td>People running models on their own computer</td><td>It is a local runtime and still needs an agent</td></tr>
 </tbody>
 </table>

--- a/tracks/cli/A1-cli-intro.md
+++ b/tracks/cli/A1-cli-intro.md
@@ -167,7 +167,8 @@ A1 只教你安全開始，不在兩個頁面重複維護同一份易變資料�
 <tr><td><a href="https://github.com/NousResearch/hermes-agent">NousResearch/hermes-agent</a></td><td>⭐⭐⭐⭐⭐</td><td>想在 terminal、desktop 或聊天平台使用同一 agent 的人</td><td>逐項開啟 provider、Skill 與 MCP 權限</td></tr>
 </tbody>
 <tbody>
-<tr><th scope="rowgroup" rowspan="2">Router／本機引擎</th><td><a href="https://openrouter.ai/docs/faq">OpenRouter</a></td><td>⭐⭐⭐⭐</td><td>想用一個 API 入口切換 provider 的人</td><td>它是 Router，仍要搭配 agent</td></tr>
+<tr><th scope="rowgroup" rowspan="3">Router／本機引擎</th><td><a href="https://openrouter.ai/docs/faq">OpenRouter</a></td><td>⭐⭐⭐⭐</td><td>想用一個 API 入口切換 provider 的人</td><td>它是 Router，仍要搭配 agent</td></tr>
+<tr><td><a href="https://github.com/sandbaseai/cli">sandbaseai/cli</a></td><td>⭐⭐⭐⭐</td><td>想把多個 CLI client 接到多個 provider 的人</td><td>它是本機 CLI／MCP bridge；先用 demo repo、最小權限與可回復設定</td></tr>
 <tr><td><a href="https://github.com/ollama/ollama">ollama/ollama</a></td><td>⭐⭐⭐⭐⭐</td><td>想在自己電腦跑模型的人</td><td>它是 local runtime，仍要搭配 agent</td></tr>
 </tbody>
 </table>

--- a/tracks/cli/A1-cli-intro.zh-Hans.md
+++ b/tracks/cli/A1-cli-intro.zh-Hans.md
@@ -158,7 +158,8 @@ A1 只教你安全开始，不在两个页面重复维护同一份易变数据�
 <tr><td><a href="https://github.com/NousResearch/hermes-agent">NousResearch/hermes-agent</a></td><td>⭐⭐⭐⭐⭐</td><td>想在 terminal、desktop 或聊天平台使用同一 agent 的人</td><td>逐项开启 provider、Skill 和 MCP 权限</td></tr>
 </tbody>
 <tbody>
-<tr><th scope="rowgroup" rowspan="2">Router／本地引擎</th><td><a href="https://openrouter.ai/docs/faq">OpenRouter</a></td><td>⭐⭐⭐⭐</td><td>想用一个 API 入口切换 provider 的人</td><td>它是 Router，仍要搭配 agent</td></tr>
+<tr><th scope="rowgroup" rowspan="3">Router／本地引擎</th><td><a href="https://openrouter.ai/docs/faq">OpenRouter</a></td><td>⭐⭐⭐⭐</td><td>想用一个 API 入口切换 provider 的人</td><td>它是 Router，仍要搭配 agent</td></tr>
+<tr><td><a href="https://github.com/sandbaseai/cli">sandbaseai/cli</a></td><td>⭐⭐⭐⭐</td><td>想把多个 CLI client 接到多个 provider 的人</td><td>它是本地 CLI／MCP bridge；先用 demo repo、最小权限与可恢复设置</td></tr>
 <tr><td><a href="https://github.com/ollama/ollama">ollama/ollama</a></td><td>⭐⭐⭐⭐⭐</td><td>想在自己电脑上运行模型的人</td><td>它是 local runtime，仍要搭配 agent</td></tr>
 </tbody>
 </table>


### PR DESCRIPTION
Closes #160.

Adds SandBase CLI to the Router/local engine comparison in all three A1 language companions. The entry frames it as a local CLI/MCP bridge for connecting multiple clients and providers, with least-privilege and reversible-settings guidance.

Project: https://github.com/sandbaseai/cli