### PR TITLE
docs(navigation): Align the learner route across the site

### DIFF
--- a/CAPSTONE.en.md
+++ b/CAPSTONE.en.md
@@ -17,7 +17,7 @@ After finishing a track, **build something yourself** — this file is not a tut
 
 ## Track A Capstone — CLI Power User
 
-**Prerequisites**: Stage 0–2 + A1 + A2 + Stage 5 + A3 have each passed their self-check (Stage 8 is a shared hub across both tracks — recommended, but it does not gate capstone entry; the Track A capstone focuses on the CLI workflow).
+**Prerequisites:** Stage 0–2 + A1 + A2 + Stage 5's Track A core 5.1–5.4 + A3 have each passed their self-check. Stage 5 sections 5.5–5.8 do not block entry. Stage 8 is recommended, but it does not block Capstone entry either; the Track A Capstone focuses on the CLI workflow.
 
 **Brief**: Assemble a CLI-agent workflow **you will reuse**, automating something you currently do by hand.
 

--- a/CAPSTONE.md
+++ b/CAPSTONE.md
@@ -17,7 +17,7 @@
 
 ## Track A Capstone — CLI Power User
 
-**進入條件**:Stage 0–2 + A1 + A2 + Stage 5 + A3 都過了各自的自我檢查(Stage 8 是兩軌共用 hub,建議完成、但不擋 capstone 入場——Track A capstone 聚焦 CLI 工作流)。
+**進入條件**：Stage 0–2 + A1 + A2 + Stage 5 的 Track A 核心 5.1–5.4 + A3 都通過自我檢查。Stage 5 的 5.5–5.8 不擋入場。建議接著完成 Stage 8，但它也不擋 Capstone 入場；Track A Capstone 聚焦 CLI 工作流。
 
 **題目**:組一條**你會重複用**的 CLI-agent 工作流,把一件你現在手動做的事自動化。
 

--- a/CAPSTONE.zh-Hans.md
+++ b/CAPSTONE.zh-Hans.md
@@ -17,7 +17,7 @@
 
 ## Track A Capstone — CLI Power User
 
-**进入条件**:Stage 0–2 + A1 + A2 + Stage 5 + A3 都过了各自的自我检查(Stage 8 是两轨共用 hub,建议完成、但不挡 capstone 入场——Track A capstone 聚焦 CLI 工作流)。
+**进入条件**：Stage 0–2 + A1 + A2 + Stage 5 的 Track A 核心 5.1–5.4 + A3 都通过自我检查。Stage 5 的 5.5–5.8 不影响入场。Stage 8 建议完成，但也不影响 Capstone 入场；Track A Capstone 聚焦 CLI 工作流。
 
 **题目**:组一条**你会重复用**的 CLI-agent 工作流,把一件你现在手动做的事自动化。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Format: `YYYY-MM-DD · category · 1-line summary (commit-sha)`.
 
 ## 2026-08-29
 
+- **navigation / whole-site learning route** · **README、Progress、Roadmap、Capstone 與章節出口改用同一條三語學習順序**：共用基礎固定為 `Stage 0 → 1 → 2`；Track A 固定為 `A1 → A2 → Stage 5 → A3 → Stage 8`，並清楚說明 A3 後即可開始 Capstone、Stage 8 建議完成但不擋入場；Track B 固定為 `Stage 3 → 4 → 5 → 6 → 7 → 7.5 → 8`。A2、Stage 5、A3 的上一站／下一站與先備條件同步修正，Roadmap 移除已完成的 2026-05 缺口宣稱；新增 30 條 route contract，阻擋三語再次各走不同順序。
 - **maintenance / repository freshness** · **修正全站 9 組已搬家的 GitHub repository 入口**：OpenHands、prompts.chat、flonat-research、Instructor、xberg、LobeHub、Mozilla inclusion、Graphify 與 Supabase MCP 的現行引用改用 canonical owner／repo，三語可見名稱同步更新；歷史 CHANGELOG 與規劃文件保留當時名稱。GitHub API 於 `2026-08-29T00:20:01Z` 完整重查目前 259 個 unique repo，結果為 0 個 hard error、154 個人工複查提醒；沒有 release、缺 SPDX metadata 或較久未 push 不會自動刪除仍有教學價值的穩定專案。
 
 ## 2026-08-28

--- a/PROGRESS.en.md
+++ b/PROGRESS.en.md
@@ -35,7 +35,7 @@ This is a checklist **for your own use**. You do not need to submit it, open a P
 - [ ] **A2 — CLI Workflow Patterns** · [`tracks/cli/A2-cli-workflow.en.md`](tracks/cli/A2-cli-workflow.en.md)
 - [ ] **Stage 5 — Claude Code Ecosystem (shared by both tracks)** · [`stages/05-claude-code-ecosystem.en.md`](stages/05-claude-code-ecosystem.en.md)
 - [ ] **A3 — Integration & Production** · [`tracks/cli/A3-cli-production.en.md`](tracks/cli/A3-cli-production.en.md)
-- [ ] **Stage 8 — Agent Interfaces (shared by both tracks)** · [`stages/08-agent-interfaces.en.md`](stages/08-agent-interfaces.en.md)
+- [ ] **Stage 8 — Agent Interfaces (recommended; does not block Track A Capstone entry)** · [`stages/08-agent-interfaces.en.md`](stages/08-agent-interfaces.en.md)
 
 ---
 
@@ -78,7 +78,7 @@ After finishing a track, build something you can show + self-assess. The brief, 
 
 Do not want to plan it yourself? Follow this path to reach "able to do hands-on work" with roughly the fewest detours:
 
-`Stage 0 → Stage 1 → Stage 2 →` choose a track `→`(Track A: `A1 → A2 → Stage 5 → A3`;Track B: `Stage 3 → Stage 4 → Stage 5 → Stage 6`)`→` your branch `→`(advanced, applies to Track B: `Stage 7 → 7.5 → 8`;Track A's Stage 8 is already in the main path above)`→` your track's **Capstone** (see [`CAPSTONE.en.md`](CAPSTONE.en.md))
+`Stage 0 → Stage 1 → Stage 2 →` choose a track `→` (Track A: `A1 → A2 → Stage 5 → A3 → Stage 8`; Track B: `Stage 3 → Stage 4 → Stage 5 → Stage 6 → Stage 7 → 7.5 → 8`) `→` your branch `→` your track's **Capstone** (see [`CAPSTONE.en.md`](CAPSTONE.en.md)). Track A can start the Capstone after A3; Stage 8 is recommended but does not block entry.
 
 ---
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -35,7 +35,7 @@
 - [ ] **A2 — CLI Workflow Patterns** · [`tracks/cli/A2-cli-workflow.md`](tracks/cli/A2-cli-workflow.md)
 - [ ] **Stage 5 — Claude Code 生態(兩軌共用)** · [`stages/05-claude-code-ecosystem.md`](stages/05-claude-code-ecosystem.md)
 - [ ] **A3 — Integration & Production** · [`tracks/cli/A3-cli-production.md`](tracks/cli/A3-cli-production.md)
-- [ ] **Stage 8 — Agent 操作介面(兩軌共用)** · [`stages/08-agent-interfaces.md`](stages/08-agent-interfaces.md)
+- [ ] **Stage 8 — Agent 操作介面（建議；不擋 Track A Capstone 入場）** · [`stages/08-agent-interfaces.md`](stages/08-agent-interfaces.md)
 
 ---
 
@@ -78,7 +78,7 @@
 
 不想自己排?照這個走,大約能在最少繞路下到「能動手做事」:
 
-`Stage 0 → Stage 1 → Stage 2 →` 選軌道 `→`(Track A: `A1 → A2 → Stage 5 → A3`;Track B: `Stage 3 → Stage 4 → Stage 5 → Stage 6`)`→` 你的 branch `→`(進階,Track B 適用:`Stage 7 → 7.5 → 8`;Track A 的 Stage 8 已在上方主線)`→` 你那軌的 **Capstone**(見 [`CAPSTONE.md`](CAPSTONE.md))
+`Stage 0 → Stage 1 → Stage 2 →` 選軌道 `→`（Track A：`A1 → A2 → Stage 5 → A3 → Stage 8`；Track B：`Stage 3 → Stage 4 → Stage 5 → Stage 6 → Stage 7 → 7.5 → 8`）`→` 你的 branch `→` 你那軌的 **Capstone**（見 [`CAPSTONE.md`](CAPSTONE.md)）。Track A 做完 A3 就能開始 Capstone；Stage 8 建議完成，但不擋入場。
 
 ---
 

--- a/PROGRESS.zh-Hans.md
+++ b/PROGRESS.zh-Hans.md
@@ -35,7 +35,7 @@
 - [ ] **A2 — CLI Workflow Patterns** · [`tracks/cli/A2-cli-workflow.zh-Hans.md`](tracks/cli/A2-cli-workflow.zh-Hans.md)
 - [ ] **Stage 5 — Claude Code 生态(两轨共用)** · [`stages/05-claude-code-ecosystem.zh-Hans.md`](stages/05-claude-code-ecosystem.zh-Hans.md)
 - [ ] **A3 — Integration & Production** · [`tracks/cli/A3-cli-production.zh-Hans.md`](tracks/cli/A3-cli-production.zh-Hans.md)
-- [ ] **Stage 8 — Agent 操作界面(两轨共用)** · [`stages/08-agent-interfaces.zh-Hans.md`](stages/08-agent-interfaces.zh-Hans.md)
+- [ ] **Stage 8 — Agent 操作界面（建议；不影响 Track A Capstone 入场）** · [`stages/08-agent-interfaces.zh-Hans.md`](stages/08-agent-interfaces.zh-Hans.md)
 
 ---
 
@@ -78,7 +78,7 @@
 
 不想自己排？照这个走，大约能在最少绕路下到“能动手做事”：
 
-`Stage 0 → Stage 1 → Stage 2 →` 选轨道 `→`（Track A: `A1 → A2 → Stage 5 → A3`;Track B: `Stage 3 → Stage 4 → Stage 5 → Stage 6`）`→` 你的 branch `→`（进阶，Track B 适用：`Stage 7 → 7.5 → 8`;Track A 的 Stage 8 已在上方主线）`→` 你那轨的 **Capstone**（见 [`CAPSTONE.zh-Hans.md`](CAPSTONE.zh-Hans.md)）
+`Stage 0 → Stage 1 → Stage 2 →` 选轨道 `→`（Track A：`A1 → A2 → Stage 5 → A3 → Stage 8`；Track B：`Stage 3 → Stage 4 → Stage 5 → Stage 6 → Stage 7 → 7.5 → 8`）`→` 你的 branch `→` 你那轨的 **Capstone**（见 [`CAPSTONE.zh-Hans.md`](CAPSTONE.zh-Hans.md)）。Track A 做完 A3 就能开始 Capstone；Stage 8 建议完成，但不影响入场。
 
 ---
 

--- a/README.en.md
+++ b/README.en.md
@@ -117,11 +117,13 @@ The two tracks are **not mutually exclusive** — most people start with A to ge
 |---|---|---|---|
 | **A1** | [CLI Agent Intro & Selection](tracks/cli/A1-cli-intro.en.md) | CLI agent selection · install · first run | 1 wk |
 | **A2** | [CLI Workflow Patterns](tracks/cli/A2-cli-workflow.en.md) | Project instructions · Skill · task decomposition | 1-2 wks |
-| **A3** | [Integration & Production](tracks/cli/A3-cli-production.en.md) | MCP-into-CLI · CI automation · cost / observability | 1-2 wks |
 | **+5** | [Stage 5 — Claude Code Ecosystem](stages/05-claude-code-ecosystem.en.md) (**Shared Hub**) | MCP · Skills · Plugins · Subagents; Track A reads 5.1-5.4 (5.5-5.7 optional) | 1-2 wks (Track A view) |
+| **A3** | [Integration & Production](tracks/cli/A3-cli-production.en.md) | MCP-into-CLI · CI automation · cost / observability | 1-2 wks |
 | **+8** | [Stage 8 — Agent Interfaces](stages/08-agent-interfaces.en.md) (**Shared Hub**) | Computer Use · Browser Use · Code Sandbox; Track A reads Track A usage | 1-2 wks (Track A view) |
 
 > **Track A total time**: includes Stages 0-2 (shared foundations) + A1-A3 + **Stage 5 + Stage 8 (two shared hubs) ≈ 8-10 weeks**. Core reference: [`resources/cli-agents-guide.en.md`](resources/cli-agents-guide.en.md).
+>
+> **Capstone gate:** You can start the Track A Capstone after A3. Stage 8 is the recommended next stop, but it does not block Capstone entry.
 
 ### Track B — Agent Builder (build agents from scratch)
 

--- a/README.md
+++ b/README.md
@@ -117,11 +117,13 @@ cd awesome-agentic-ai-zh
 |---|---|---|---|
 | **A1** | [選一個 CLI Agent，開始用它做事（CLI Agent Intro & Selection）](tracks/cli/A1-cli-intro.md) | CLI agent 選擇 · 安裝 · 第一次跑 | 1 週 |
 | **A2** | [建立可重複使用的 CLI 工作流程（CLI Workflow Patterns）](tracks/cli/A2-cli-workflow.md) | 專案規則 · Skill · 任務拆解 | 1-2 週 |
-| **A3** | [把 CLI Agent 接進真實工作流程（Integration & Production）](tracks/cli/A3-cli-production.md) | MCP 接 CLI · CI 自動化 · cost / observability | 1-2 週 |
 | **+5** | [Stage 5 — Claude Code 生態](stages/05-claude-code-ecosystem.md)（**共用 hub**） | MCP · Skills · Plugins · Subagents、Track A 必看 5.1-5.4 / 選讀 5.5-5.7 | 1-2 週（Track A 視角）|
+| **A3** | [把 CLI Agent 接進真實工作流程（Integration & Production）](tracks/cli/A3-cli-production.md) | MCP 接 CLI · CI 自動化 · cost / observability | 1-2 週 |
 | **+8** | [Stage 8 — Agent Interfaces](stages/08-agent-interfaces.md)（**共用 hub**）| Computer Use · Browser Use · Code Sandbox、Track A 視角看 Track A 怎麼用 | 1-2 週（Track A 視角）|
 
 > **Track A 預估總時程**：含 Stage 0-2（共用基礎）+ A1-A3 + **Stage 5 + Stage 8（兩個共用 hub）= 約 8-10 週**。核心參考：[`resources/cli-agents-guide.md`](resources/cli-agents-guide.md)。
+>
+> **Capstone 門檻**：做到 A3 就能開始 Track A Capstone。Stage 8 是建議的下一站，但不擋 Capstone 入場。
 
 ### Track B — Agent Builder（從零打造 agent）
 

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -117,11 +117,13 @@ cd awesome-agentic-ai-zh
 |---|---|---|---|
 | **A1** | [选一个 CLI Agent，开始用它做事（CLI Agent Intro & Selection）](tracks/cli/A1-cli-intro.zh-Hans.md) | CLI agent 选择 · 安装 · 第一次跑 | 1 周 |
 | **A2** | [建立可重复使用的 CLI 工作流程（CLI Workflow Patterns）](tracks/cli/A2-cli-workflow.zh-Hans.md) | 项目规则 · Skill · 任务拆解 | 1-2 周 |
-| **A3** | [把 CLI Agent 接进真实工作流程（Integration & Production）](tracks/cli/A3-cli-production.zh-Hans.md) | MCP 接 CLI · CI 自动化 · cost / observability | 1-2 周 |
 | **+5** | [Stage 5 — Claude Code 生态系（Claude Code Ecosystem）](stages/05-claude-code-ecosystem.zh-Hans.md)（**共用 hub**）| MCP · Skills · Plugins · Subagents、Track A 必看 5.1-5.4 / 选读 5.5-5.7 | 1-2 周（Track A 视角）|
+| **A3** | [把 CLI Agent 接进真实工作流程（Integration & Production）](tracks/cli/A3-cli-production.zh-Hans.md) | MCP 接 CLI · CI 自动化 · cost / observability | 1-2 周 |
 | **+8** | [Stage 8 — Agent 操作介面（Agent Interfaces）](stages/08-agent-interfaces.zh-Hans.md)（**共用 hub**）| Computer Use · Browser Use · Code Sandbox、Track A 视角看 Track A 怎么用 | 1-2 周（Track A 视角）|
 
 > **Track A 预估总时程**：含 Stage 0-2（共用基础）+ A1-A3 + **Stage 5 + Stage 8（两个共用 hub）= 约 8-10 周**。核心参考：[`resources/cli-agents-guide.zh-Hans.md`](resources/cli-agents-guide.zh-Hans.md)。
+>
+> **Capstone 门槛**：做到 A3 就能开始 Track A Capstone。Stage 8 是建议的下一站，但不影响 Capstone 入场。
 
 ### Track B — Agent Builder（想从零构建 agent）
 

--- a/ROADMAP.en.md
+++ b/ROADMAP.en.md
@@ -2,55 +2,75 @@
 
 > [繁體中文](./ROADMAP.md) | [简体中文](./ROADMAP.zh-Hans.md) | **English**
 
-This repo is a **community-maintained learning roadmap**: no release date, no promised schedule. This document makes public “where we know things are not good enough and where we want to go next”, so people who want to contribute can pick one piece to start with, without reading the whole repo first just to know what is missing.
+This page answers two questions: **What is usable now, and what still needs work?** It is not a release date or delivery promise.
 
-> Want to work on one item? Open a [Discussion](https://github.com/WenyuChiou/awesome-agentic-ai-zh/discussions) first, or send a PR directly. For long-term stage / branch maintainers, see [`CONTRIBUTORS.md`](CONTRIBUTORS.md). For beginner entry points, see the “5 easy entry points” section in [`CONTRIBUTING.en.md`](CONTRIBUTING.en.md).
-
-**Status legend**: 🟢 In progress / always open to contributions · 🟡 Known gap, wanted · 🔵 Idea, pending discussion · ✅ Recently completed
+**Status:** 🟢 active / open to contributions · 🟡 known gap · 🔵 idea · ✅ recently completed
 
 ---
 
-## Near-Term Gaps We Want to Fill
+<a id="near-term-gaps-we-want-to-fill"></a>
+<a id="in-progress--always-open-to-contributions"></a>
+<a id="-fill-out-hands-on-exercise-coverage"></a>
+<a id="-deepen-the-audience-branch-files"></a>
+<a id="-stage-2--stage-3-2026-freshness-touch-up"></a>
 
-### 🟡 Fill Out Hands-On Exercise Coverage
-`examples/` currently covers Stage 1, 2, 3, 4, 5, 6, and 7. **Missing**: Stage 0 (Foundation Concepts), Stage 7.5 (Advanced Agentic Concepts), and Stage 8 (Agent Interfaces). In other words, only Stage 0, 7.5, and 8 remain without corresponding hands-on examples. Each example should run in under 30 minutes and include `how to run` commands.
+## 🟢 Active work
 
-### 🟡 Deepen the audience branch Files
-5 audience branch files by length (zh-TW canonical, 2026-05 snapshot): for-knowledge-worker (143 lines, shortest) < for-developer (166) < for-everyday-users (179) < for-researcher (208) < for-teacher (224). **The shortest files, `for-knowledge-worker.md` / `for-developer.md`, need scenario coverage the most**. `for-teacher.md` is actually the longest, but `CONTRIBUTORS.md` still marks it as “especially open to self-nominations”: what is truly thin is the **academic citation depth for teacher scenarios** (currently only Chen 2020 / Mittal 2024), and more 3-tier teacher AI application scenarios + matching citations are welcome.
+### 1. Connect the site into one route
 
-### 🟡 Stage 2 / Stage 3 2026 freshness Touch-Up
-A few small 2026 wording / model-reference updates have not been synced to mirrors yet (about 5 lines of diff × 2 locales).
+- Shared foundation: `Stage 0 → Stage 1 → Stage 2`
+- Track A: `A1 → A2 → Stage 5 → A3 → Stage 8`
+- Track B: `Stage 3 → Stage 4 → Stage 5 → Stage 6 → Stage 7 → Stage 7.5 → Stage 8`
 
----
+Track A may start its Capstone after A3. Stage 8 is recommended, but it does not block entry. Text and tests are frozen before the homepage learning map is redrawn.
 
-## In Progress / Always Open to Contributions
+### 2. Improve the five role paths
 
-- 🟢 **Outdated entry reports** — Run `python scripts/refresh-stars.py` to find repos with large star-count gaps, then open an issue or PR to annotate / remove them.
-- 🟢 **Broken link fixes** — Monthly CI scans for link-rot, but direct PRs for anything found in real time are fastest.
-- 🟢 **Complete `how to run` sections** — Many entries are missing installation / execution commands. If you have run one, add them.
-- 🟢 **Mirror translation smoothing** — Compare `.en.md` / `.zh-Hans.md` against zh-TW, and fix one sentence that reads awkwardly.
-- 🟢 **Long-term stage / branch maintainers** — Claim one stage or branch and review it when you have time. The slot table is in `CONTRIBUTORS.md`.
+Researcher, developer, teacher, knowledge-worker, and everyday-user paths will each show one “start today” action. Full project tables, alternatives, and troubleshooting stay closed by default. Core terms and editorial star ratings stay intact.
 
----
+### 3. Improve setup, courses, cookbook, glossary, and catalog
 
-## Infrastructure (maintainer in progress)
+- Setup first helps readers choose Web, Desktop, IDE, CLI, or API.
+- Cookbook recipes show the outcome, first copyable action, and success check first.
+- Glossary terms and short definitions remain directly searchable.
+- The MCP/Skills catalog stays searchable and gains category navigation and maintenance status.
 
-- ✅ **Community health files** — `CODE_OF_CONDUCT.md` / `SECURITY.md` / `CITATION.cff` / issue-template routing (same batch as this roadmap).
-- 🟢 **Learner progress layer** — `PROGRESS.md` self-check template + “Self check / Exit check” at the end of each stage (planned).
-- 🔵 **Browsable docs site** — Render stages/tracks/branches into a website with navigation + search + language switching (GitHub Pages, under evaluation).
-- 🟢 **Trilingual mirror parity** — `mirror-sync-reminder` + `check-mirror-sync.py` already guard PRs, and legacy drift is being cleaned continuously.
-- 🟢 **Quality gates** — link-rot / star-drift / banned-word / anchor / zh-Hans localization CI is online and maintained.
+### 4. Keep repositories and volatile facts current
 
----
-
-## Idea Box (pending discussion, not committed yet)
-
-- 🔵 **More audience branch files**: There are currently 5 (researcher / developer / teacher / knowledge-worker / everyday-users). Whether to split further (for example PM / designer / legal) depends on community needs.
-- 🔵 **A third track?**: Today, Track A = CLI Power User (A1–A3 under `tracks/cli/`), and Track B = stages learning path (`stages/` directory Stage 0–8, **not** a standalone directory under `tracks/`). Whether to add a third track (for example “no-code agent only”) is pending discussion.
-- 🔵 **Video / interactive supplements**: Whether a text-only learning roadmap should include minimal video walkthroughs depends on cost and maintenance load.
-
-To suggest an idea, open a [Discussion](https://github.com/WenyuChiou/awesome-agentic-ai-zh/discussions), not an issue (issues are for bugs / outdated entries / new projects).
+The weekly workflow checks canonical GitHub repositories, redirects, archives, license metadata, releases, and activity. An older last push is a warning, not an automatic deletion rule. Models, prices, APIs, and capabilities still require chapter-by-chapter official-source checks.
 
 ---
 
-> This roadmap is not a contract. It reflects the direction “now”, and will change as the community contributes. The most reliable source for “what should happen next” is always open issues + Discussions.
+<a id="infrastructure-maintainer-in-progress"></a>
+
+## ✅ Recently completed
+
+- Stage 0–8 and A1–A3 completed their first progressive-disclosure, core-term, resource-table, and trilingual pass.
+- Stage 2 retained zero-shot, one-shot, few-shot, and Chain of Thought, and gained a localized Prompt Engineering map.
+- Stage 3 gained a localized Tool Use loop; Stage 6 gained a two-lane RAG pipeline; Stage 8 gained interface-choice and safety maps.
+- Stage 0 has an integrated exercise. Stage 7.5 is intentionally a reading map. Stage 8 has copyable safety exercises; a separate end-to-end example remains open to contributions.
+- MkDocs build, mirror/anchor/locale checks, reader-UX, freshness, and repository snapshot gates are in the maintenance flow.
+
+---
+
+## 🟢 Good contribution tasks
+
+- Report an outdated fact or broken link with a current official source.
+- Add a clearer “how to run” and success check to one exercise.
+- Improve one English or Simplified Chinese sentence without changing meaning, numbers, URLs, or safety rules.
+- Add one real role-path scenario with input, output, human review, and privacy boundaries.
+- Add status, license, or limits for a stable project; do not judge it only by stars or last-push date.
+
+Start with [`CONTRIBUTING.en.md`](CONTRIBUTING.en.md). For long-term chapter maintenance, see [`CONTRIBUTORS.en.md`](CONTRIBUTORS.en.md).
+
+---
+
+<a id="idea-box-pending-discussion-not-committed-yet"></a>
+
+## 🔵 Still under discussion
+
+- Whether a third formal no-code/web-only track is needed; everyday users can already enter through their role path.
+- Whether to add a minimal video walkthrough, including subtitle, trilingual, and maintenance cost.
+- Whether Voice Agents and VLA belong under Stage 8/research/developer extensions or need a separate topic page.
+
+Use [Discussions](https://github.com/WenyuChiou/awesome-agentic-ai-zh/discussions) for ideas; keep issues for defects, stale information, or concrete new resources.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,55 +2,77 @@
 
 > **繁體中文** | [简体中文](./ROADMAP.zh-Hans.md) | [English](./ROADMAP.en.md)
 
-這份 repo 是**社群維護的學習路線圖**——沒有發行日期、沒有承諾的時程。這份文件公開「我們知道哪裡還不夠好、接下來想往哪走」,讓想貢獻的人能挑一塊上手,而不用先讀完整個 repo 才知道缺什麼。
+這份文件只回答兩件事：**現在已經能用什麼？接下來還要補什麼？** 它不是發行日期，也不承諾完成時間。
 
-> 想動其中一項?開個 [Discussion](https://github.com/WenyuChiou/awesome-agentic-ai-zh/discussions) 講一聲,或直接 PR。擔任 stage / branch 長期維護者請看 [`CONTRIBUTORS.md`](CONTRIBUTORS.md)。新手切入點看 [`CONTRIBUTING.md`](CONTRIBUTING.md) 的「好上手的 5 個切入點」。
-
-**狀態圖例**:🟢 進行中 / 隨時可貢獻 · 🟡 已知缺口、想做 · 🔵 想法、待討論 · ✅ 近期完成
+**狀態圖例**：🟢 正在做／隨時可貢獻 · 🟡 已知缺口 · 🔵 想法 · ✅ 最近完成
 
 ---
 
-## 近期想補的缺口
+<a id="近期想補的缺口"></a>
+<a id="進行中--隨時可貢獻"></a>
+<a id="-動手練習覆蓋補齊"></a>
+<a id="-audience-branch-深化"></a>
+<a id="-stage-2--stage-3-2026-freshness-小修"></a>
 
-### 🟡 動手練習覆蓋補齊
-`examples/` 目前涵蓋 Stage 1、2、3、4、5、6、7。**缺**:Stage 0(基礎概念)、Stage 7.5(進階 Agentic 概念)、Stage 8(Agent Interfaces)。也就是只剩 Stage 0、7.5、8 尚未有對應的 hands-on 範例。每個範例要能在 30 分鐘內跑完、附 `怎麼跑` 指令。
+## 🟢 現在正在做
 
-### 🟡 audience branch 深化
-5 條 audience branch 篇幅(zh-TW canonical,2026-05 snapshot):for-knowledge-worker(143 行,最短)< for-developer(166)< for-everyday-users(179)< for-researcher(208)< for-teacher(224)。**篇幅最短的 `for-knowledge-worker.md` / `for-developer.md` 最需要補情境**。`for-teacher.md` 篇幅其實最長,但 `CONTRIBUTORS.md` 仍把它標「特別歡迎自薦」——它真正薄的是**教師情境的學術引用深度**(目前只有 Chen 2020 / Mittal 2024 兩筆),歡迎補更多 3-tier 教師 AI 應用情境 + 對應引用。
+### 1. 把整站接成同一條路
 
-### 🟡 Stage 2 / Stage 3 2026 freshness 小修
-幾處 2026 用語 / 模型引用的小幅更新還沒同步到鏡像(約 5 行 diff × 2 locale)。
+文字路線統一為：
 
----
+- 共用基礎：`Stage 0 → Stage 1 → Stage 2`
+- Track A：`A1 → A2 → Stage 5 → A3 → Stage 8`
+- Track B：`Stage 3 → Stage 4 → Stage 5 → Stage 6 → Stage 7 → Stage 7.5 → Stage 8`
 
-## 進行中 / 隨時可貢獻
+Track A 做完 A3 就能開始 Capstone；Stage 8 建議完成，但不擋入場。文字與測試先定稿，首頁學習地圖之後再重畫。
 
-- 🟢 **過時 entry 回報** — 跑 `python scripts/refresh-stars.py` 找星數差距大的 repo,開 issue 或 PR 標註 / 移除。
-- 🟢 **失效連結修正** — link-rot 每月 CI 會掃,但即時發現的直接 PR 最快。
-- 🟢 **`怎麼跑` section 補完** — 很多 entry 缺安裝 / 執行指令,你跑過就補。
-- 🟢 **鏡像翻譯順稿** — 對照 `.en.md` / `.zh-Hans.md` 與 zh-TW,改一句翻得不順的。
-- 🟢 **stage / branch 長期維護者** — 認領一個 stage 或 branch,有空時 review 一輪。名額表在 `CONTRIBUTORS.md`。
+### 2. 整理五條角色路徑
 
----
+研究人員、開發者、教師、知識工作者與日常使用者都會補上「今天先做什麼」。第一個動作留在畫面上；完整專案表、替代方案與疑難排解預設收合。重要名詞與五星編輯推薦度不會因為縮短頁面而消失。
 
-## 基礎建設(maintainer 進行中)
+### 3. 整理 setup、courses、cookbook、glossary 與 catalog
 
-- ✅ **社群健康檔** — `CODE_OF_CONDUCT.md` / `SECURITY.md` / `CITATION.cff` / issue-template 導流(本路線圖同批)。
-- 🟢 **學習者進度層** — `PROGRESS.md` 自我打勾範本 + 每個 stage 結尾「自我檢核 / Exit check」(規劃中)。
-- 🔵 **可瀏覽文件站** — 把 stages/tracks/branches 渲染成有導覽 + 搜尋 + 語言切換的網站(GitHub Pages,評估中)。
-- 🟢 **三語鏡像 parity** — `mirror-sync-reminder` + `check-mirror-sync.py` 已在 PR 時把關,持續清 legacy drift。
-- 🟢 **品質 gate** — link-rot / star-drift / banned-word / anchor / zh-Hans 在地化 CI 已上線並維護中。
+- Setup 先幫讀者選 Web、Desktop、IDE、CLI 或 API，再展開安裝細節。
+- Cookbook 先顯示成果、第一個可複製動作與成功條件。
+- Glossary 的名詞和短定義保持可搜尋；長例子才收合。
+- MCP／Skills catalog 保持可搜尋，增加分類導航與維護狀態，不把每一列拆成一個選單。
 
----
+### 4. 持續檢查 repository 與易變資訊
 
-## 想法箱(待討論,還沒承諾)
-
-- 🔵 **更多 audience branch**:目前 5 條(researcher / developer / teacher / knowledge-worker / everyday-users),是否要再分(例如 PM / 設計師 / 法務)看社群需求。
-- 🔵 **第三條軌道?**:目前 Track A = CLI Power User(`tracks/cli/` 的 A1–A3)、Track B = stages 學習路線(`stages/` 目錄 Stage 0–8,**不是** `tracks/` 下的獨立目錄)。是否要有第三條軌道(例如「只用 no-code agent」)待討論。
-- 🔵 **影音 / 互動補充**:純文字學習路線是否要配最小影音 walkthrough,成本與維護負擔待評估。
-
-要提想法請開 [Discussion](https://github.com/WenyuChiou/awesome-agentic-ai-zh/discussions),不要開 issue(issue 留給 bug / 過時 entry / 新增 project)。
+每週 workflow 逐一檢查 canonical GitHub repo、redirect、archive、license metadata、release 與最近活動。較久沒 push 只會產生 warning，不會自動刪除穩定且仍有教學價值的專案。模型、價格、API 與產品能力仍要回官方文件逐章查證。
 
 ---
 
-> 這份路線圖不是契約。它反映「現在」的方向,會隨社群投入而變。最可靠的「接下來要做什麼」永遠是 open issues + Discussions。
+<a id="基礎建設maintainer-進行中"></a>
+
+## ✅ 最近完成
+
+- Stage 0–8 與 A1–A3 已完成第一輪漸進式揭露、三語一致性、核心詞與資源表整理。
+- Stage 2 保留 zero-shot、one-shot、few-shot、Chain of Thought 等必要名詞，並加入三語 Prompt Engineering 概念圖。
+- Stage 3 加入三語 Tool Use 迴圈圖；Stage 6 重畫兩條路的 RAG pipeline；Stage 8 補上介面選擇與安全檢查圖。
+- Stage 0 有整合練習；Stage 7.5 本來就是 reading map，不強迫新增程式資料夾；Stage 8 已有可複製的安全練習，獨立 end-to-end 範例仍可貢獻。
+- MkDocs build、三語 mirror／anchor／locale gate、reader-UX gate、freshness gate 與 repository snapshot 都已納入維護流程。
+
+---
+
+## 🟢 很適合貢獻的小任務
+
+- 回報過時事實或失效連結，附官方新來源。
+- 替一個練習補上更清楚的「怎麼跑」與成功條件。
+- 修順一段英文或簡中鏡像，但不要改變原意、數字、URL 或安全規則。
+- 替 role path 補一個真實情境，說清楚輸入、輸出、人工檢查與隱私邊界。
+- 替穩定專案補 status／license／限制；不要只用 stars 或最近 push 日期下結論。
+
+先看 [`CONTRIBUTING.md`](CONTRIBUTING.md)；想長期維護一章，再看 [`CONTRIBUTORS.md`](CONTRIBUTORS.md)。
+
+---
+
+<a id="想法箱待討論還沒承諾"></a>
+
+## 🔵 還在討論
+
+- 是否需要第三條正式軌道，例如 no-code／web-only 路線；目前日常使用者可直接走 role path，不必先多造一條主幹。
+- 是否加入最小影音 walkthrough；需要先衡量字幕、三語同步與長期維護成本。
+- Voice Agent 與 VLA 應放在既有 Stage 8／研究或開發者延伸，還是需要新的專題頁；先避免為新名詞增加主線負擔。
+
+要提想法請開 [Discussion](https://github.com/WenyuChiou/awesome-agentic-ai-zh/discussions)；issue 留給缺陷、過時資訊或明確的新資源。

--- a/ROADMAP.zh-Hans.md
+++ b/ROADMAP.zh-Hans.md
@@ -2,55 +2,75 @@
 
 > [繁體中文](./ROADMAP.md) | **简体中文** | [English](./ROADMAP.en.md)
 
-这份 repo 是**社区维护的学习路线图**——没有发布日期、没有承诺的时间表。这份文件公开“我们知道哪里还不够好、接下来想往哪里走”，让想贡献的人能挑一块上手，而不用先读完整个 repo 才知道缺什么。
+这份页面只回答两件事：**现在已经能用什么？接下来还要补什么？** 它不是发布日期，也不承诺完成时间。
 
-> 想动其中一项？开个 [Discussion](https://github.com/WenyuChiou/awesome-agentic-ai-zh/discussions) 说一声，或直接 PR。担任 stage / branch 长期维护者请看 [`CONTRIBUTORS.md`](CONTRIBUTORS.md)。新手切入点看 [`CONTRIBUTING.zh-Hans.md`](CONTRIBUTING.zh-Hans.md) 的“好上手的 5 个切入点”。
-
-**状态图例**：🟢 进行中 / 随时可贡献 · 🟡 已知缺口、想做 · 🔵 想法、待讨论 · ✅ 近期完成
+**状态：** 🟢 正在做／随时可贡献 · 🟡 已知缺口 · 🔵 想法 · ✅ 最近完成
 
 ---
 
-## 近期想补的缺口
+<a id="近期想补的缺口"></a>
+<a id="进行中--随时可贡献"></a>
+<a id="-动手练习覆盖补齐"></a>
+<a id="-audience-branch-深化"></a>
+<a id="-stage-2--stage-3-2026-freshness-小修"></a>
 
-### 🟡 动手练习覆盖补齐
-`examples/` 目前覆盖 Stage 1、2、3、4、5、6、7。**缺**：Stage 0（基础概念）、Stage 7.5（进阶 Agentic 概念）和 Stage 8（Agent Interfaces）。也就是说，只剩 Stage 0、7.5 和 8 尚未有对应的 hands-on 示例。每个示例要能在 30 分钟内跑完，并附 `怎么跑` 命令。
+## 🟢 现在正在做
 
-### 🟡 audience branch 深化
-5 条 audience branch 篇幅（zh-TW canonical, 2026-05 snapshot）：for-knowledge-worker（143 行，最短）< for-developer（166）< for-everyday-users（179）< for-researcher（208）< for-teacher（224）。**篇幅最短的 `for-knowledge-worker.md` / `for-developer.md` 最需要补情境**。`for-teacher.md` 篇幅其实最长，但 `CONTRIBUTORS.md` 仍把它标为“特别欢迎自荐”——它真正薄的是**教师情境的学术引用深度**（目前只有 Chen 2020 / Mittal 2024 两笔），欢迎补更多 3-tier 教师 AI 应用情境 + 对应引用。
+### 1. 把整站接成同一条路
 
-### 🟡 Stage 2 / Stage 3 2026 freshness 小修
-几处 2026 用语 / 模型引用的小幅更新还没同步到镜像（约 5 行 diff × 2 locale）。
+- 共用基础：`Stage 0 → Stage 1 → Stage 2`
+- Track A：`A1 → A2 → Stage 5 → A3 → Stage 8`
+- Track B：`Stage 3 → Stage 4 → Stage 5 → Stage 6 → Stage 7 → Stage 7.5 → Stage 8`
 
----
+Track A 做完 A3 就能开始 Capstone；Stage 8 建议完成，但不影响入场。文字与测试先定稿，首页学习地图之后再重画。
 
-## 进行中 / 随时可贡献
+### 2. 整理五条角色路径
 
-- 🟢 **过时 entry 反馈** — 跑 `python scripts/refresh-stars.py` 找星数差距大的 repo，开 issue 或 PR 标注 / 移除。
-- 🟢 **失效链接修正** — link-rot 每月 CI 会扫，但即时发现的直接 PR 最快。
-- 🟢 **`怎么跑` section 补完** — 很多 entry 缺安装 / 执行命令，你跑过就补。
-- 🟢 **镜像翻译顺稿** — 对照 `.en.md` / `.zh-Hans.md` 与 zh-TW，改一句翻得不顺的。
-- 🟢 **stage / branch 长期维护者** — 认领一个 stage 或 branch，有空时 review 一轮。名额表在 `CONTRIBUTORS.md`。
+研究人员、开发者、教师、知识工作者和日常用户都会补上“今天先做什么”。第一个动作留在页面上；完整项目表、替代方案和疑难排解默认收合。核心词和五星编辑推荐度不会消失。
 
----
+### 3. 整理 setup、courses、cookbook、glossary 和 catalog
 
-## 基础建设（maintainer 进行中）
+- Setup 先帮读者选 Web、Desktop、IDE、CLI 或 API。
+- Cookbook 先显示成果、第一个可复制动作和成功条件。
+- Glossary 的术语和短定义保持可搜索。
+- MCP／Skills catalog 保持可搜索，并增加分类导航与维护状态。
 
-- ✅ **社区健康文件** — `CODE_OF_CONDUCT.md` / `SECURITY.md` / `CITATION.cff` / issue-template 导流（本路线图同批）。
-- 🟢 **学习者进度层** — `PROGRESS.md` 自我打勾模板 + 每个 stage 结尾“自我检查 / Exit check”（规划中）。
-- 🔵 **可浏览文件站** — 把 stages/tracks/branches 渲染成有导航 + 搜索 + 语言切换的网站（GitHub Pages，评估中）。
-- 🟢 **三语镜像 parity** — `mirror-sync-reminder` + `check-mirror-sync.py` 已在 PR 时把关，持续清 legacy drift。
-- 🟢 **质量 gate** — link-rot / star-drift / banned-word / anchor / zh-Hans 本地化 CI 已上线并维护中。
+### 4. 持续检查 repository 和易变信息
 
----
-
-## 想法箱（待讨论，还没承诺）
-
-- 🔵 **更多 audience branch**：目前 5 条（researcher / developer / teacher / knowledge-worker / everyday-users），是否要再分（例如 PM / 设计师 / 法务）看社区需求。
-- 🔵 **第三条轨道？**：目前 Track A = CLI Power User（`tracks/cli/` 的 A1–A3）、Track B = stages 学习路线（`stages/` 目录 Stage 0–8，**不是** `tracks/` 下的独立目录）。是否要有第三条轨道（例如“只用 no-code agent”）待讨论。
-- 🔵 **视频 / 互动补充**：纯文字学习路线是否要配最小视频 walkthrough，成本与维护负担待评估。
-
-要提想法请开 [Discussion](https://github.com/WenyuChiou/awesome-agentic-ai-zh/discussions)，不要开 issue（issue 留给 bug / 过时 entry / 新增项目）。
+每周 workflow 检查 canonical GitHub repo、redirect、archive、license metadata、release 和最近活动。较久没 push 只会产生 warning，不会自动删除稳定且仍有教学价值的项目。模型、价格、API 和产品能力仍要回官方文件逐章查证。
 
 ---
 
-> 这份路线图不是契约。它反映“现在”的方向，会随社区投入而变。最可靠的“接下来要做什么”永远是 open issues + Discussions。
+<a id="基础建设maintainer-进行中"></a>
+
+## ✅ 最近完成
+
+- Stage 0–8 和 A1–A3 已完成第一轮渐进式揭露、核心词、资源表和三语整理。
+- Stage 2 保留 zero-shot、one-shot、few-shot、Chain of Thought，并加入三语 Prompt Engineering 概念图。
+- Stage 3 加入三语 Tool Use 循环图；Stage 6 重画两条路的 RAG pipeline；Stage 8 补上界面选择与安全检查图。
+- Stage 0 有整合练习；Stage 7.5 本来就是 reading map；Stage 8 已有可复制安全练习，独立 end-to-end 范例仍可贡献。
+- MkDocs build、mirror／anchor／locale、reader-UX、freshness 和 repository snapshot gate 都已纳入维护流程。
+
+---
+
+## 🟢 很适合贡献的小任务
+
+- 回报过时事实或失效链接，并附官方新来源。
+- 给一个练习补上更清楚的“怎么跑”和成功条件。
+- 修顺一段英文或简中，但不要改变原意、数字、URL 或安全规则。
+- 给 role path 补一个真实情境，写清输入、输出、人工检查和隐私边界。
+- 给稳定项目补 status／license／限制；不要只用 stars 或最近 push 日期下结论。
+
+先看 [`CONTRIBUTING.zh-Hans.md`](CONTRIBUTING.zh-Hans.md)；想长期维护一章，再看 [`CONTRIBUTORS.zh-Hans.md`](CONTRIBUTORS.zh-Hans.md)。
+
+---
+
+<a id="想法箱待讨论还没承诺"></a>
+
+## 🔵 还在讨论
+
+- 是否需要第三条 no-code／web-only 正式轨道；日常用户目前可直接走角色路径。
+- 是否加入最小视频 walkthrough；需要先衡量字幕、三语同步和维护成本。
+- Voice Agent 与 VLA 应放在 Stage 8／研究或开发者延伸，还是需要独立专题页。
+
+想法请开 [Discussion](https://github.com/WenyuChiou/awesome-agentic-ai-zh/discussions)；issue 留给缺陷、过时信息或明确的新资源。

--- a/branches/for-developer.en.md
+++ b/branches/for-developer.en.md
@@ -153,7 +153,7 @@ Branches that overlap heavily with developers:
 - **Wire Notion / Linear / Atlassian / Postgres / Figma into your CLI** → [`resources/mcp-skills-catalog.en.md`](../resources/mcp-skills-catalog.en.md)
 - **Author your own Skill / MCP server** → [Stage 5](../stages/05-claude-code-ecosystem.en.md) + [`resources/cookbook.en.md`](../resources/cookbook.en.md)
 - **Schema design details** → [`resources/schema-design-cheatsheet.en.md`](../resources/schema-design-cheatsheet.en.md)
-- **CLI from zero** → [Track A](../tracks/cli/A1-cli-intro.en.md) (A1 → A2 → A3)
+- **CLI from zero** → [Track A](../tracks/cli/A1-cli-intro.en.md) (A1 → A2 → [Stage 5 sections 5.1–5.4](../stages/05-claude-code-ecosystem.en.md#-entry-requirements-and-reading-paths) → A3; Stage 8 is recommended but does not block the Capstone)
 
 ## Community Note
 

--- a/branches/for-developer.md
+++ b/branches/for-developer.md
@@ -153,7 +153,7 @@ jobs:
 - **接 Notion / Linear / Atlassian / Postgres / Figma** 等 dev tool → [`resources/mcp-skills-catalog.md`](../resources/mcp-skills-catalog.md)
 - **要寫自己的 Skill / MCP server** → [Stage 5](../stages/05-claude-code-ecosystem.md) + [`resources/cookbook.md`](../resources/cookbook.md)
 - **想看 schema 設計細節** → [`resources/schema-design-cheatsheet.md`](../resources/schema-design-cheatsheet.md)
-- **CLI 從零開始** → [Track A](../tracks/cli/A1-cli-intro.md)（A1 → A2 → A3）
+- **CLI 從零開始** → [Track A](../tracks/cli/A1-cli-intro.md)（A1 → A2 → [Stage 5 的 5.1–5.4](../stages/05-claude-code-ecosystem.md#-進入條件與閱讀路線) → A3；Stage 8 建議完成，但不擋 Capstone）
 
 ## 社群備註
 

--- a/branches/for-developer.zh-Hans.md
+++ b/branches/for-developer.zh-Hans.md
@@ -153,7 +153,7 @@ jobs:
 - **接 Notion / Linear / Atlassian / Postgres / Figma** 等 dev tool → [`resources/mcp-skills-catalog.zh-Hans.md`](../resources/mcp-skills-catalog.zh-Hans.md)
 - **要写自己的 Skill / MCP server** → [Stage 5](../stages/05-claude-code-ecosystem.zh-Hans.md) + [`resources/cookbook.zh-Hans.md`](../resources/cookbook.zh-Hans.md)
 - **想看 schema 设计细节** → [`resources/schema-design-cheatsheet.zh-Hans.md`](../resources/schema-design-cheatsheet.zh-Hans.md)
-- **CLI 从零开始** → [Track A](../tracks/cli/A1-cli-intro.zh-Hans.md)（A1 → A2 → A3）
+- **CLI 从零开始** → [Track A](../tracks/cli/A1-cli-intro.zh-Hans.md)（A1 → A2 → [Stage 5 的 5.1–5.4](../stages/05-claude-code-ecosystem.zh-Hans.md#-进入条件与阅读路径) → A3；Stage 8 建议完成，但不影响 Capstone）
 
 ## 社群备注
 

--- a/docs/TESTING_PLAN.md
+++ b/docs/TESTING_PLAN.md
@@ -153,6 +153,15 @@ at `4,625／7,281／4,702` non-whitespace characters with only a 50-character al
 and requires all eight core terms before Exercise 1. The freshness gate separately enforces
 the 90-day fact pack for Computer Use, Browser Use, sandboxes, availability, benchmarks, and security.
 
+### Whole-site learner-route coherence
+
+`scripts/test_site_route_coherence.py` treats text navigation as the source of truth before diagrams
+are redrawn. It locks Track A to `A1 → A2 → Stage 5 → A3 → Stage 8`, requires A2 to hand off to
+Stage 5, requires Stage 5 to split Track A toward A3 and Track B toward Stage 6, and requires A3 to
+list the Track A core of Stage 5 as a prerequisite. It also keeps Stage 8 recommended for Track A
+without making it a Capstone entry requirement, and rejects completed or stale ROADMAP gap claims
+in any locale.
+
 ## v2 path (deferred)
 
 Per `docs/HOW_TO_USE.md` "給維護者：v2 path":

--- a/scripts/reader-ux-pages.yml
+++ b/scripts/reader-ux-pages.yml
@@ -958,9 +958,9 @@ pages:
         en: {heading: "🎯 Curated projects and learning resources", anchor: -curated-projects-and-learning-resources}
         zh-Hans: {heading: "🎯 精选项目与学习资源", anchor: -精选项目与学习资源}
       completion:
-        zh-TW: {heading: "✅ 進入 Stage 6 前的自我檢查", anchor: -進入-stage-6-前的自我檢查}
-        en: {heading: "✅ Self-check before Stage 6", anchor: -self-check-before-stage-6}
-        zh-Hans: {heading: "✅ 进入 Stage 6 前的自我检查", anchor: -进入-stage-6-前的自我检查}
+        zh-TW: {heading: "✅ 進入下一站前的自我檢查", anchor: -進入下一站前的自我檢查}
+        en: {heading: "✅ Self-check before your next stop", anchor: -self-check-before-your-next-stop}
+        zh-Hans: {heading: "✅ 进入下一站前的自我检查", anchor: -进入下一站前的自我检查}
     core_terms:
       section_id: core-terms
       first_exercise_section_id: exercise-1
@@ -1663,7 +1663,7 @@ pages:
       zh-Hans: tracks/cli/A2-cli-workflow.zh-Hans.md
     max_visible_chars:
       zh-TW: 2699
-      en: 4872
+      en: 4938
       zh-Hans: 2682
     max_open_details: 0
     visible_section_order: [core-terms, learning-goals, required-reading, hands-on, projects, completion]
@@ -1760,14 +1760,14 @@ pages:
           anchor: 动手练习-cli-8做一张-portable-prompt-对照卡
       completion:
         zh-TW:
-          heading: "✅ 進 A3 前的自我檢查"
-          anchor: -進-a3-前的自我檢查
+          heading: "✅ 進 Stage 5 前的自我檢查"
+          anchor: -進-stage-5-前的自我檢查
         en:
-          heading: "✅ Self-check before A3"
-          anchor: -self-check-before-a3
+          heading: "✅ Self-check before Stage 5"
+          anchor: -self-check-before-stage-5
         zh-Hans:
-          heading: "✅ 进入 A3 前的自我检查"
-          anchor: -进入-a3-前的自我检查
+          heading: "✅ 进入 Stage 5 前的自我检查"
+          anchor: -进入-stage-5-前的自我检查
     core_terms:
       section_id: core-terms
       first_exercise_section_id: cli-5

--- a/scripts/repository-freshness-snapshot.json
+++ b/scripts/repository-freshness-snapshot.json
@@ -1,12 +1,12 @@
 {
   "schema_version": 1,
-  "verified_at": "2026-08-29T00:20:01Z",
+  "verified_at": "2026-08-29T00:39:03Z",
   "repository_count": 259,
   "repositories": {
     "01-ai/yi": {
       "requested": "01-ai/Yi",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "01-ai/Yi",
       "html_url": "https://github.com/01-ai/Yi",
@@ -28,7 +28,7 @@
     "1weiho/open-slide": {
       "requested": "1weiho/open-slide",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "1weiho/open-slide",
       "html_url": "https://github.com/1weiho/open-slide",
@@ -53,7 +53,7 @@
     "21st-dev/magic-mcp": {
       "requested": "21st-dev/magic-mcp",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "21st-dev/magic-mcp",
       "html_url": "https://github.com/21st-dev/magic-mcp",
@@ -75,7 +75,7 @@
     "567-labs/instructor": {
       "requested": "567-labs/instructor",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "567-labs/instructor",
       "html_url": "https://github.com/567-labs/instructor",
@@ -103,7 +103,7 @@
     "aaif-goose/goose": {
       "requested": "aaif-goose/goose",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "aaif-goose/goose",
       "html_url": "https://github.com/aaif-goose/goose",
@@ -134,7 +134,7 @@
     "agentscope-ai/agentscope": {
       "requested": "agentscope-ai/agentscope",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "agentscope-ai/agentscope",
       "html_url": "https://github.com/agentscope-ai/agentscope",
@@ -159,7 +159,7 @@
     "agno-agi/agno": {
       "requested": "agno-agi/agno",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "agno-agi/agno",
       "html_url": "https://github.com/agno-agi/agno",
@@ -184,7 +184,7 @@
     "ai-boost/awesome-harness-engineering": {
       "requested": "ai-boost/awesome-harness-engineering",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "ai-boost/awesome-harness-engineering",
       "html_url": "https://github.com/ai-boost/awesome-harness-engineering",
@@ -212,7 +212,7 @@
     "aider-ai/aider": {
       "requested": "Aider-AI/aider",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "Aider-AI/aider",
       "html_url": "https://github.com/Aider-AI/aider",
@@ -243,7 +243,7 @@
     "aihubcn/awesome-chinese-llm": {
       "requested": "AiHubCN/Awesome-Chinese-LLM",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "AiHubCN/Awesome-Chinese-LLM",
       "html_url": "https://github.com/AiHubCN/Awesome-Chinese-LLM",
@@ -267,7 +267,7 @@
     "alirezarezvani/claude-skills": {
       "requested": "alirezarezvani/claude-skills",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "alirezarezvani/claude-skills",
       "html_url": "https://github.com/alirezarezvani/claude-skills",
@@ -292,7 +292,7 @@
     "amap-ml/longhorizon-harness": {
       "requested": "AMAP-ML/LongHorizon-Harness",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "AMAP-ML/LongHorizon-Harness",
       "html_url": "https://github.com/AMAP-ML/LongHorizon-Harness",
@@ -317,7 +317,7 @@
     "ankimcp/anki-mcp-server": {
       "requested": "ankimcp/anki-mcp-server",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "ankimcp/anki-mcp-server",
       "html_url": "https://github.com/ankimcp/anki-mcp-server",
@@ -342,7 +342,7 @@
     "anomalyco/opencode": {
       "requested": "anomalyco/opencode",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "anomalyco/opencode",
       "html_url": "https://github.com/anomalyco/opencode",
@@ -352,7 +352,7 @@
       "visibility": "public",
       "default_branch": "dev",
       "license": "MIT",
-      "pushed_at": "2026-08-28T23:41:33Z",
+      "pushed_at": "2026-08-29T00:31:31Z",
       "latest_release": {
         "tag": "v1.18.25",
         "published_at": "2026-08-28T05:58:20Z"
@@ -382,7 +382,7 @@
     "anthropics/claude-agent-sdk-python": {
       "requested": "anthropics/claude-agent-sdk-python",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "anthropics/claude-agent-sdk-python",
       "html_url": "https://github.com/anthropics/claude-agent-sdk-python",
@@ -413,7 +413,7 @@
     "anthropics/claude-code": {
       "requested": "anthropics/claude-code",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "anthropics/claude-code",
       "html_url": "https://github.com/anthropics/claude-code",
@@ -459,7 +459,7 @@
     "anthropics/claude-code-action": {
       "requested": "anthropics/claude-code-action",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "anthropics/claude-code-action",
       "html_url": "https://github.com/anthropics/claude-code-action",
@@ -487,7 +487,7 @@
     "anthropics/claude-cookbooks": {
       "requested": "anthropics/claude-cookbooks",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "anthropics/claude-cookbooks",
       "html_url": "https://github.com/anthropics/claude-cookbooks",
@@ -524,7 +524,7 @@
     "anthropics/claude-for-legal": {
       "requested": "anthropics/claude-for-legal",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "anthropics/claude-for-legal",
       "html_url": "https://github.com/anthropics/claude-for-legal",
@@ -546,7 +546,7 @@
     "anthropics/claude-plugins-official": {
       "requested": "anthropics/claude-plugins-official",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "anthropics/claude-plugins-official",
       "html_url": "https://github.com/anthropics/claude-plugins-official",
@@ -578,7 +578,7 @@
     "anthropics/claude-quickstarts": {
       "requested": "anthropics/claude-quickstarts",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "anthropics/claude-quickstarts",
       "html_url": "https://github.com/anthropics/claude-quickstarts",
@@ -603,7 +603,7 @@
     "anthropics/courses": {
       "requested": "anthropics/courses",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "anthropics/courses",
       "html_url": "https://github.com/anthropics/courses",
@@ -631,7 +631,7 @@
     "anthropics/knowledge-work-plugins": {
       "requested": "anthropics/knowledge-work-plugins",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "anthropics/knowledge-work-plugins",
       "html_url": "https://github.com/anthropics/knowledge-work-plugins",
@@ -653,7 +653,7 @@
     "anthropics/life-sciences": {
       "requested": "anthropics/life-sciences",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "anthropics/life-sciences",
       "html_url": "https://github.com/anthropics/life-sciences",
@@ -678,7 +678,7 @@
     "anthropics/prompt-eng-interactive-tutorial": {
       "requested": "anthropics/prompt-eng-interactive-tutorial",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "anthropics/prompt-eng-interactive-tutorial",
       "html_url": "https://github.com/anthropics/prompt-eng-interactive-tutorial",
@@ -703,7 +703,7 @@
     "anthropics/skills": {
       "requested": "anthropics/skills",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "anthropics/skills",
       "html_url": "https://github.com/anthropics/skills",
@@ -737,7 +737,7 @@
     "arize-ai/phoenix": {
       "requested": "Arize-ai/phoenix",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "Arize-ai/phoenix",
       "html_url": "https://github.com/Arize-ai/phoenix",
@@ -768,7 +768,7 @@
     "arunpshankar/react-from-scratch": {
       "requested": "arunpshankar/react-from-scratch",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "arunpshankar/react-from-scratch",
       "html_url": "https://github.com/arunpshankar/react-from-scratch",
@@ -790,7 +790,7 @@
     "assafelovic/gpt-researcher": {
       "requested": "assafelovic/gpt-researcher",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "assafelovic/gpt-researcher",
       "html_url": "https://github.com/assafelovic/gpt-researcher",
@@ -815,7 +815,7 @@
     "atlassian/atlassian-mcp-server": {
       "requested": "atlassian/atlassian-mcp-server",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "atlassian/atlassian-mcp-server",
       "html_url": "https://github.com/atlassian/atlassian-mcp-server",
@@ -840,7 +840,7 @@
     "awslabs/mcp": {
       "requested": "awslabs/mcp",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "awslabs/mcp",
       "html_url": "https://github.com/awslabs/mcp",
@@ -865,7 +865,7 @@
     "benborla/mcp-server-mysql": {
       "requested": "benborla/mcp-server-mysql",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "benborla/mcp-server-mysql",
       "html_url": "https://github.com/benborla/mcp-server-mysql",
@@ -890,7 +890,7 @@
     "bentoml/bentoml": {
       "requested": "bentoml/BentoML",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "bentoml/BentoML",
       "html_url": "https://github.com/bentoml/BentoML",
@@ -915,7 +915,7 @@
     "berriai/litellm": {
       "requested": "BerriAI/litellm",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "BerriAI/litellm",
       "html_url": "https://github.com/BerriAI/litellm",
@@ -925,7 +925,7 @@
       "visibility": "public",
       "default_branch": "litellm_internal_staging",
       "license": "NOASSERTION",
-      "pushed_at": "2026-08-29T00:16:02Z",
+      "pushed_at": "2026-08-29T00:37:24Z",
       "latest_release": {
         "tag": "v1.98.0",
         "published_at": "2026-08-23T00:28:24Z"
@@ -940,7 +940,7 @@
     "browser-use/browser-use": {
       "requested": "browser-use/browser-use",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "browser-use/browser-use",
       "html_url": "https://github.com/browser-use/browser-use",
@@ -968,7 +968,7 @@
     "browserbase/mcp-server-browserbase": {
       "requested": "browserbase/mcp-server-browserbase",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "browserbase/mcp-server-browserbase",
       "html_url": "https://github.com/browserbase/mcp-server-browserbase",
@@ -993,7 +993,7 @@
     "bytebase/dbhub": {
       "requested": "bytebase/dbhub",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "bytebase/dbhub",
       "html_url": "https://github.com/bytebase/dbhub",
@@ -1018,7 +1018,7 @@
     "bytedance/ui-tars-desktop": {
       "requested": "bytedance/UI-TARS-desktop",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "bytedance/UI-TARS-desktop",
       "html_url": "https://github.com/bytedance/UI-TARS-desktop",
@@ -1043,7 +1043,7 @@
     "cft0808/edict": {
       "requested": "cft0808/edict",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "cft0808/edict",
       "html_url": "https://github.com/cft0808/edict",
@@ -1066,7 +1066,7 @@
     "chatchat-space/langchain-chatchat": {
       "requested": "chatchat-space/Langchain-Chatchat",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "chatchat-space/Langchain-Chatchat",
       "html_url": "https://github.com/chatchat-space/Langchain-Chatchat",
@@ -1091,7 +1091,7 @@
     "chroma-core/chroma": {
       "requested": "chroma-core/chroma",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "chroma-core/chroma",
       "html_url": "https://github.com/chroma-core/chroma",
@@ -1116,7 +1116,7 @@
     "chromedevtools/chrome-devtools-mcp": {
       "requested": "ChromeDevTools/chrome-devtools-mcp",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "ChromeDevTools/chrome-devtools-mcp",
       "html_url": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
@@ -1141,7 +1141,7 @@
     "cline/cline": {
       "requested": "cline/cline",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "cline/cline",
       "html_url": "https://github.com/cline/cline",
@@ -1151,7 +1151,7 @@
       "visibility": "public",
       "default_branch": "main",
       "license": "Apache-2.0",
-      "pushed_at": "2026-08-29T00:18:53Z",
+      "pushed_at": "2026-08-29T00:25:33Z",
       "latest_release": {
         "tag": "desktop-v0.0.20",
         "published_at": "2026-08-28T01:33:08Z"
@@ -1166,7 +1166,7 @@
     "cloudflare/mcp-server-cloudflare": {
       "requested": "cloudflare/mcp-server-cloudflare",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "cloudflare/mcp-server-cloudflare",
       "html_url": "https://github.com/cloudflare/mcp-server-cloudflare",
@@ -1191,7 +1191,7 @@
     "cloudflare/sandbox-sdk": {
       "requested": "cloudflare/sandbox-sdk",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "cloudflare/sandbox-sdk",
       "html_url": "https://github.com/cloudflare/sandbox-sdk",
@@ -1216,7 +1216,7 @@
     "coddingtonbear/obsidian-local-rest-api": {
       "requested": "coddingtonbear/obsidian-local-rest-api",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "coddingtonbear/obsidian-local-rest-api",
       "html_url": "https://github.com/coddingtonbear/obsidian-local-rest-api",
@@ -1241,7 +1241,7 @@
     "comet-ml/opik": {
       "requested": "comet-ml/opik",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "comet-ml/opik",
       "html_url": "https://github.com/comet-ml/opik",
@@ -1266,7 +1266,7 @@
     "composiohq/composio": {
       "requested": "ComposioHQ/composio",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "ComposioHQ/composio",
       "html_url": "https://github.com/ComposioHQ/composio",
@@ -1276,7 +1276,7 @@
       "visibility": "public",
       "default_branch": "next",
       "license": "MIT",
-      "pushed_at": "2026-08-29T00:05:37Z",
+      "pushed_at": "2026-08-29T00:25:12Z",
       "latest_release": {
         "tag": "@composio/vercel@0.11.2",
         "published_at": "2026-08-27T18:24:56Z"
@@ -1291,7 +1291,7 @@
     "continuedev/continue": {
       "requested": "continuedev/continue",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "continuedev/continue",
       "html_url": "https://github.com/continuedev/continue",
@@ -1316,7 +1316,7 @@
     "coze-dev/coze-loop": {
       "requested": "coze-dev/coze-loop",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "coze-dev/coze-loop",
       "html_url": "https://github.com/coze-dev/coze-loop",
@@ -1341,7 +1341,7 @@
     "coze-dev/coze-studio": {
       "requested": "coze-dev/coze-studio",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "coze-dev/coze-studio",
       "html_url": "https://github.com/coze-dev/coze-studio",
@@ -1366,7 +1366,7 @@
     "crewaiinc/crewai": {
       "requested": "crewAIInc/crewAI",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "crewAIInc/crewAI",
       "html_url": "https://github.com/crewAIInc/crewAI",
@@ -1394,7 +1394,7 @@
     "crewaiinc/crewai-examples": {
       "requested": "crewAIInc/crewAI-examples",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "crewAIInc/crewAI-examples",
       "html_url": "https://github.com/crewAIInc/crewAI-examples",
@@ -1416,7 +1416,7 @@
     "dair-ai/prompt-engineering-guide": {
       "requested": "dair-ai/Prompt-Engineering-Guide",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "dair-ai/Prompt-Engineering-Guide",
       "html_url": "https://github.com/dair-ai/Prompt-Engineering-Guide",
@@ -1438,7 +1438,7 @@
     "datawhalechina/agentic-ai": {
       "requested": "datawhalechina/agentic-ai",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "datawhalechina/agentic-ai",
       "html_url": "https://github.com/datawhalechina/agentic-ai",
@@ -1460,7 +1460,7 @@
     "datawhalechina/happy-llm": {
       "requested": "datawhalechina/happy-llm",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "datawhalechina/happy-llm",
       "html_url": "https://github.com/datawhalechina/happy-llm",
@@ -1485,7 +1485,7 @@
     "datawhalechina/hello-agents": {
       "requested": "datawhalechina/hello-agents",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "datawhalechina/hello-agents",
       "html_url": "https://github.com/datawhalechina/hello-agents",
@@ -1591,7 +1591,7 @@
     "datawhalechina/llm-cookbook": {
       "requested": "datawhalechina/llm-cookbook",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "datawhalechina/llm-cookbook",
       "html_url": "https://github.com/datawhalechina/llm-cookbook",
@@ -1616,7 +1616,7 @@
     "datawhalechina/llm-universe": {
       "requested": "datawhalechina/llm-universe",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "datawhalechina/llm-universe",
       "html_url": "https://github.com/datawhalechina/llm-universe",
@@ -1644,7 +1644,7 @@
     "deepseek-ai/deepseek-harness": {
       "requested": "deepseek-ai/deepseek-harness",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "deepseek-ai/deepseek-harness",
       "html_url": "https://github.com/deepseek-ai/deepseek-harness",
@@ -1667,7 +1667,7 @@
     "deepset-ai/haystack": {
       "requested": "deepset-ai/haystack",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "deepset-ai/haystack",
       "html_url": "https://github.com/deepset-ai/haystack",
@@ -1692,7 +1692,7 @@
     "deusdata/codebase-memory-mcp": {
       "requested": "DeusData/codebase-memory-mcp",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "DeusData/codebase-memory-mcp",
       "html_url": "https://github.com/DeusData/codebase-memory-mcp",
@@ -1717,7 +1717,7 @@
     "dottxt-ai/outlines": {
       "requested": "dottxt-ai/outlines",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "dottxt-ai/outlines",
       "html_url": "https://github.com/dottxt-ai/outlines",
@@ -1742,7 +1742,7 @@
     "e2b-dev/e2b": {
       "requested": "e2b-dev/E2B",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "e2b-dev/E2B",
       "html_url": "https://github.com/e2b-dev/E2B",
@@ -1767,7 +1767,7 @@
     "earendil-works/pi": {
       "requested": "earendil-works/pi",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "earendil-works/pi",
       "html_url": "https://github.com/earendil-works/pi",
@@ -1798,7 +1798,7 @@
     "ehmatthes/pcc_3e": {
       "requested": "ehmatthes/pcc_3e",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "ehmatthes/pcc_3e",
       "html_url": "https://github.com/ehmatthes/pcc_3e",
@@ -1823,7 +1823,7 @@
     "ergut/mcp-logseq": {
       "requested": "ergut/mcp-logseq",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "ergut/mcp-logseq",
       "html_url": "https://github.com/ergut/mcp-logseq",
@@ -1848,7 +1848,7 @@
     "exa-labs/exa-mcp-server": {
       "requested": "exa-labs/exa-mcp-server",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "exa-labs/exa-mcp-server",
       "html_url": "https://github.com/exa-labs/exa-mcp-server",
@@ -1870,7 +1870,7 @@
     "excalidraw/excalidraw-mcp": {
       "requested": "excalidraw/excalidraw-mcp",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "excalidraw/excalidraw-mcp",
       "html_url": "https://github.com/excalidraw/excalidraw-mcp",
@@ -1895,7 +1895,7 @@
     "f/prompts.chat": {
       "requested": "f/prompts.chat",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "f/prompts.chat",
       "html_url": "https://github.com/f/prompts.chat",
@@ -1920,7 +1920,7 @@
     "firecrawl/firecrawl-mcp-server": {
       "requested": "firecrawl/firecrawl-mcp-server",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "firecrawl/firecrawl-mcp-server",
       "html_url": "https://github.com/firecrawl/firecrawl-mcp-server",
@@ -1945,7 +1945,7 @@
     "flonat/flonat-research": {
       "requested": "flonat/flonat-research",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "flonat/flonat-research",
       "html_url": "https://github.com/flonat/flonat-research",
@@ -1970,7 +1970,7 @@
     "future-house/paper-qa": {
       "requested": "Future-House/paper-qa",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "Future-House/paper-qa",
       "html_url": "https://github.com/Future-House/paper-qa",
@@ -1995,7 +1995,7 @@
     "getsentry/sentry-mcp": {
       "requested": "getsentry/sentry-mcp",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "getsentry/sentry-mcp",
       "html_url": "https://github.com/getsentry/sentry-mcp",
@@ -2020,7 +2020,7 @@
     "getzep/graphiti": {
       "requested": "getzep/graphiti",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "getzep/graphiti",
       "html_url": "https://github.com/getzep/graphiti",
@@ -2045,7 +2045,7 @@
     "getzep/zep": {
       "requested": "getzep/zep",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "getzep/zep",
       "html_url": "https://github.com/getzep/zep",
@@ -2070,7 +2070,7 @@
     "ggml-org/llama.cpp": {
       "requested": "ggml-org/llama.cpp",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "ggml-org/llama.cpp",
       "html_url": "https://github.com/ggml-org/llama.cpp",
@@ -2095,7 +2095,7 @@
     "github/github-mcp-server": {
       "requested": "github/github-mcp-server",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "github/github-mcp-server",
       "html_url": "https://github.com/github/github-mcp-server",
@@ -2129,7 +2129,7 @@
     "glips/figma-context-mcp": {
       "requested": "GLips/Figma-Context-MCP",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "GLips/Figma-Context-MCP",
       "html_url": "https://github.com/GLips/Figma-Context-MCP",
@@ -2154,7 +2154,7 @@
     "gongrzhe/office-powerpoint-mcp-server": {
       "requested": "GongRzhe/Office-PowerPoint-MCP-Server",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "GongRzhe/Office-PowerPoint-MCP-Server",
       "html_url": "https://github.com/GongRzhe/Office-PowerPoint-MCP-Server",
@@ -2179,7 +2179,7 @@
     "google-gemini/cookbook": {
       "requested": "google-gemini/cookbook",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "google-gemini/cookbook",
       "html_url": "https://github.com/google-gemini/cookbook",
@@ -2201,7 +2201,7 @@
     "google-gemini/gemini-cli": {
       "requested": "google-gemini/gemini-cli",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "google-gemini/gemini-cli",
       "html_url": "https://github.com/google-gemini/gemini-cli",
@@ -2241,7 +2241,7 @@
     "googleapis/mcp-toolbox": {
       "requested": "googleapis/mcp-toolbox",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "googleapis/mcp-toolbox",
       "html_url": "https://github.com/googleapis/mcp-toolbox",
@@ -2266,7 +2266,7 @@
     "googlecloudplatform/generative-ai": {
       "requested": "GoogleCloudPlatform/generative-ai",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "GoogleCloudPlatform/generative-ai",
       "html_url": "https://github.com/GoogleCloudPlatform/generative-ai",
@@ -2288,7 +2288,7 @@
     "grafana/mcp-grafana": {
       "requested": "grafana/mcp-grafana",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "grafana/mcp-grafana",
       "html_url": "https://github.com/grafana/mcp-grafana",
@@ -2313,7 +2313,7 @@
     "graphify-labs/graphify": {
       "requested": "Graphify-Labs/graphify",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "Graphify-Labs/graphify",
       "html_url": "https://github.com/Graphify-Labs/graphify",
@@ -2338,7 +2338,7 @@
     "harbor-framework/terminal-bench-1": {
       "requested": "harbor-framework/terminal-bench-1",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "harbor-framework/terminal-bench-1",
       "html_url": "https://github.com/harbor-framework/terminal-bench-1",
@@ -2360,7 +2360,7 @@
     "hardness1020/awesome-agent-architecture": {
       "requested": "hardness1020/awesome-agent-architecture",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "hardness1020/awesome-agent-architecture",
       "html_url": "https://github.com/hardness1020/awesome-agent-architecture",
@@ -2385,7 +2385,7 @@
     "haris-musa/excel-mcp-server": {
       "requested": "haris-musa/excel-mcp-server",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "haris-musa/excel-mcp-server",
       "html_url": "https://github.com/haris-musa/excel-mcp-server",
@@ -2410,7 +2410,7 @@
     "helicone/helicone": {
       "requested": "Helicone/helicone",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "Helicone/helicone",
       "html_url": "https://github.com/Helicone/helicone",
@@ -2435,7 +2435,7 @@
     "henryfcb/openclaw-memory-enhancer": {
       "requested": "henryfcb/openclaw-memory-enhancer",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "henryfcb/openclaw-memory-enhancer",
       "html_url": "https://github.com/henryfcb/openclaw-memory-enhancer",
@@ -2460,7 +2460,7 @@
     "hesreallyhim/awesome-claude-code": {
       "requested": "hesreallyhim/awesome-claude-code",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "hesreallyhim/awesome-claude-code",
       "html_url": "https://github.com/hesreallyhim/awesome-claude-code",
@@ -2470,7 +2470,7 @@
       "visibility": "public",
       "default_branch": "main",
       "license": "NOASSERTION",
-      "pushed_at": "2026-08-28T21:24:16Z",
+      "pushed_at": "2026-08-29T00:24:30Z",
       "latest_release": null,
       "reference_count": 14,
       "sources": [
@@ -2493,7 +2493,7 @@
     "hkuds/lightrag": {
       "requested": "HKUDS/LightRAG",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "HKUDS/LightRAG",
       "html_url": "https://github.com/HKUDS/LightRAG",
@@ -2518,7 +2518,7 @@
     "httpie/cli": {
       "requested": "httpie/cli",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "httpie/cli",
       "html_url": "https://github.com/httpie/cli",
@@ -2543,7 +2543,7 @@
     "huggingface/agents-course": {
       "requested": "huggingface/agents-course",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "huggingface/agents-course",
       "html_url": "https://github.com/huggingface/agents-course",
@@ -2565,7 +2565,7 @@
     "huggingface/smolagents": {
       "requested": "huggingface/smolagents",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "huggingface/smolagents",
       "html_url": "https://github.com/huggingface/smolagents",
@@ -2596,7 +2596,7 @@
     "infiniflow/ragflow": {
       "requested": "infiniflow/ragflow",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "infiniflow/ragflow",
       "html_url": "https://github.com/infiniflow/ragflow",
@@ -2621,7 +2621,7 @@
     "jd/tenacity": {
       "requested": "jd/tenacity",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "jd/tenacity",
       "html_url": "https://github.com/jd/tenacity",
@@ -2646,7 +2646,7 @@
     "jerhadf/linear-mcp-server": {
       "requested": "jerhadf/linear-mcp-server",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "jerhadf/linear-mcp-server",
       "html_url": "https://github.com/jerhadf/linear-mcp-server",
@@ -2671,7 +2671,7 @@
     "jingyaogong/minimind": {
       "requested": "jingyaogong/minimind",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "jingyaogong/minimind",
       "html_url": "https://github.com/jingyaogong/minimind",
@@ -2696,7 +2696,7 @@
     "jjyaoao/helloagents": {
       "requested": "jjyaoao/HelloAgents",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "jjyaoao/HelloAgents",
       "html_url": "https://github.com/jjyaoao/HelloAgents",
@@ -2724,7 +2724,7 @@
     "jlevy/the-art-of-command-line": {
       "requested": "jlevy/the-art-of-command-line",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "jlevy/the-art-of-command-line",
       "html_url": "https://github.com/jlevy/the-art-of-command-line",
@@ -2746,7 +2746,7 @@
     "jqlang/jq": {
       "requested": "jqlang/jq",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "jqlang/jq",
       "html_url": "https://github.com/jqlang/jq",
@@ -2771,7 +2771,7 @@
     "k88hudson/git-flight-rules": {
       "requested": "k88hudson/git-flight-rules",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "k88hudson/git-flight-rules",
       "html_url": "https://github.com/k88hudson/git-flight-rules",
@@ -2793,7 +2793,7 @@
     "kaixindelele/chatpaper": {
       "requested": "kaixindelele/ChatPaper",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "kaixindelele/ChatPaper",
       "html_url": "https://github.com/kaixindelele/ChatPaper",
@@ -2815,7 +2815,7 @@
     "karpathy/llm101n": {
       "requested": "karpathy/LLM101n",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "karpathy/LLM101n",
       "html_url": "https://github.com/karpathy/LLM101n",
@@ -2837,7 +2837,7 @@
     "khoj-ai/khoj": {
       "requested": "khoj-ai/khoj",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "khoj-ai/khoj",
       "html_url": "https://github.com/khoj-ai/khoj",
@@ -2862,7 +2862,7 @@
     "kimtaeyoon83/mcp-server-youtube-transcript": {
       "requested": "kimtaeyoon83/mcp-server-youtube-transcript",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "kimtaeyoon83/mcp-server-youtube-transcript",
       "html_url": "https://github.com/kimtaeyoon83/mcp-server-youtube-transcript",
@@ -2884,7 +2884,7 @@
     "kimyx0207/ai-coding-guide-zh": {
       "requested": "KimYx0207/AI-Coding-Guide-Zh",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "KimYx0207/AI-Coding-Guide-Zh",
       "html_url": "https://github.com/KimYx0207/AI-Coding-Guide-Zh",
@@ -2909,7 +2909,7 @@
     "korotovsky/slack-mcp-server": {
       "requested": "korotovsky/slack-mcp-server",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "korotovsky/slack-mcp-server",
       "html_url": "https://github.com/korotovsky/slack-mcp-server",
@@ -2937,7 +2937,7 @@
     "kyrolabs/awesome-agents": {
       "requested": "kyrolabs/awesome-agents",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "kyrolabs/awesome-agents",
       "html_url": "https://github.com/kyrolabs/awesome-agents",
@@ -2957,7 +2957,7 @@
     "kyrolabs/awesome-langchain": {
       "requested": "kyrolabs/awesome-langchain",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "kyrolabs/awesome-langchain",
       "html_url": "https://github.com/kyrolabs/awesome-langchain",
@@ -2977,7 +2977,7 @@
     "lancedb/lancedb": {
       "requested": "lancedb/lancedb",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "lancedb/lancedb",
       "html_url": "https://github.com/lancedb/lancedb",
@@ -3002,7 +3002,7 @@
     "langchain-ai/deepagents": {
       "requested": "langchain-ai/deepagents",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "langchain-ai/deepagents",
       "html_url": "https://github.com/langchain-ai/deepagents",
@@ -3012,7 +3012,7 @@
       "visibility": "public",
       "default_branch": "main",
       "license": "MIT",
-      "pushed_at": "2026-08-28T23:59:28Z",
+      "pushed_at": "2026-08-29T00:26:29Z",
       "latest_release": {
         "tag": "deepagents==0.7.11",
         "published_at": "2026-08-28T23:11:01Z"
@@ -3033,7 +3033,7 @@
     "langchain-ai/langchain": {
       "requested": "langchain-ai/langchain",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "langchain-ai/langchain",
       "html_url": "https://github.com/langchain-ai/langchain",
@@ -3059,7 +3059,7 @@
     "langchain-ai/langgraph": {
       "requested": "langchain-ai/langgraph",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "langchain-ai/langgraph",
       "html_url": "https://github.com/langchain-ai/langgraph",
@@ -3090,7 +3090,7 @@
     "langchain-ai/langmem": {
       "requested": "langchain-ai/langmem",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "langchain-ai/langmem",
       "html_url": "https://github.com/langchain-ai/langmem",
@@ -3112,7 +3112,7 @@
     "langchain-ai/open_deep_research": {
       "requested": "langchain-ai/open_deep_research",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "langchain-ai/open_deep_research",
       "html_url": "https://github.com/langchain-ai/open_deep_research",
@@ -3134,7 +3134,7 @@
     "langchain-ai/openwiki": {
       "requested": "langchain-ai/openwiki",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "langchain-ai/openwiki",
       "html_url": "https://github.com/langchain-ai/openwiki",
@@ -3159,7 +3159,7 @@
     "langchain-ai/react-agent": {
       "requested": "langchain-ai/react-agent",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "langchain-ai/react-agent",
       "html_url": "https://github.com/langchain-ai/react-agent",
@@ -3181,7 +3181,7 @@
     "langflow-ai/langflow": {
       "requested": "langflow-ai/langflow",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "langflow-ai/langflow",
       "html_url": "https://github.com/langflow-ai/langflow",
@@ -3191,7 +3191,7 @@
       "visibility": "public",
       "default_branch": "main",
       "license": "MIT",
-      "pushed_at": "2026-08-28T23:32:48Z",
+      "pushed_at": "2026-08-29T00:35:08Z",
       "latest_release": {
         "tag": "v1.11.5",
         "published_at": "2026-08-25T15:35:11Z"
@@ -3206,7 +3206,7 @@
     "langfuse/langfuse": {
       "requested": "langfuse/langfuse",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "langfuse/langfuse",
       "html_url": "https://github.com/langfuse/langfuse",
@@ -3237,7 +3237,7 @@
     "leemysw/feishu-docx": {
       "requested": "leemysw/feishu-docx",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "leemysw/feishu-docx",
       "html_url": "https://github.com/leemysw/feishu-docx",
@@ -3268,7 +3268,7 @@
     "letta-ai/letta": {
       "requested": "letta-ai/letta",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "letta-ai/letta",
       "html_url": "https://github.com/letta-ai/letta",
@@ -3296,7 +3296,7 @@
     "letta-ai/letta-code": {
       "requested": "letta-ai/letta-code",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "letta-ai/letta-code",
       "html_url": "https://github.com/letta-ai/letta-code",
@@ -3321,7 +3321,7 @@
     "liaokongvfx/langchain-chinese-getting-started-guide": {
       "requested": "liaokongVFX/LangChain-Chinese-Getting-Started-Guide",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "liaokongVFX/LangChain-Chinese-Getting-Started-Guide",
       "html_url": "https://github.com/liaokongVFX/LangChain-Chinese-Getting-Started-Guide",
@@ -3345,7 +3345,7 @@
     "livekit/agents": {
       "requested": "livekit/agents",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "livekit/agents",
       "html_url": "https://github.com/livekit/agents",
@@ -3370,7 +3370,7 @@
     "liyupi/ai-guide": {
       "requested": "liyupi/ai-guide",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "liyupi/ai-guide",
       "html_url": "https://github.com/liyupi/ai-guide",
@@ -3393,7 +3393,7 @@
     "lobehub/lobehub": {
       "requested": "lobehub/lobehub",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "lobehub/lobehub",
       "html_url": "https://github.com/lobehub/lobehub",
@@ -3418,7 +3418,7 @@
     "lsdefine/genericagent": {
       "requested": "lsdefine/GenericAgent",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "lsdefine/GenericAgent",
       "html_url": "https://github.com/lsdefine/GenericAgent",
@@ -3443,7 +3443,7 @@
     "makenotion/notion-mcp-server": {
       "requested": "makenotion/notion-mcp-server",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "makenotion/notion-mcp-server",
       "html_url": "https://github.com/makenotion/notion-mcp-server",
@@ -3471,7 +3471,7 @@
     "markuspfundstein/mcp-obsidian": {
       "requested": "MarkusPfundstein/mcp-obsidian",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "MarkusPfundstein/mcp-obsidian",
       "html_url": "https://github.com/MarkusPfundstein/mcp-obsidian",
@@ -3496,7 +3496,7 @@
     "mattambrogi/agent-implementation": {
       "requested": "mattambrogi/agent-implementation",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "mattambrogi/agent-implementation",
       "html_url": "https://github.com/mattambrogi/agent-implementation",
@@ -3518,7 +3518,7 @@
     "mattpocock/skills": {
       "requested": "mattpocock/skills",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "mattpocock/skills",
       "html_url": "https://github.com/mattpocock/skills",
@@ -3546,7 +3546,7 @@
     "meirtz/awesome-context-engineering": {
       "requested": "Meirtz/Awesome-Context-Engineering",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "Meirtz/Awesome-Context-Engineering",
       "html_url": "https://github.com/Meirtz/Awesome-Context-Engineering",
@@ -3568,7 +3568,7 @@
     "mem0ai/mem0": {
       "requested": "mem0ai/mem0",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "mem0ai/mem0",
       "html_url": "https://github.com/mem0ai/mem0",
@@ -3596,7 +3596,7 @@
     "merill/lokka": {
       "requested": "merill/lokka",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "merill/lokka",
       "html_url": "https://github.com/merill/lokka",
@@ -3618,7 +3618,7 @@
     "microsoft/agent-framework": {
       "requested": "microsoft/agent-framework",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "microsoft/agent-framework",
       "html_url": "https://github.com/microsoft/agent-framework",
@@ -3647,7 +3647,7 @@
     "microsoft/ai-agents-for-beginners": {
       "requested": "microsoft/ai-agents-for-beginners",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "microsoft/ai-agents-for-beginners",
       "html_url": "https://github.com/microsoft/ai-agents-for-beginners",
@@ -3672,7 +3672,7 @@
     "microsoft/autogen": {
       "requested": "microsoft/autogen",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "microsoft/autogen",
       "html_url": "https://github.com/microsoft/autogen",
@@ -3700,7 +3700,7 @@
     "microsoft/graphrag": {
       "requested": "microsoft/graphrag",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "microsoft/graphrag",
       "html_url": "https://github.com/microsoft/graphrag",
@@ -3725,7 +3725,7 @@
     "microsoft/omniparser": {
       "requested": "microsoft/OmniParser",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "microsoft/OmniParser",
       "html_url": "https://github.com/microsoft/OmniParser",
@@ -3750,7 +3750,7 @@
     "microsoft/playwright-mcp": {
       "requested": "microsoft/playwright-mcp",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "microsoft/playwright-mcp",
       "html_url": "https://github.com/microsoft/playwright-mcp",
@@ -3778,7 +3778,7 @@
     "microsoft/prompt-engine": {
       "requested": "microsoft/prompt-engine",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "microsoft/prompt-engine",
       "html_url": "https://github.com/microsoft/prompt-engine",
@@ -3800,7 +3800,7 @@
     "microsoft/promptflow": {
       "requested": "microsoft/promptflow",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "microsoft/promptflow",
       "html_url": "https://github.com/microsoft/promptflow",
@@ -3825,7 +3825,7 @@
     "microsoft/semantic-kernel": {
       "requested": "microsoft/semantic-kernel",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "microsoft/semantic-kernel",
       "html_url": "https://github.com/microsoft/semantic-kernel",
@@ -3850,7 +3850,7 @@
     "mintplex-labs/anything-llm": {
       "requested": "Mintplex-Labs/anything-llm",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "Mintplex-Labs/anything-llm",
       "html_url": "https://github.com/Mintplex-Labs/anything-llm",
@@ -3875,7 +3875,7 @@
     "ml-explore/mlx": {
       "requested": "ml-explore/mlx",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "ml-explore/mlx",
       "html_url": "https://github.com/ml-explore/mlx",
@@ -3900,7 +3900,7 @@
     "modelcontextprotocol/python-sdk": {
       "requested": "modelcontextprotocol/python-sdk",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "modelcontextprotocol/python-sdk",
       "html_url": "https://github.com/modelcontextprotocol/python-sdk",
@@ -3925,7 +3925,7 @@
     "modelcontextprotocol/servers": {
       "requested": "modelcontextprotocol/servers",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "modelcontextprotocol/servers",
       "html_url": "https://github.com/modelcontextprotocol/servers",
@@ -3962,7 +3962,7 @@
     "modelcontextprotocol/typescript-sdk": {
       "requested": "modelcontextprotocol/typescript-sdk",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "modelcontextprotocol/typescript-sdk",
       "html_url": "https://github.com/modelcontextprotocol/typescript-sdk",
@@ -3987,7 +3987,7 @@
     "mongodb-js/mongodb-mcp-server": {
       "requested": "mongodb-js/mongodb-mcp-server",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "mongodb-js/mongodb-mcp-server",
       "html_url": "https://github.com/mongodb-js/mongodb-mcp-server",
@@ -4012,7 +4012,7 @@
     "moonshotai/kimi-k2": {
       "requested": "MoonshotAI/Kimi-K2",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "MoonshotAI/Kimi-K2",
       "html_url": "https://github.com/MoonshotAI/Kimi-K2",
@@ -4034,7 +4034,7 @@
     "morluto/jacobian": {
       "requested": "morluto/jacobian",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "morluto/jacobian",
       "html_url": "https://github.com/morluto/jacobian",
@@ -4059,7 +4059,7 @@
     "mozilla/inclusion": {
       "requested": "mozilla/inclusion",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "mozilla/inclusion",
       "html_url": "https://github.com/mozilla/inclusion",
@@ -4081,7 +4081,7 @@
     "mudler/localai": {
       "requested": "mudler/LocalAI",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "mudler/LocalAI",
       "html_url": "https://github.com/mudler/LocalAI",
@@ -4106,7 +4106,7 @@
     "muisedestiny/zotero-gpt": {
       "requested": "MuiseDestiny/zotero-gpt",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "MuiseDestiny/zotero-gpt",
       "html_url": "https://github.com/MuiseDestiny/zotero-gpt",
@@ -4137,7 +4137,7 @@
     "n8n-io/n8n": {
       "requested": "n8n-io/n8n",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "n8n-io/n8n",
       "html_url": "https://github.com/n8n-io/n8n",
@@ -4162,7 +4162,7 @@
     "netease-youdao/lobsterai": {
       "requested": "netease-youdao/LobsterAI",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "netease-youdao/LobsterAI",
       "html_url": "https://github.com/netease-youdao/LobsterAI",
@@ -4187,7 +4187,7 @@
     "nirdiamant/prompt_engineering": {
       "requested": "NirDiamant/Prompt_Engineering",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "NirDiamant/Prompt_Engineering",
       "html_url": "https://github.com/NirDiamant/Prompt_Engineering",
@@ -4209,7 +4209,7 @@
     "nirdiamant/rag_techniques": {
       "requested": "NirDiamant/RAG_Techniques",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "NirDiamant/RAG_Techniques",
       "html_url": "https://github.com/NirDiamant/RAG_Techniques",
@@ -4234,7 +4234,7 @@
     "nolabs-ai/nono": {
       "requested": "nolabs-ai/nono",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "nolabs-ai/nono",
       "html_url": "https://github.com/nolabs-ai/nono",
@@ -4260,7 +4260,7 @@
     "nousresearch/hermes-agent": {
       "requested": "NousResearch/hermes-agent",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "NousResearch/hermes-agent",
       "html_url": "https://github.com/NousResearch/hermes-agent",
@@ -4270,7 +4270,7 @@
       "visibility": "public",
       "default_branch": "main",
       "license": "MIT",
-      "pushed_at": "2026-08-29T00:02:48Z",
+      "pushed_at": "2026-08-29T00:21:15Z",
       "latest_release": {
         "tag": "v2026.8.27",
         "published_at": "2026-08-27T12:06:53Z"
@@ -4294,7 +4294,7 @@
     "nvidia/nemoclaw": {
       "requested": "NVIDIA/NemoClaw",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "NVIDIA/NemoClaw",
       "html_url": "https://github.com/NVIDIA/NemoClaw",
@@ -4304,7 +4304,7 @@
       "visibility": "public",
       "default_branch": "main",
       "license": "Apache-2.0",
-      "pushed_at": "2026-08-29T00:12:23Z",
+      "pushed_at": "2026-08-29T00:37:32Z",
       "latest_release": null,
       "reference_count": 4,
       "sources": [
@@ -4317,7 +4317,7 @@
     "nvidia/openshell": {
       "requested": "NVIDIA/OpenShell",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "NVIDIA/OpenShell",
       "html_url": "https://github.com/NVIDIA/OpenShell",
@@ -4327,7 +4327,7 @@
       "visibility": "public",
       "default_branch": "main",
       "license": "Apache-2.0",
-      "pushed_at": "2026-08-29T00:10:36Z",
+      "pushed_at": "2026-08-29T00:36:48Z",
       "latest_release": {
         "tag": "v0.0.116",
         "published_at": "2026-08-28T09:10:23Z"
@@ -4343,7 +4343,7 @@
     "obra/superpowers": {
       "requested": "obra/superpowers",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "obra/superpowers",
       "html_url": "https://github.com/obra/superpowers",
@@ -4383,7 +4383,7 @@
     "obra/superpowers-marketplace": {
       "requested": "obra/superpowers-marketplace",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "obra/superpowers-marketplace",
       "html_url": "https://github.com/obra/superpowers-marketplace",
@@ -4408,7 +4408,7 @@
     "ollama/ollama": {
       "requested": "ollama/ollama",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "ollama/ollama",
       "html_url": "https://github.com/ollama/ollama",
@@ -4418,7 +4418,7 @@
       "visibility": "public",
       "default_branch": "main",
       "license": "MIT",
-      "pushed_at": "2026-08-28T19:46:41Z",
+      "pushed_at": "2026-08-29T00:34:39Z",
       "latest_release": {
         "tag": "v0.33.2",
         "published_at": "2026-08-27T20:31:47Z"
@@ -4439,7 +4439,7 @@
     "onyx-dot-app/onyx": {
       "requested": "onyx-dot-app/onyx",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "onyx-dot-app/onyx",
       "html_url": "https://github.com/onyx-dot-app/onyx",
@@ -4449,7 +4449,7 @@
       "visibility": "public",
       "default_branch": "main",
       "license": "NOASSERTION",
-      "pushed_at": "2026-08-28T23:17:18Z",
+      "pushed_at": "2026-08-29T00:27:59Z",
       "latest_release": {
         "tag": "v4.6.4",
         "published_at": "2026-08-28T01:53:42Z"
@@ -4464,7 +4464,7 @@
     "open-telemetry/semantic-conventions-genai": {
       "requested": "open-telemetry/semantic-conventions-genai",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "open-telemetry/semantic-conventions-genai",
       "html_url": "https://github.com/open-telemetry/semantic-conventions-genai",
@@ -4486,7 +4486,7 @@
     "openai/codex": {
       "requested": "openai/codex",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "openai/codex",
       "html_url": "https://github.com/openai/codex",
@@ -4496,7 +4496,7 @@
       "visibility": "public",
       "default_branch": "main",
       "license": "Apache-2.0",
-      "pushed_at": "2026-08-28T23:36:03Z",
+      "pushed_at": "2026-08-29T00:35:28Z",
       "latest_release": {
         "tag": "rust-v0.150.1",
         "published_at": "2026-08-27T01:56:54Z"
@@ -4523,7 +4523,7 @@
     "openai/codex-action": {
       "requested": "openai/codex-action",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "openai/codex-action",
       "html_url": "https://github.com/openai/codex-action",
@@ -4545,7 +4545,7 @@
     "openai/openai-agents-python": {
       "requested": "openai/openai-agents-python",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "openai/openai-agents-python",
       "html_url": "https://github.com/openai/openai-agents-python",
@@ -4570,7 +4570,7 @@
     "openai/openai-cookbook": {
       "requested": "openai/openai-cookbook",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "openai/openai-cookbook",
       "html_url": "https://github.com/openai/openai-cookbook",
@@ -4595,7 +4595,7 @@
     "openai/swarm": {
       "requested": "openai/swarm",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "openai/swarm",
       "html_url": "https://github.com/openai/swarm",
@@ -4618,7 +4618,7 @@
     "openhands/openhands": {
       "requested": "OpenHands/OpenHands",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "OpenHands/OpenHands",
       "html_url": "https://github.com/OpenHands/OpenHands",
@@ -4643,7 +4643,7 @@
     "osu-nlp-group/mind2web": {
       "requested": "OSU-NLP-Group/Mind2Web",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "OSU-NLP-Group/Mind2Web",
       "html_url": "https://github.com/OSU-NLP-Group/Mind2Web",
@@ -4665,7 +4665,7 @@
     "pbakaus/impeccable": {
       "requested": "pbakaus/impeccable",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "pbakaus/impeccable",
       "html_url": "https://github.com/pbakaus/impeccable",
@@ -4690,7 +4690,7 @@
     "pguso/ai-agents-from-scratch": {
       "requested": "pguso/ai-agents-from-scratch",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "pguso/ai-agents-from-scratch",
       "html_url": "https://github.com/pguso/ai-agents-from-scratch",
@@ -4715,7 +4715,7 @@
     "pgvector/pgvector": {
       "requested": "pgvector/pgvector",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "pgvector/pgvector",
       "html_url": "https://github.com/pgvector/pgvector",
@@ -4737,7 +4737,7 @@
     "pleaseprompto/notebooklm-skill": {
       "requested": "PleasePrompto/notebooklm-skill",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "PleasePrompto/notebooklm-skill",
       "html_url": "https://github.com/PleasePrompto/notebooklm-skill",
@@ -4768,7 +4768,7 @@
     "promptfoo/promptfoo": {
       "requested": "promptfoo/promptfoo",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "promptfoo/promptfoo",
       "html_url": "https://github.com/promptfoo/promptfoo",
@@ -4778,7 +4778,7 @@
       "visibility": "public",
       "default_branch": "main",
       "license": "MIT",
-      "pushed_at": "2026-08-29T00:18:54Z",
+      "pushed_at": "2026-08-29T00:34:42Z",
       "latest_release": {
         "tag": "code-scan-action-0.2.0",
         "published_at": "2026-08-28T07:34:11Z"
@@ -4814,7 +4814,7 @@
     "punkpeye/awesome-mcp-servers": {
       "requested": "punkpeye/awesome-mcp-servers",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "punkpeye/awesome-mcp-servers",
       "html_url": "https://github.com/punkpeye/awesome-mcp-servers",
@@ -4851,7 +4851,7 @@
     "pydantic/pydantic-ai": {
       "requested": "pydantic/pydantic-ai",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "pydantic/pydantic-ai",
       "html_url": "https://github.com/pydantic/pydantic-ai",
@@ -4876,7 +4876,7 @@
     "qdrant/qdrant": {
       "requested": "qdrant/qdrant",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "qdrant/qdrant",
       "html_url": "https://github.com/qdrant/qdrant",
@@ -4901,7 +4901,7 @@
     "quantalogic/quantalogic": {
       "requested": "quantalogic/quantalogic",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "quantalogic/quantalogic",
       "html_url": "https://github.com/quantalogic/quantalogic",
@@ -4929,7 +4929,7 @@
     "qwenlm/qwen-agent": {
       "requested": "QwenLM/Qwen-Agent",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "QwenLM/Qwen-Agent",
       "html_url": "https://github.com/QwenLM/Qwen-Agent",
@@ -4954,7 +4954,7 @@
     "rasbt/llms-from-scratch": {
       "requested": "rasbt/LLMs-from-scratch",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "rasbt/LLMs-from-scratch",
       "html_url": "https://github.com/rasbt/LLMs-from-scratch",
@@ -4976,7 +4976,7 @@
     "redis/mcp-redis": {
       "requested": "redis/mcp-redis",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "redis/mcp-redis",
       "html_url": "https://github.com/redis/mcp-redis",
@@ -5001,7 +5001,7 @@
     "rohitg00/awesome-claude-code-toolkit": {
       "requested": "rohitg00/awesome-claude-code-toolkit",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "rohitg00/awesome-claude-code-toolkit",
       "html_url": "https://github.com/rohitg00/awesome-claude-code-toolkit",
@@ -5026,7 +5026,7 @@
     "roocodeinc/roo-code": {
       "requested": "RooCodeInc/Roo-Code",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "RooCodeInc/Roo-Code",
       "html_url": "https://github.com/RooCodeInc/Roo-Code",
@@ -5054,7 +5054,7 @@
     "run-llama/llama_index": {
       "requested": "run-llama/llama_index",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "run-llama/llama_index",
       "html_url": "https://github.com/run-llama/llama_index",
@@ -5082,7 +5082,7 @@
     "ryaker/outlook-mcp": {
       "requested": "ryaker/outlook-mcp",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "ryaker/outlook-mcp",
       "html_url": "https://github.com/ryaker/outlook-mcp",
@@ -5104,7 +5104,7 @@
     "sakanaai/ai-scientist-v2": {
       "requested": "SakanaAI/AI-Scientist-v2",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "SakanaAI/AI-Scientist-v2",
       "html_url": "https://github.com/SakanaAI/AI-Scientist-v2",
@@ -5126,7 +5126,7 @@
     "saseq/discord-mcp": {
       "requested": "SaseQ/discord-mcp",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "SaseQ/discord-mcp",
       "html_url": "https://github.com/SaseQ/discord-mcp",
@@ -5151,7 +5151,7 @@
     "shubhamsaboo/awesome-llm-apps": {
       "requested": "Shubhamsaboo/awesome-llm-apps",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "Shubhamsaboo/awesome-llm-apps",
       "html_url": "https://github.com/Shubhamsaboo/awesome-llm-apps",
@@ -5171,7 +5171,7 @@
     "sierra-research/tau2-bench": {
       "requested": "sierra-research/tau2-bench",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "sierra-research/tau2-bench",
       "html_url": "https://github.com/sierra-research/tau2-bench",
@@ -5199,7 +5199,7 @@
     "simonlin1212/a-stock-data": {
       "requested": "simonlin1212/a-stock-data",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "simonlin1212/a-stock-data",
       "html_url": "https://github.com/simonlin1212/a-stock-data",
@@ -5224,7 +5224,7 @@
     "skridlevsky/graphthulhu": {
       "requested": "skridlevsky/graphthulhu",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "skridlevsky/graphthulhu",
       "html_url": "https://github.com/skridlevsky/graphthulhu",
@@ -5249,7 +5249,7 @@
     "softeria/ms-365-mcp-server": {
       "requested": "Softeria/ms-365-mcp-server",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "Softeria/ms-365-mcp-server",
       "html_url": "https://github.com/Softeria/ms-365-mcp-server",
@@ -5274,7 +5274,7 @@
     "sooperset/mcp-atlassian": {
       "requested": "sooperset/mcp-atlassian",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "sooperset/mcp-atlassian",
       "html_url": "https://github.com/sooperset/mcp-atlassian",
@@ -5299,7 +5299,7 @@
     "stablyai/orca": {
       "requested": "stablyai/orca",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "stablyai/orca",
       "html_url": "https://github.com/stablyai/orca",
@@ -5309,7 +5309,7 @@
       "visibility": "public",
       "default_branch": "main",
       "license": "MIT",
-      "pushed_at": "2026-08-29T00:19:16Z",
+      "pushed_at": "2026-08-29T00:21:51Z",
       "latest_release": {
         "tag": "v1.4.191",
         "published_at": "2026-08-28T18:32:02Z"
@@ -5325,7 +5325,7 @@
     "stacklok/toolhive": {
       "requested": "stacklok/toolhive",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "stacklok/toolhive",
       "html_url": "https://github.com/stacklok/toolhive",
@@ -5351,7 +5351,7 @@
     "stanford-oval/storm": {
       "requested": "stanford-oval/storm",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "stanford-oval/storm",
       "html_url": "https://github.com/stanford-oval/storm",
@@ -5376,7 +5376,7 @@
     "stanfordnlp/dspy": {
       "requested": "stanfordnlp/dspy",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "stanfordnlp/dspy",
       "html_url": "https://github.com/stanfordnlp/dspy",
@@ -5407,7 +5407,7 @@
     "strands-agents/harness-sdk": {
       "requested": "strands-agents/harness-sdk",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "strands-agents/harness-sdk",
       "html_url": "https://github.com/strands-agents/harness-sdk",
@@ -5432,7 +5432,7 @@
     "stripe/ai": {
       "requested": "stripe/ai",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "stripe/ai",
       "html_url": "https://github.com/stripe/ai",
@@ -5454,7 +5454,7 @@
     "supabase/mcp": {
       "requested": "supabase/mcp",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "supabase/mcp",
       "html_url": "https://github.com/supabase/mcp",
@@ -5479,7 +5479,7 @@
     "swe-bench/swe-bench": {
       "requested": "SWE-bench/SWE-bench",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "SWE-bench/SWE-bench",
       "html_url": "https://github.com/SWE-bench/SWE-bench",
@@ -5501,7 +5501,7 @@
     "sylphxai/pdf-reader-mcp": {
       "requested": "SylphxAI/pdf-reader-mcp",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "SylphxAI/pdf-reader-mcp",
       "html_url": "https://github.com/SylphxAI/pdf-reader-mcp",
@@ -5511,7 +5511,7 @@
       "visibility": "public",
       "default_branch": "main",
       "license": "MIT",
-      "pushed_at": "2026-08-28T22:49:01Z",
+      "pushed_at": "2026-08-29T00:26:32Z",
       "latest_release": {
         "tag": "v4.1.3",
         "published_at": "2026-08-03T02:50:54Z"
@@ -5529,7 +5529,7 @@
     "tauricresearch/tradingagents": {
       "requested": "TauricResearch/TradingAgents",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "TauricResearch/TradingAgents",
       "html_url": "https://github.com/TauricResearch/TradingAgents",
@@ -5554,7 +5554,7 @@
     "tavily-ai/tavily-mcp": {
       "requested": "tavily-ai/tavily-mcp",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "tavily-ai/tavily-mcp",
       "html_url": "https://github.com/tavily-ai/tavily-mcp",
@@ -5576,7 +5576,7 @@
     "taylorwilsdon/google_workspace_mcp": {
       "requested": "taylorwilsdon/google_workspace_mcp",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "taylorwilsdon/google_workspace_mcp",
       "html_url": "https://github.com/taylorwilsdon/google_workspace_mcp",
@@ -5604,7 +5604,7 @@
     "teng-lin/notebooklm-py": {
       "requested": "teng-lin/notebooklm-py",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "teng-lin/notebooklm-py",
       "html_url": "https://github.com/teng-lin/notebooklm-py",
@@ -5632,7 +5632,7 @@
     "tfriedel/claude-office-skills": {
       "requested": "tfriedel/claude-office-skills",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "tfriedel/claude-office-skills",
       "html_url": "https://github.com/tfriedel/claude-office-skills",
@@ -5657,7 +5657,7 @@
     "thebrierfox/intuitek-ace": {
       "requested": "thebrierfox/intuitek-ace",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "thebrierfox/intuitek-ace",
       "html_url": "https://github.com/thebrierfox/intuitek-ace",
@@ -5679,7 +5679,7 @@
     "theshiphq/claw-spark": {
       "requested": "theshiphq/claw-spark",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "theshiphq/claw-spark",
       "html_url": "https://github.com/theshiphq/claw-spark",
@@ -5701,7 +5701,7 @@
     "timescale/pg-aiguide": {
       "requested": "timescale/pg-aiguide",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "timescale/pg-aiguide",
       "html_url": "https://github.com/timescale/pg-aiguide",
@@ -5726,7 +5726,7 @@
     "tldr-pages/tldr": {
       "requested": "tldr-pages/tldr",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "tldr-pages/tldr",
       "html_url": "https://github.com/tldr-pages/tldr",
@@ -5752,7 +5752,7 @@
     "trailofbits/skills": {
       "requested": "trailofbits/skills",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "trailofbits/skills",
       "html_url": "https://github.com/trailofbits/skills",
@@ -5775,7 +5775,7 @@
     "trailofbits/skills-curated": {
       "requested": "trailofbits/skills-curated",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "trailofbits/skills-curated",
       "html_url": "https://github.com/trailofbits/skills-curated",
@@ -5800,7 +5800,7 @@
     "travisvn/awesome-claude-skills": {
       "requested": "travisvn/awesome-claude-skills",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "travisvn/awesome-claude-skills",
       "html_url": "https://github.com/travisvn/awesome-claude-skills",
@@ -5832,7 +5832,7 @@
     "truera/trulens": {
       "requested": "truera/trulens",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "truera/trulens",
       "html_url": "https://github.com/truera/trulens",
@@ -5857,7 +5857,7 @@
     "trycua/cua": {
       "requested": "trycua/cua",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "trycua/cua",
       "html_url": "https://github.com/trycua/cua",
@@ -5882,7 +5882,7 @@
     "ukgovernmentbeis/inspect_ai": {
       "requested": "UKGovernmentBEIS/inspect_ai",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "UKGovernmentBEIS/inspect_ai",
       "html_url": "https://github.com/UKGovernmentBEIS/inspect_ai",
@@ -5904,7 +5904,7 @@
     "upstash/context7": {
       "requested": "upstash/context7",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "upstash/context7",
       "html_url": "https://github.com/upstash/context7",
@@ -5929,7 +5929,7 @@
     "usewhale/whale": {
       "requested": "usewhale/whale",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "usewhale/Whale",
       "html_url": "https://github.com/usewhale/Whale",
@@ -5954,7 +5954,7 @@
     "varunneal/spotify-mcp": {
       "requested": "varunneal/spotify-mcp",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "varunneal/spotify-mcp",
       "html_url": "https://github.com/varunneal/spotify-mcp",
@@ -5976,7 +5976,7 @@
     "vercel/eve": {
       "requested": "vercel/eve",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "vercel/eve",
       "html_url": "https://github.com/vercel/eve",
@@ -6001,7 +6001,7 @@
     "vibrantlabsai/ragas": {
       "requested": "vibrantlabsai/ragas",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "vibrantlabsai/ragas",
       "html_url": "https://github.com/vibrantlabsai/ragas",
@@ -6026,7 +6026,7 @@
     "virattt/ai-hedge-fund": {
       "requested": "virattt/ai-hedge-fund",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "virattt/ai-hedge-fund",
       "html_url": "https://github.com/virattt/ai-hedge-fund",
@@ -6051,7 +6051,7 @@
     "vllm-project/vllm": {
       "requested": "vllm-project/vllm",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "vllm-project/vllm",
       "html_url": "https://github.com/vllm-project/vllm",
@@ -6061,7 +6061,7 @@
       "visibility": "public",
       "default_branch": "main",
       "license": "Apache-2.0",
-      "pushed_at": "2026-08-29T00:16:37Z",
+      "pushed_at": "2026-08-29T00:25:01Z",
       "latest_release": {
         "tag": "v0.28.0",
         "published_at": "2026-08-26T09:46:30Z"
@@ -6076,7 +6076,7 @@
     "voltagent/awesome-agent-skills": {
       "requested": "VoltAgent/awesome-agent-skills",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "VoltAgent/awesome-agent-skills",
       "html_url": "https://github.com/VoltAgent/awesome-agent-skills",
@@ -6098,7 +6098,7 @@
     "wangrongsheng/awesome-llm-resources": {
       "requested": "WangRongsheng/awesome-LLM-resources",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "WangRongsheng/awesome-LLM-resources",
       "html_url": "https://github.com/WangRongsheng/awesome-LLM-resources",
@@ -6122,7 +6122,7 @@
     "weaviate/weaviate": {
       "requested": "weaviate/weaviate",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "weaviate/weaviate",
       "html_url": "https://github.com/weaviate/weaviate",
@@ -6147,7 +6147,7 @@
     "web-arena-x/webarena": {
       "requested": "web-arena-x/webarena",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "web-arena-x/webarena",
       "html_url": "https://github.com/web-arena-x/webarena",
@@ -6172,7 +6172,7 @@
     "wenyuchiou/academic-writing-skills": {
       "requested": "WenyuChiou/academic-writing-skills",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "WenyuChiou/academic-writing-skills",
       "html_url": "https://github.com/WenyuChiou/academic-writing-skills",
@@ -6200,7 +6200,7 @@
     "wenyuchiou/agent-collab-skills": {
       "requested": "WenyuChiou/agent-collab-skills",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "WenyuChiou/agent-collab-skills",
       "html_url": "https://github.com/WenyuChiou/agent-collab-skills",
@@ -6228,7 +6228,7 @@
     "wenyuchiou/ai-research-skills": {
       "requested": "WenyuChiou/ai-research-skills",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "WenyuChiou/ai-research-skills",
       "html_url": "https://github.com/WenyuChiou/ai-research-skills",
@@ -6259,7 +6259,7 @@
     "wenyuchiou/awesome-agentic-ai-zh": {
       "requested": "WenyuChiou/awesome-agentic-ai-zh",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "WenyuChiou/awesome-agentic-ai-zh",
       "html_url": "https://github.com/WenyuChiou/awesome-agentic-ai-zh",
@@ -6269,12 +6269,12 @@
       "visibility": "public",
       "default_branch": "main",
       "license": "MIT",
-      "pushed_at": "2026-08-29T00:06:20Z",
+      "pushed_at": "2026-08-29T00:31:14Z",
       "latest_release": {
         "tag": "v2026.08.23",
         "published_at": "2026-08-23T16:16:59Z"
       },
-      "reference_count": 126,
+      "reference_count": 123,
       "sources": [
         ".github/outreach/_send-day-packages.md",
         ".github/outreach/awesome-claude-code.md",
@@ -6324,7 +6324,7 @@
     "wenyuchiou/awesome-mcp-servers": {
       "requested": "WenyuChiou/awesome-mcp-servers",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "WenyuChiou/awesome-mcp-servers",
       "html_url": "https://github.com/WenyuChiou/awesome-mcp-servers",
@@ -6344,7 +6344,7 @@
     "wenyuchiou/codex-delegate": {
       "requested": "WenyuChiou/codex-delegate",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "WenyuChiou/codex-delegate",
       "html_url": "https://github.com/WenyuChiou/codex-delegate",
@@ -6372,7 +6372,7 @@
     "wenyuchiou/gemini-delegate-skill": {
       "requested": "WenyuChiou/gemini-delegate-skill",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "WenyuChiou/gemini-delegate-skill",
       "html_url": "https://github.com/WenyuChiou/gemini-delegate-skill",
@@ -6400,7 +6400,7 @@
     "wenyuchiou/research-hub": {
       "requested": "WenyuChiou/research-hub",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "WenyuChiou/research-hub",
       "html_url": "https://github.com/WenyuChiou/research-hub",
@@ -6437,7 +6437,7 @@
     "wenyuchiou/zotero-skills": {
       "requested": "WenyuChiou/zotero-skills",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "WenyuChiou/zotero-skills",
       "html_url": "https://github.com/WenyuChiou/zotero-skills",
@@ -6471,7 +6471,7 @@
     "winor30/mcp-server-datadog": {
       "requested": "winor30/mcp-server-datadog",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "winor30/mcp-server-datadog",
       "html_url": "https://github.com/winor30/mcp-server-datadog",
@@ -6496,7 +6496,7 @@
     "wong2/awesome-mcp-servers": {
       "requested": "wong2/awesome-mcp-servers",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "wong2/awesome-mcp-servers",
       "html_url": "https://github.com/wong2/awesome-mcp-servers",
@@ -6533,7 +6533,7 @@
     "wshobson/agents": {
       "requested": "wshobson/agents",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "wshobson/agents",
       "html_url": "https://github.com/wshobson/agents",
@@ -6555,7 +6555,7 @@
     "xai-org/grok-build": {
       "requested": "xai-org/grok-build",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "xai-org/grok-build",
       "html_url": "https://github.com/xai-org/grok-build",
@@ -6585,7 +6585,7 @@
     "xberg-io/xberg": {
       "requested": "xberg-io/xberg",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "xberg-io/xberg",
       "html_url": "https://github.com/xberg-io/xberg",
@@ -6610,7 +6610,7 @@
     "xing5/mcp-google-sheets": {
       "requested": "xing5/mcp-google-sheets",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "xing5/mcp-google-sheets",
       "html_url": "https://github.com/xing5/mcp-google-sheets",
@@ -6635,7 +6635,7 @@
     "xlang-ai/osworld": {
       "requested": "xlang-ai/OSWorld",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "xlang-ai/OSWorld",
       "html_url": "https://github.com/xlang-ai/OSWorld",
@@ -6663,7 +6663,7 @@
     "yamadashy/repomix": {
       "requested": "yamadashy/repomix",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "yamadashy/repomix",
       "html_url": "https://github.com/yamadashy/repomix",
@@ -6694,7 +6694,7 @@
     "yc-software/qm": {
       "requested": "yc-software/qm",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "yc-software/qm",
       "html_url": "https://github.com/yc-software/qm",
@@ -6720,7 +6720,7 @@
     "yctimlin/mcp_excalidraw": {
       "requested": "yctimlin/mcp_excalidraw",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "yctimlin/mcp_excalidraw",
       "html_url": "https://github.com/yctimlin/mcp_excalidraw",
@@ -6742,7 +6742,7 @@
     "zai-org/glm-4.5": {
       "requested": "zai-org/GLM-4.5",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "zai-org/GLM-4.5",
       "html_url": "https://github.com/zai-org/GLM-4.5",
@@ -6764,7 +6764,7 @@
     "zhanghandong/harness-engineering-from-cc-to-ai-coding": {
       "requested": "ZhangHanDong/harness-engineering-from-cc-to-ai-coding",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "ZhangHanDong/harness-engineering-from-cc-to-ai-coding",
       "html_url": "https://github.com/ZhangHanDong/harness-engineering-from-cc-to-ai-coding",
@@ -6789,7 +6789,7 @@
     "zilliztech/vectordbbench": {
       "requested": "zilliztech/VectorDBBench",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "zilliztech/VectorDBBench",
       "html_url": "https://github.com/zilliztech/VectorDBBench",
@@ -6814,7 +6814,7 @@
     "zubeidhendricks/youtube-mcp-server": {
       "requested": "ZubeidHendricks/youtube-mcp-server",
       "state": "verified",
-      "checked_at": "2026-08-29T00:20:01Z",
+      "checked_at": "2026-08-29T00:39:03Z",
       "api_status": 200,
       "canonical": "ZubeidHendricks/youtube-mcp-server",
       "html_url": "https://github.com/ZubeidHendricks/youtube-mcp-server",

--- a/scripts/test_site_route_coherence.py
+++ b/scripts/test_site_route_coherence.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+LOCALES = {
+    "zh-TW": {
+        "suffix": "",
+        "track_a": "### Track A",
+        "track_b": "### Track B",
+        "optional": ("建議", "不擋"),
+        "stage5_core": "5.1–5.4",
+        "legacy_a2_anchor": "-進-a3-前的自我檢查",
+        "legacy_stage5_anchor": "-進入-stage-6-前的自我檢查",
+        "legacy_roadmap_anchors": (
+            "近期想補的缺口",
+            "進行中--隨時可貢獻",
+            "-動手練習覆蓋補齊",
+            "-audience-branch-深化",
+            "-stage-2--stage-3-2026-freshness-小修",
+            "基礎建設maintainer-進行中",
+            "想法箱待討論還沒承諾",
+        ),
+        "foundation_route": "`Stage 0 → Stage 1 → Stage 2`",
+        "track_a_route": "`A1 → A2 → Stage 5 → A3 → Stage 8`",
+        "track_b_route": "`Stage 3 → Stage 4 → Stage 5 → Stage 6 → Stage 7 → Stage 7.5 → Stage 8`",
+        "roadmap_stale": (
+            "2026-05 snapshot",
+            "Stage 2 / Stage 3 2026 freshness 小修",
+            "GitHub Pages,評估中",
+        ),
+    },
+    "en": {
+        "suffix": ".en",
+        "track_a": "### Track A",
+        "track_b": "### Track B",
+        "optional": ("recommended", "does not block"),
+        "stage5_core": "5.1–5.4",
+        "legacy_a2_anchor": "-self-check-before-a3",
+        "legacy_stage5_anchor": "-self-check-before-stage-6",
+        "legacy_roadmap_anchors": (
+            "near-term-gaps-we-want-to-fill",
+            "in-progress--always-open-to-contributions",
+            "-fill-out-hands-on-exercise-coverage",
+            "-deepen-the-audience-branch-files",
+            "-stage-2--stage-3-2026-freshness-touch-up",
+            "infrastructure-maintainer-in-progress",
+            "idea-box-pending-discussion-not-committed-yet",
+        ),
+        "foundation_route": "`Stage 0 → Stage 1 → Stage 2`",
+        "track_a_route": "`A1 → A2 → Stage 5 → A3 → Stage 8`",
+        "track_b_route": "`Stage 3 → Stage 4 → Stage 5 → Stage 6 → Stage 7 → Stage 7.5 → Stage 8`",
+        "roadmap_stale": (
+            "2026-05 snapshot",
+            "Stage 2 / Stage 3 2026 freshness",
+            "GitHub Pages, under evaluation",
+        ),
+    },
+    "zh-Hans": {
+        "suffix": ".zh-Hans",
+        "track_a": "### Track A",
+        "track_b": "### Track B",
+        "optional": ("建议", "不影响"),
+        "stage5_core": "5.1–5.4",
+        "legacy_a2_anchor": "-进入-a3-前的自我检查",
+        "legacy_stage5_anchor": "-进入-stage-6-前的自我检查",
+        "legacy_roadmap_anchors": (
+            "近期想补的缺口",
+            "进行中--随时可贡献",
+            "-动手练习覆盖补齐",
+            "-audience-branch-深化",
+            "-stage-2--stage-3-2026-freshness-小修",
+            "基础建设maintainer-进行中",
+            "想法箱待讨论还没承诺",
+        ),
+        "foundation_route": "`Stage 0 → Stage 1 → Stage 2`",
+        "track_a_route": "`A1 → A2 → Stage 5 → A3 → Stage 8`",
+        "track_b_route": "`Stage 3 → Stage 4 → Stage 5 → Stage 6 → Stage 7 → Stage 7.5 → Stage 8`",
+        "roadmap_stale": (
+            "2026-05 snapshot",
+            "Stage 2 / Stage 3 2026 freshness 小修",
+            "GitHub Pages,评估中",
+        ),
+    },
+}
+
+
+def locale_path(stem: str, suffix: str) -> Path:
+    return ROOT / f"{stem}{suffix}.md"
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def between(text: str, start: str, end: str) -> str:
+    start_at = text.index(start)
+    end_at = text.index(end, start_at + len(start))
+    return text[start_at:end_at]
+
+
+def assert_in_order(text: str, needles: tuple[str, ...]) -> None:
+    positions = [text.index(needle) for needle in needles]
+    assert positions == sorted(positions), dict(zip(needles, positions, strict=True))
+
+
+@pytest.mark.parametrize("locale,config", LOCALES.items())
+def test_readme_uses_one_track_a_order(locale: str, config: dict[str, object]) -> None:
+    text = read(locale_path("README", str(config["suffix"])))
+    track_a = between(text, str(config["track_a"]), str(config["track_b"]))
+    assert_in_order(
+        track_a,
+        (
+            "tracks/cli/A1-cli-intro",
+            "tracks/cli/A2-cli-workflow",
+            "stages/05-claude-code-ecosystem",
+            "tracks/cli/A3-cli-production",
+            "stages/08-agent-interfaces",
+        ),
+    )
+
+
+@pytest.mark.parametrize("locale,config", LOCALES.items())
+def test_readme_keeps_shared_foundation_and_track_b_order(
+    locale: str, config: dict[str, object]
+) -> None:
+    text = read(locale_path("README", str(config["suffix"])))
+    assert_in_order(
+        text,
+        (
+            "stages/00-foundations",
+            "stages/01-llm-basics",
+            "stages/02-prompt-engineering",
+        ),
+    )
+    track_b = text[text.index(str(config["track_b"])) :]
+    assert_in_order(
+        track_b,
+        (
+            "stages/03-tool-use-and-hello-agent",
+            "stages/04-agent-frameworks",
+            "stages/05-claude-code-ecosystem",
+            "stages/06-memory-rag",
+            "stages/07-multi-agent-production",
+            "stages/07.5-advanced-agentic-concepts",
+            "stages/08-agent-interfaces",
+        ),
+    )
+
+
+@pytest.mark.parametrize("locale,config", LOCALES.items())
+def test_progress_matches_route_and_marks_stage8_recommended(
+    locale: str, config: dict[str, object]
+) -> None:
+    text = read(locale_path("PROGRESS", str(config["suffix"])))
+    track_a = between(text, "## Track A", "## Track B")
+    assert_in_order(
+        track_a,
+        (
+            "tracks/cli/A1-cli-intro",
+            "tracks/cli/A2-cli-workflow",
+            "stages/05-claude-code-ecosystem",
+            "tracks/cli/A3-cli-production",
+            "stages/08-agent-interfaces",
+        ),
+    )
+    stage8_line = next(line for line in track_a.splitlines() if "08-agent-interfaces" in line)
+    for marker in config["optional"]:
+        assert marker in stage8_line, (locale, marker, stage8_line)
+
+
+@pytest.mark.parametrize("locale,config", LOCALES.items())
+def test_a2_sends_reader_to_stage5_not_directly_to_a3(
+    locale: str, config: dict[str, object]
+) -> None:
+    text = read(locale_path("tracks/cli/A2-cli-workflow", str(config["suffix"])))
+    header = "\n".join(text.splitlines()[:8])
+    self_check = text[text.index("## ✅") :]
+    target = "../../stages/05-claude-code-ecosystem"
+    assert target in header
+    assert target in self_check
+    assert "A3-cli-production" not in header
+
+
+@pytest.mark.parametrize("locale,config", LOCALES.items())
+def test_stage5_routes_track_a_to_a3_and_track_b_to_stage6(
+    locale: str, config: dict[str, object]
+) -> None:
+    text = read(locale_path("stages/05-claude-code-ecosystem", str(config["suffix"])))
+    entry = text[text.index("## 🚪") : text.index("<details", text.index("## 🚪"))]
+    self_check = text[text.index("## ✅") :]
+    assert "../tracks/cli/A2-cli-workflow" in entry
+    assert "../tracks/cli/A3-cli-production" in entry
+    assert "../tracks/cli/A3-cli-production" in self_check
+    assert "06-memory-rag" in self_check
+
+
+@pytest.mark.parametrize("locale,config", LOCALES.items())
+def test_a3_requires_stage5_and_recommends_stage8_next(
+    locale: str, config: dict[str, object]
+) -> None:
+    text = read(locale_path("tracks/cli/A3-cli-production", str(config["suffix"])))
+    before_exercises = text[: text.index("## 🛠")]
+    self_check = text[text.index("## ✅") :]
+    assert "../../stages/05-claude-code-ecosystem" in before_exercises
+    assert "../../stages/08-agent-interfaces" in self_check
+
+
+@pytest.mark.parametrize("locale,config", LOCALES.items())
+def test_track_a_capstone_keeps_stage8_optional(
+    locale: str, config: dict[str, object]
+) -> None:
+    text = read(locale_path("CAPSTONE", str(config["suffix"])))
+    track_a = between(text, "## Track A", "## Track B")
+    assert "Stage 0" in track_a
+    assert "A1" in track_a and "A2" in track_a and "A3" in track_a
+    assert "Stage 5" in track_a and "Stage 8" in track_a
+    assert str(config["stage5_core"]) in track_a
+    for marker in config["optional"]:
+        assert marker in track_a, (locale, marker)
+
+
+@pytest.mark.parametrize("locale,config", LOCALES.items())
+def test_roadmap_states_the_exact_canonical_routes(
+    locale: str, config: dict[str, object]
+) -> None:
+    text = read(locale_path("ROADMAP", str(config["suffix"])))
+    assert str(config["foundation_route"]) in text
+    assert str(config["track_a_route"]) in text
+    assert str(config["track_b_route"]) in text
+
+
+@pytest.mark.parametrize("locale,config", LOCALES.items())
+def test_developer_branch_uses_the_canonical_track_a_route(
+    locale: str, config: dict[str, object]
+) -> None:
+    text = read(locale_path("branches/for-developer", str(config["suffix"])))
+    route_line = next(
+        line
+        for line in text.splitlines()
+        if "A1-cli-intro" in line and "05-claude-code-ecosystem" in line
+    )
+    assert "A1 → A2 →" in route_line
+    assert "stages/05-claude-code-ecosystem" in route_line
+    assert "→ A3" in route_line
+    for marker in config["optional"]:
+        assert marker in route_line, (locale, marker, route_line)
+
+
+@pytest.mark.parametrize("locale,config", LOCALES.items())
+def test_roadmap_drops_completed_or_stale_gap_claims(
+    locale: str, config: dict[str, object]
+) -> None:
+    text = read(locale_path("ROADMAP", str(config["suffix"])))
+    for stale in config["roadmap_stale"]:
+        assert stale not in text, (locale, stale)
+
+
+@pytest.mark.parametrize("locale,config", LOCALES.items())
+def test_renamed_route_headings_keep_legacy_deep_links(
+    locale: str, config: dict[str, object]
+) -> None:
+    suffix = str(config["suffix"])
+    a2 = read(locale_path("tracks/cli/A2-cli-workflow", suffix))
+    stage5 = read(locale_path("stages/05-claude-code-ecosystem", suffix))
+    roadmap = read(locale_path("ROADMAP", suffix))
+
+    assert f'<a id="{config["legacy_a2_anchor"]}"></a>' in a2
+    assert f'<a id="{config["legacy_stage5_anchor"]}"></a>' in stage5
+    for anchor in config["legacy_roadmap_anchors"]:
+        assert f'<a id="{anchor}"></a>' in roadmap

--- a/stages/05-claude-code-ecosystem.en.md
+++ b/stages/05-claude-code-ecosystem.en.md
@@ -74,7 +74,7 @@ It is a toolkit that lets your Python or TypeScript program control an agent. Th
 
 ## 🚪 Entry requirements and reading paths
 
-- **Track A (CLI user):** Read 5.1–5.4 first. You can stop after learning the project rulebook, Skills, MCP, and Plugins.
+- **Track A (CLI user):** After [A2](../tracks/cli/A2-cli-workflow.en.md), read 5.1–5.4 to learn project instructions, Skills, MCP, and Plugins, then continue to [A3](../tracks/cli/A3-cli-production.en.md).
 - **Track B (agent developer):** Complete [Stage 3](03-tool-use-and-hello-agent.en.md) and [Stage 4](04-agent-frameworks.en.md), then read 5.5–5.8.
 
 <details markdown="1">
@@ -567,7 +567,9 @@ On your first pass, choose only one entry that matches the exercise at hand. Fiv
 
 </details>
 
-## ✅ Self-check before Stage 6
+<a id="-self-check-before-stage-6"></a>
+
+## ✅ Self-check before your next stop
 
 Can you:
 
@@ -577,4 +579,4 @@ Can you:
 - [ ] Identify the categories of Claude Code, OpenRouter, OpenCode/Pi, and Ollama?
 - [ ] Decide whether your need is “use the CLI” or “actually need the Agent SDK”?
 
-If yes, continue to [Stage 6 — Memory & RAG](06-memory-rag.en.md). If not, return to “Choose the right component with one table” and redo only the row you cannot distinguish.
+If yes, follow your route: **Track A** continues to [A3 — Safe team workflows](../tracks/cli/A3-cli-production.en.md); **Track B** continues to [Stage 6 — Memory & RAG](06-memory-rag.en.md). If not, return to “Choose the right component with one table” and redo only the row you cannot distinguish.

--- a/stages/05-claude-code-ecosystem.md
+++ b/stages/05-claude-code-ecosystem.md
@@ -74,7 +74,7 @@
 
 ## 🚪 進入條件與閱讀路線
 
-- **Track A（CLI 使用者）**：先讀 5.1–5.4，學會專案守則、Skill、MCP 和 Plugin 就可以停。
+- **Track A（CLI 使用者）**：完成 [A2](../tracks/cli/A2-cli-workflow.md) 後讀 5.1–5.4，學會專案守則、Skill、MCP 和 Plugin，再前往 [A3](../tracks/cli/A3-cli-production.md)。
 - **Track B（Agent 開發者）**：完成 [Stage 3](03-tool-use-and-hello-agent.md) 與 [Stage 4](04-agent-frameworks.md) 後，再讀 5.5–5.8。
 
 <details markdown="1">
@@ -563,7 +563,9 @@ SDK 會執行命令並保存 session state，不能把它當成普通 stateless 
 
 </details>
 
-## ✅ 進入 Stage 6 前的自我檢查
+<a id="-進入-stage-6-前的自我檢查"></a>
+
+## ✅ 進入下一站前的自我檢查
 
 你能不能：
 
@@ -573,4 +575,4 @@ SDK 會執行命令並保存 session state，不能把它當成普通 stateless 
 - [ ] 說出 Claude Code、OpenRouter、OpenCode／Pi 和 Ollama 各是哪一類東西？
 - [ ] 判斷自己的需求是「使用 CLI」還是「真的需要 Agent SDK」？
 
-如果可以，前往 [Stage 6 — Memory & RAG](06-memory-rag.md)。如果還不行，回到「一張表先選對零件」，只重做你分不清的那一列。
+如果可以，依你的路線前進：**Track A** 前往 [A3 — 安全的團隊流程](../tracks/cli/A3-cli-production.md)；**Track B** 前往 [Stage 6 — Memory & RAG](06-memory-rag.md)。如果還不行，回到「一張表先選對零件」，只重做你分不清的那一列。

--- a/stages/05-claude-code-ecosystem.zh-Hans.md
+++ b/stages/05-claude-code-ecosystem.zh-Hans.md
@@ -74,7 +74,7 @@
 
 ## 🚪 进入条件与阅读路径
 
-- **Track A（CLI 用户）**：先读 5.1–5.4；掌握项目守则、Skill、MCP 和 Plugin 后即可暂停。
+- **Track A（CLI 用户）**：完成 [A2](../tracks/cli/A2-cli-workflow.zh-Hans.md) 后读 5.1–5.4，掌握项目守则、Skill、MCP 和 Plugin，再前往 [A3](../tracks/cli/A3-cli-production.zh-Hans.md)。
 - **Track B（代理开发者）**：完成 [Stage 3](03-tool-use-and-hello-agent.zh-Hans.md) 和 [Stage 4](04-agent-frameworks.zh-Hans.md) 后，再读 5.5–5.8。
 
 <details markdown="1">
@@ -561,7 +561,9 @@ SDK 会执行命令并保存 session state，不能把它当普通 stateless tex
 
 </details>
 
-## ✅ 进入 Stage 6 前的自我检查
+<a id="-进入-stage-6-前的自我检查"></a>
+
+## ✅ 进入下一站前的自我检查
 
 你能否：
 
@@ -571,4 +573,4 @@ SDK 会执行命令并保存 session state，不能把它当普通 stateless tex
 - [ ] 说明 Claude Code、OpenRouter、OpenCode／Pi 与 Ollama 各是哪一类工具？
 - [ ] 判断自己的需求是“使用 CLI”还是“确实需要 Agent SDK”？
 
-如果可以，前往 [Stage 6 — Memory & RAG](06-memory-rag.zh-Hans.md)。如果还不行，回到“一张表先选对组件”，只重做你分不清的那一行。
+如果可以，按你的路线前进：**Track A** 前往 [A3 — 安全的团队流程](../tracks/cli/A3-cli-production.zh-Hans.md)；**Track B** 前往 [Stage 6 — Memory & RAG](06-memory-rag.zh-Hans.md)。如果还不行，回到“一张表先选对组件”，只重做你分不清的那一行。

--- a/stages/DESIGN.md
+++ b/stages/DESIGN.md
@@ -6,6 +6,17 @@
 
 ---
 
+## 全站唯一學習順序
+
+- 共用基礎：`Stage 0 → Stage 1 → Stage 2`。
+- Track A 建議順序：`A1 → A2 → Stage 5（只讀 Track A 核心 5.1–5.4）→ A3 → Stage 8`。
+- Track B：`Stage 3 → Stage 4 → Stage 5 → Stage 6 → Stage 7 → Stage 7.5 → Stage 8`。
+- Track A 做完 A3 就能開始 Capstone；Stage 8 建議完成，但不擋入場。
+
+README、PROGRESS、CAPSTONE、章節頁首、章末下一站與路線圖必須使用同一順序。先改可存取的文字與測試，再重畫圖片；圖片不能成為唯一導航。
+
+---
+
 ## Track A 跟 Track B 的 2-track 結構
 
 從 Phase 7 開始 catalog 拆成兩條軌道。原本的線性 Stage 結構**還在**（現為 Stage 1-8，後來補了 Stage 7.5 進階概念 reading-map 跟 Stage 8 Agent Interfaces），但定位變成「**Track B — Agent Builder**」（從零打造 agent 的路線）。新增的 `tracks/cli/A1-A3` 是「**Track A — CLI Power User**」（用現成 CLI agent 把工作做完的路線）。

--- a/tracks/cli/A2-cli-workflow.en.md
+++ b/tracks/cli/A2-cli-workflow.en.md
@@ -2,7 +2,7 @@
 
 > [繁體中文](./A2-cli-workflow.md) | [简体中文](./A2-cli-workflow.zh-Hans.md) | **English**
 
-> [← A1 — Safely complete your first CLI task](A1-cli-intro.en.md) · **Track A: CLI Power User** Stop 2 · [Next: A3](A3-cli-production.en.md)
+> [← A1 — Safely complete your first CLI task](A1-cli-intro.en.md) · **Track A: CLI Power User** Stop 2 · [Next: Stage 5 Track A core](../../stages/05-claude-code-ecosystem.en.md#-entry-requirements-and-reading-paths)
 
 This stop answers one question: **How do you make a CLI agent remember the same way of working when it enters the same repo next time?**
 
@@ -200,14 +200,16 @@ The resources below are divided into five groups by purpose. Each group shows it
 </table>
 </details>
 
-## ✅ Self-check before A3
+<a id="-self-check-before-a3"></a>
+
+## ✅ Self-check before Stage 5
 
 - [ ] I can distinguish project instructions, Skill, and one-off prompt in my own words.
 - [ ] My project-rules card states the purpose, forbidden actions, verification command, and delivery format, and the agent can read it.
 - [ ] My review Skill reads changes only; after testing, `git status --short` shows no unexpected modifications.
 - [ ] I know that a “shared core” does not mean every CLI has the same filenames and permissions.
 
-Once all four are done, move on to [A3 — Connect a CLI agent to a safe production workflow](A3-cli-production.en.md). If not, return to the demo repo and repeat CLI-5 or CLI-6; you do not need to read every supplement first.
+Once all four are done, go to the [Stage 5 Track A core](../../stages/05-claude-code-ecosystem.en.md#-entry-requirements-and-reading-paths), read 5.1–5.4, then continue to A3. If not, return to the demo repo and repeat CLI-5 or CLI-6; you do not need to read every supplement first.
 
 <details markdown="1">
 <summary>Expand common questions and fixes</summary>

--- a/tracks/cli/A2-cli-workflow.md
+++ b/tracks/cli/A2-cli-workflow.md
@@ -2,7 +2,7 @@
 
 > **繁體中文** | [简体中文](./A2-cli-workflow.zh-Hans.md) | [English](./A2-cli-workflow.en.md)
 
-> [← A1 — 安全完成第一個 CLI 任務](A1-cli-intro.md) · **Track A: CLI Power User** 第 2 站 · [下一站：A3](A3-cli-production.md)
+> [← A1 — 安全完成第一個 CLI 任務](A1-cli-intro.md) · **Track A: CLI Power User** 第 2 站 · [下一站：Stage 5 的 Track A 核心](../../stages/05-claude-code-ecosystem.md#-進入條件與閱讀路線)
 
 這一站只解決一個問題：**怎麼讓 CLI agent 下次進到同一個 repo，還記得同一套做事方法？**
 
@@ -202,14 +202,16 @@ Claude Code 的 `.claude/commands/<name>.md` 目前仍能建立同名 `/name`，
 </table>
 </details>
 
-## ✅ 進 A3 前的自我檢查
+<a id="-進-a3-前的自我檢查"></a>
+
+## ✅ 進 Stage 5 前的自我檢查
 
 - [ ] 我能用自己的話分清專案規則、Skill、單次 prompt。
 - [ ] 我的規則卡有用途、禁止事項、驗證指令、交付格式，而且 agent 能讀到。
 - [ ] 我的 review Skill 只讀取變更，測試後 `git status --short` 沒有多出非預期修改。
 - [ ] 我知道「共用核心」不等於「所有 CLI 的檔名與權限都一樣」。
 
-四項都做到，就進入 [A3 — 把 CLI agent 接進安全的 production 流程](A3-cli-production.md)。若還沒做到，先回 demo repo 重跑 CLI-5 或 CLI-6，不必先讀完所有補充資料。
+四項都做到，就進入 [Stage 5 的 Track A 核心](../../stages/05-claude-code-ecosystem.md#-進入條件與閱讀路線)，先讀 5.1–5.4，再前往 A3。若還沒做到，先回 demo repo 重跑 CLI-5 或 CLI-6，不必先讀完所有補充資料。
 
 <details markdown="1">
 <summary>展開常見問題與修正方式</summary>

--- a/tracks/cli/A2-cli-workflow.zh-Hans.md
+++ b/tracks/cli/A2-cli-workflow.zh-Hans.md
@@ -2,7 +2,7 @@
 
 > [繁體中文](./A2-cli-workflow.md) | **简体中文** | [English](./A2-cli-workflow.en.md)
 
-> [← A1 — 安全完成第一个 CLI 任务](A1-cli-intro.zh-Hans.md) · **Track A: CLI Power User** 第 2 站 · [下一站：A3](A3-cli-production.zh-Hans.md)
+> [← A1 — 安全完成第一个 CLI 任务](A1-cli-intro.zh-Hans.md) · **Track A: CLI Power User** 第 2 站 · [下一站：Stage 5 的 Track A 核心](../../stages/05-claude-code-ecosystem.zh-Hans.md#-进入条件与阅读路径)
 
 这一站只解决一个问题：**怎么让 CLI agent 下次进入同一个 repo 时，还记得同一套做事方法？**
 
@@ -200,14 +200,16 @@ Claude Code 的 `.claude/commands/<name>.md` 目前仍能建立同名 `/name`，
 </table>
 </details>
 
-## ✅ 进入 A3 前的自我检查
+<a id="-进入-a3-前的自我检查"></a>
+
+## ✅ 进入 Stage 5 前的自我检查
 
 - [ ] 我能用自己的话分清项目规则、Skill、单次 prompt。
 - [ ] 我的项目规则卡有用途、禁止事项、验证指令、交付格式，而且 agent 能读到。
 - [ ] 我的 review Skill 只读取变更，测试后 `git status --short` 没有多出非预期修改。
 - [ ] 我知道“共用核心”不等于“所有 CLI 的文件名和权限都一样”。
 
-四项都做到，就进入 [A3 — 把 CLI agent 接进安全的 production 流程](A3-cli-production.zh-Hans.md)。如果还没做到，先回 demo repo 重跑 CLI-5 或 CLI-6，不必先读完所有补充资料。
+四项都做到，就进入 [Stage 5 的 Track A 核心](../../stages/05-claude-code-ecosystem.zh-Hans.md#-进入条件与阅读路径)，先读 5.1–5.4，再前往 A3。如果还没做到，先回 demo repo 重跑 CLI-5 或 CLI-6，不必先读完所有补充资料。
 
 <details markdown="1">
 <summary>展开常见问题和修正方式</summary>

--- a/tracks/cli/A3-cli-production.en.md
+++ b/tracks/cli/A3-cli-production.en.md
@@ -2,7 +2,7 @@
 
 > [繁體中文](./A3-cli-production.md) | [简体中文](./A3-cli-production.zh-Hans.md) | **English**
 
-> [← A2 — Make the CLI agent follow the same method every time](A2-cli-workflow.en.md) · **Track A: CLI Power User** Stop 3 (final)
+> [← Stage 5 — Track A core](../../stages/05-claude-code-ecosystem.en.md#-entry-requirements-and-reading-paths) · **Track A: CLI Power User** Stop 3 (final core stop)
 
 This stop has one goal: **have a CLI agent perform a read-only check on a test PR. It may give feedback, but it must not merge, deploy, or obtain extra permissions by itself.**
 
@@ -37,7 +37,7 @@ The three terms appear together but are not the same thing: MCP connects tools, 
 <summary>Expand for time, prerequisites, environment, and cost</summary>
 
 - **Time**: finish the four smallest outcomes first. You can usually split them into several short practices; do not connect many services at once just to save time.
-- **Prerequisites**: complete [A1](A1-cli-intro.en.md) and [A2](A2-cli-workflow.en.md), and be able to recognize the basic screens for `git status`, PRs, and GitHub Actions.
+- **Prerequisites**: complete [A1](A1-cli-intro.en.md), [A2](A2-cli-workflow.en.md), and the [Stage 5 Track A core, sections 5.1–5.4](../../stages/05-claude-code-ecosystem.en.md#-entry-requirements-and-reading-paths), and be able to recognize the basic screens for `git status`, PRs, and GitHub Actions.
 - **Environment**: a demo repo with no real secrets; use a GitHub-hosted Linux runner for the first round because a sandbox is easier to apply there.
 - **Cost**: GitHub Actions, a CLI subscription, and model APIs may be billed separately. Check your own plan before running; do not treat someone else’s prices as yours.
 
@@ -257,4 +257,4 @@ The directory only helps you “find candidates”; it does not guarantee a cand
 - [ ] I can point to the result and usage for one run; unavailable data was not guessed.
 - [ ] A teammate can run the Skill in a clean demo repo, and `git status` shows no unexpected changes afterward.
 
-Once all five are true, Track A is complete. Then choose by purpose: return to [Stage 3](../../stages/03-tool-use-and-hello-agent.en.md) to build an application; go to [Stage 7](../../stages/07-multi-agent-production.en.md) to study production systems; or read [Stage 7.5](../../stages/07.5-advanced-agentic-concepts.en.md) to understand agent concepts more deeply.
+Once all five are true, the Track A core is complete. The recommended next stop is [Stage 8 — Agent Interfaces](../../stages/08-agent-interfaces.en.md), where you set safe boundaries for browsers, computers, and sandboxes. Stage 8 does not block Track A Capstone entry. If you want to build your own agent, return to [Stage 3](../../stages/03-tool-use-and-hello-agent.en.md).

--- a/tracks/cli/A3-cli-production.md
+++ b/tracks/cli/A3-cli-production.md
@@ -2,7 +2,7 @@
 
 > **繁體中文** | [简体中文](./A3-cli-production.zh-Hans.md) | [English](./A3-cli-production.en.md)
 
-> [← A2 — 讓 CLI agent 每次都照同一套方法做事](A2-cli-workflow.md) · **Track A: CLI Power User** 第 3 站（最後）
+> [← Stage 5 — Track A 核心](../../stages/05-claude-code-ecosystem.md#-進入條件與閱讀路線) · **Track A: CLI Power User** 第 3 站（核心最後一站）
 
 這一站只做一件事：**讓 CLI agent 在測試用 PR 做一個只讀檢查。它可以提出意見，但不能自己合併、部署或取得多餘權限。**
 
@@ -37,7 +37,7 @@
 <summary>展開時間、先備條件、環境與費用</summary>
 
 - **時間**：先完成四個最小成果，通常可拆成數次短練習；不要為了趕時間一次接很多服務。
-- **先備條件**：完成 [A1](A1-cli-intro.md) 與 [A2](A2-cli-workflow.md)，並能看懂 `git status`、PR 與 GitHub Actions 的基本畫面。
+- **先備條件**：完成 [A1](A1-cli-intro.md)、[A2](A2-cli-workflow.md) 與 [Stage 5 的 Track A 核心 5.1–5.4](../../stages/05-claude-code-ecosystem.md#-進入條件與閱讀路線)，並能看懂 `git status`、PR 與 GitHub Actions 的基本畫面。
 - **環境**：一個沒有真實 secrets 的 demo repo；第一輪使用 GitHub-hosted Linux runner，較容易套用 sandbox。
 - **費用**：GitHub Actions、CLI 訂閱與模型 API 可能分開計費。執行前先看自己使用的方案，不要把別人的價格當成自己的價格。
 
@@ -257,4 +257,4 @@ Skill 的核心意思可以共用，但資料夾、權限、frontmatter 與安�
 - [ ] 我能指出一次執行的結果與 usage；拿不到的資料沒有亂猜。
 - [ ] 隊友能在乾淨 demo repo 執行 Skill，之後 `git status` 沒有非預期修改。
 
-五項都做到，就完成 Track A。接著依目的選路：想做應用，回到 [Stage 3](../../stages/03-tool-use-and-hello-agent.md)；想研究 production 系統，進 [Stage 7](../../stages/07-multi-agent-production.md)；想理解更深的 agent 概念，再讀 [Stage 7.5](../../stages/07.5-advanced-agentic-concepts.md)。
+五項都做到，就完成 Track A 核心。建議下一站讀 [Stage 8 — Agent 操作介面](../../stages/08-agent-interfaces.md)，學會怎麼替 Browser、Computer 與 Sandbox 設安全邊界；Stage 8 不擋 Track A Capstone 入場。想自己寫 agent，再回到 [Stage 3](../../stages/03-tool-use-and-hello-agent.md)。

--- a/tracks/cli/A3-cli-production.zh-Hans.md
+++ b/tracks/cli/A3-cli-production.zh-Hans.md
@@ -2,7 +2,7 @@
 
 > [繁體中文](./A3-cli-production.md) | **简体中文** | [English](./A3-cli-production.en.md)
 
-> [← A2 — 让 CLI agent 每次都按同一套方法做事](A2-cli-workflow.zh-Hans.md) · **Track A: CLI Power User** 第 3 站（最后）
+> [← Stage 5 — Track A 核心](../../stages/05-claude-code-ecosystem.zh-Hans.md#-进入条件与阅读路径) · **Track A: CLI Power User** 第 3 站（核心最后一站）
 
 这一站只做一件事：**让 CLI agent 在测试用 PR 做一次只读检查。它可以提出意见，但不能自己合并、部署或取得额外权限。**
 
@@ -37,7 +37,7 @@
 <summary>展开时间、前置条件、环境和费用</summary>
 
 - **时间**：先完成四个最小成果，通常可以拆成几次短练习；不要为了赶时间一次接入很多服务。
-- **前置条件**：完成 [A1](A1-cli-intro.zh-Hans.md) 和 [A2](A2-cli-workflow.zh-Hans.md)，并能看懂 `git status`、PR 和 GitHub Actions 的基本界面。
+- **前置条件**：完成 [A1](A1-cli-intro.zh-Hans.md)、[A2](A2-cli-workflow.zh-Hans.md) 和 [Stage 5 的 Track A 核心 5.1–5.4](../../stages/05-claude-code-ecosystem.zh-Hans.md#-进入条件与阅读路径)，并能看懂 `git status`、PR 和 GitHub Actions 的基本界面。
 - **环境**：一个没有真实 secrets 的 demo repo；第一轮使用 GitHub-hosted Linux runner，更容易套用 sandbox。
 - **费用**：GitHub Actions、CLI 订阅和模型 API 可能分别计费。运行前先查看自己使用的方案，不要把别人的价格当成自己的价格。
 
@@ -257,4 +257,4 @@ Skill 的核心意思可以共用，但文件夹、权限、frontmatter 和安�
 - [ ] 我能指出一次运行的结果和 usage；拿不到的数据没有乱猜。
 - [ ] 队友能在干净的 demo repo 运行 Skill，之后 `git status` 没有非预期修改。
 
-五项都做到，就完成 Track A。接着按目的选择路径：想做应用，回到 [Stage 3](../../stages/03-tool-use-and-hello-agent.zh-Hans.md)；想研究 production 系统，进入 [Stage 7](../../stages/07-multi-agent-production.zh-Hans.md)；想更深入理解 agent 概念，再读 [Stage 7.5](../../stages/07.5-advanced-agentic-concepts.zh-Hans.md)。
+五项都做到，就完成 Track A 核心。建议下一站读 [Stage 8 — Agent 操作界面](../../stages/08-agent-interfaces.zh-Hans.md)，学习怎样给 Browser、Computer 和 Sandbox 设置安全边界；Stage 8 不影响 Track A Capstone 入场。想自己写 agent，再回到 [Stage 3](../../stages/03-tool-use-and-hello-agent.zh-Hans.md)。


### PR DESCRIPTION
## Summary

- make README, Progress, Roadmap, Capstone, Stage 5, A2, A3, and the developer path use one trilingual learner route
- define Track A as `A1 → A2 → Stage 5 core 5.1–5.4 → A3 → Stage 8`, with Stage 8 recommended but non-blocking for Capstone entry
- keep Track B as `Stage 3 → 4 → 5 → 6 → 7 → 7.5 → 8`
- preserve renamed A2, Stage 5, and ROADMAP deep links with exact compatibility anchors
- add route-contract regression coverage and refresh the current 259-repository snapshot

## Stack dependency

This PR is stacked on #167 and intentionally targets `codex/site-coherence-repo-links-stack`. Review #167 first. Do not merge this PR before its base PR.

## Verification

- `python -m pytest scripts -q` — 495 passed
- strict anchors, mirror parity, locale links, Hans residue, image locale, duplicate repos, freshness, catalog counts, required stage template, and repository snapshot — passed
- `python scripts/build-docs-tree.py` — passed
- `python -m mkdocs build` — passed with known baseline warnings
- independent `code-reviewer` — APPROVE, staged fingerprint `c52b0a2316d5eea2c02661ee9440d2164510a6eca50161021ba70b48153bad1f`

## Review notes

The reviewer required two corrections before approval: Capstone now explicitly limits the Track A Stage 5 prerequisite to 5.1–5.4, and every removed ROADMAP H2/H3 plus renamed A2/Stage 5 self-check keeps its former deep link in all three locales.

This PR is intentionally left open. No merge, branch deletion, worktree cleanup, or prune is included.