### PR TITLE
fix(release): verify draft before tag creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,7 +259,8 @@ jobs:
           if gh release view "$RELEASE_VERSION" --repo "$REPOSITORY" --json isDraft >/tmp/existing-release.json 2>/dev/null; then
             test "$(jq -r .isDraft /tmp/existing-release.json)" = true
             gh release edit "$RELEASE_VERSION" --repo "$REPOSITORY" \
-              --draft --title "$title" --notes-file candidate/release-body.md
+              --draft --target "$LOCKED_SHA" --title "$title" \
+              --notes-file candidate/release-body.md
           else
             gh release create "$RELEASE_VERSION" --repo "$REPOSITORY" \
               --draft --target "$LOCKED_SHA" --title "$title" \
@@ -275,10 +276,10 @@ jobs:
           LOCKED_SHA: ${{ needs.prepare.outputs.sha }}
         run: |
           set -euo pipefail
-          git fetch --force origin "refs/tags/$RELEASE_VERSION:refs/tags/$RELEASE_VERSION"
-          test "$(git rev-list -n 1 "$RELEASE_VERSION")" = "$LOCKED_SHA"
-          gh api "repos/$REPOSITORY/releases/tags/$RELEASE_VERSION" > /tmp/release.json
-          test "$(jq -r .draft /tmp/release.json)" = true
+          gh release view "$RELEASE_VERSION" --repo "$REPOSITORY" \
+            --json isDraft,targetCommitish,body,assets > /tmp/release.json
+          test "$(jq -r .isDraft /tmp/release.json)" = true
+          test "$(jq -r .targetCommitish /tmp/release.json)" = "$LOCKED_SHA"
           jq -r '.body' /tmp/release.json | grep -Fx '## 繁體中文'
           jq -r '.body' /tmp/release.json | grep -Fx '## 简体中文'
           jq -r '.body' /tmp/release.json | grep -Fx '## English'
@@ -300,9 +301,9 @@ jobs:
           set -euo pipefail
           current_main="$(gh api "repos/$REPOSITORY/commits/main" --jq .sha)"
           test "$current_main" = "$LOCKED_SHA"
+          gh release edit "$RELEASE_VERSION" --repo "$REPOSITORY" --draft=false --latest
           git fetch --force origin "refs/tags/$RELEASE_VERSION:refs/tags/$RELEASE_VERSION"
           test "$(git rev-list -n 1 "$RELEASE_VERSION")" = "$LOCKED_SHA"
-          gh release edit "$RELEASE_VERSION" --repo "$REPOSITORY" --draft=false --latest
           gh api "repos/$REPOSITORY/releases/tags/$RELEASE_VERSION" > /tmp/published-release.json
           test "$(jq -r .draft /tmp/published-release.json)" = false
           test "$(jq -r .prerelease /tmp/published-release.json)" = false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Format: `YYYY-MM-DD · category · 1-line summary (commit-sha)`.
 
 ## 2026-08-31
 
+- **release / Draft verification / tag order** · 修正首次發布時 Draft Release 尚未建立遠端 tag，驗證步驟卻先抓 tag 而失敗的順序問題：Draft 階段改為核對 GitHub API 回傳的 `target_commitish` 是否等於鎖定的 main SHA；只有正式發布後才抓取 tag 並再次驗證 tag SHA。重跑既有 Draft 時也會把 target 重新鎖回同一 SHA，不會跳過附件、三語 body 或人工 Environment gate。
 - **maintenance / researcher route / official source** · 三語研究人員路線的 DVC command reference 改用目前會直接回應的官方 `doc.dvc.org/command-reference`，不再繞過已重新導向且容易被 rate limit 的舊入口；學習順序與說明不變。
 - **maintenance / Stage 1 / official source** · 三語 Llama 列不再指向已搬遷的 `ai.meta.com/llama/get-started`，改用重新導向後的 Meta AI 現行開發者文件；freshness gate 會阻擋舊入口回歸，模型內容與推薦定位不變。
 - **maintenance / setup guide / product identity** · 三語 Setup Guide 將已更名的 Windsurf 更新為現行 **Devin Desktop（原 Windsurf）**，入口改用官方 `devin.ai/desktop`，並說清楚它是桌面 Coding Agent／IDE 介面，不只是籠統的 AI editor；推薦度維持不變。Setup Guide 的官方來源包與查核日期同步更新，freshness gate 會阻擋舊 `windsurf.com/editor` 入口回歸。

--- a/scripts/test_release_workflow.py
+++ b/scripts/test_release_workflow.py
@@ -45,12 +45,31 @@ def test_prepare_locks_main_and_builds_all_locales() -> None:
 def test_publish_rechecks_sha_and_verifies_draft_before_publish() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
     assert text.count('test "$current_main" = "$LOCKED_SHA"') == 2
-    assert text.count('test "$(git rev-list -n 1 "$RELEASE_VERSION")" = "$LOCKED_SHA"') == 3
+    assert text.count('test "$(git rev-list -n 1 "$RELEASE_VERSION")" = "$LOCKED_SHA"') == 2
     assert 'git ls-remote --exit-code --tags origin "refs/tags/$RELEASE_VERSION"' in text
     draft = text.index("Create or refresh a Draft Release")
     verify = text.index("Verify the Draft Release before publishing")
     publish = text.index("Publish and verify the Release")
     assert draft < verify < publish
+    draft_verify_block = text[verify:publish]
+    assert 'gh release view "$RELEASE_VERSION" --repo "$REPOSITORY"' in draft_verify_block
+    assert "--json isDraft,targetCommitish,body,assets" in draft_verify_block
+    assert 'test "$(jq -r .isDraft /tmp/release.json)" = true' in draft_verify_block
+    assert 'test "$(jq -r .targetCommitish /tmp/release.json)" = "$LOCKED_SHA"' in draft_verify_block
+    assert "releases/tags/" not in draft_verify_block
+    refresh_block = text[draft:verify]
+    existing_draft_branch = refresh_block.split("          else", maxsplit=1)[0]
+    assert 'gh release edit "$RELEASE_VERSION"' in existing_draft_branch
+    assert '--draft --target "$LOCKED_SHA" --title "$title"' in existing_draft_branch
+    publish_command = text.index(
+        'gh release edit "$RELEASE_VERSION" --repo "$REPOSITORY" --draft=false --latest',
+        publish,
+    )
+    tag_fetch = text.index(
+        'git fetch --force origin "refs/tags/$RELEASE_VERSION:refs/tags/$RELEASE_VERSION"',
+        publish,
+    )
+    assert publish_command < tag_fetch
     for locale in ("zh-TW", "zh-Hans", "en"):
         assert f'awesome-agentic-ai-zh-$RELEASE_VERSION-{locale}.pdf' in text
 


### PR DESCRIPTION
## Why

The first formal release correctly built and uploaded all three PDFs, but the publish job tried to fetch the remote tag while the release was still a Draft. GitHub does not create that tag until publication.

## Fix

- Read Draft metadata through gh release view, which supports Draft releases.
- Lock an existing Draft back to the selected main SHA on reruns.
- Verify targetCommitish, body, and all three assets before publishing.
- Fetch and verify the remote tag only after publication.
- Add regression assertions for the existing-Draft branch and reject the published-tag endpoint in Draft verification.

## Evidence

- 1082 passed, 1 skipped
- Workflow security: 7/7
- git diff --check: passed
- Existing Draft 379678546 successfully returned the locked SHA and three assets through the new lookup
- Independent code-reviewer: APPROVE, P0-P3 none

Final evaluation remains with the maintainer.