### PR TITLE
content(stage1): add Claude Fable and Mythos 5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Format: `YYYY-MM-DD · category · 1-line summary (commit-sha)`.
 
 ---
 
+## 2026-09-01
+
+- **content / Stage 1 / Claude models** · 依 Anthropic 於 2026-09-01 發布的官方公告與模型頁，三語主流模型表更新為 **Claude Fable 5.1**（`claude-fable-5-1`）與 **Claude Mythos 5.1**（`claude-mythos-5-1`）：兩者皆為 1M context、128K 最大輸出、$10/$50（每百萬輸入／輸出 token），cache read 降為 $0.25。教材明確區分 Fable 5.1 一般可用；Mythos 5.1 是同一模型，但只提供給通過審核的資安與生命科學使用者。Stage 1 freshness 查核日與官方來源、專案模型白名單、Release Notes 及 citation 版本同步更新。
+
 ## 2026-08-31
 
 - **release / Draft verification / tag order** · 修正首次發布時 Draft Release 尚未建立遠端 tag，驗證步驟卻先抓 tag 而失敗的順序問題：Draft 階段改為核對 GitHub API 回傳的 `target_commitish` 是否等於鎖定的 main SHA；只有正式發布後才抓取 tag 並再次驗證 tag SHA。重跑既有 Draft 時也會把 target 重新鎖回同一 SHA，不會跳過附件、三語 body 或人工 Environment gate。

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,8 +16,8 @@ abstract: >-
   ecosystem, memory/RAG, and multi-agent production, organized as
   staged tracks and audience-specific branches.
 license: MIT
-version: "2026.08.23"
-date-released: "2026-08-23"
+version: "2026.09.01"
+date-released: "2026-09-01"
 keywords:
   - agentic-ai
   - ai-agents

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,10 +50,11 @@ If unsure, ask the user to run `ollama list` and verify.
 
 | Model | Use case | Pricing (per 1M tokens) |
 |---|---|---|
-| **`claude-fable-5`** | Mythos-class (above Opus); suspended 2026-06-12, **restored 2026-07-01** (controls lifted 2026-06-30); the highest Claude tier | $10 input / $50 output |
+| **`claude-fable-5-1`** | Highest widely released Claude tier; 1M context, 128K max output, and stronger long-running agentic work | $10 input / $50 output; $0.25 cache read |
+| **`claude-mythos-5-1`** | Same model as Fable 5.1, with access limited to vetted cybersecurity and life-science users | $10 input / $50 output; $0.25 cache read |
 | **`claude-haiku-4-5`** | Cheapest cloud option, OK for all exercises | $1 input / $5 output |
 | **`claude-sonnet-5`** | Production default, agent development | $2 input / $10 output |
-| **`claude-opus-5`** | Opus-class flagship (2026-07-24; succeeds Opus 4.8 at the same price, which stays available as legacy); high quality, complex reasoning (Fable 5 is the tier above) | $5 input / $25 output |
+| **`claude-opus-5`** | Opus-class default for most workloads; use Fable 5.1 when evals still fall short | $5 input / $25 output |
 
 ## Framing rules (do not violate)
 

--- a/release/notes.yml
+++ b/release/notes.yml
@@ -1,54 +1,15 @@
 schema_version: 1
-release_version: v2026.08.31
+release_version: v2026.09.01
 
 # One ordered list produces all three language sections in the GitHub Release.
 # Links are shared so the three summaries cannot silently point to different pages.
 changes:
-  - id: beginner-path
-    category: curriculum
-    zh-TW: 把 Stage 0–8、Stage 7.5 與 A1–A3 整理成清楚的學習路線；核心詞、必讀、精選專案與完成條件保持展開，補充步驟才收合。
-    zh-Hans: 把 Stage 0–8、Stage 7.5 与 A1–A3 整理成清楚的学习路线；核心词、必读、精选项目与完成条件保持展开，补充步骤才收合。
-    en: Reworked Stages 0–8, Stage 7.5, and A1–A3 into a clear learning path. Core terms, required reading, selected projects, and completion checks stay visible; secondary steps collapse.
+  - id: claude-fable-mythos-5-1
+    category: models
+    zh-TW: 依 2026-09-01 官方公告，主流模型表更新為 Claude Fable 5.1 與 Claude Mythos 5.1。兩者皆有 1M context、128K 最大輸出與 $10/$50 輸入／輸出價格，cache read 為 $0.25；Fable 5.1 一般可用，Mythos 5.1 只提供給通過審核的資安與生命科學使用者。
+    zh-Hans: 根据 2026-09-01 官方公告，主流模型表更新为 Claude Fable 5.1 与 Claude Mythos 5.1。两者都有 1M context、128K 最大输出和 $10/$50 输入／输出价格，cache read 为 $0.25；Fable 5.1 普遍可用，Mythos 5.1 只提供给通过审核的网络安全与生命科学用户。
+    en: Updated the model guide for the September 1, 2026 release of Claude Fable 5.1 and Claude Mythos 5.1. Both have a 1M context window, 128K maximum output, $10/$50 input/output pricing, and $0.25 cache reads. Fable 5.1 is generally available; Mythos 5.1 is limited to vetted cybersecurity and life-science users.
     links:
-      - https://github.com/WenyuChiou/awesome-agentic-ai-zh/tree/main/stages
-      - https://github.com/WenyuChiou/awesome-agentic-ai-zh/tree/main/tracks/cli
-  - id: definitions-and-model-lifecycle
-    category: fundamentals
-    zh-TW: 說清楚 AI Agent、Prompt、Token、Context、Pre-training、Post-training、Inference 等重要名詞，也補上從資料到 Agent 的模型生命週期圖。
-    zh-Hans: 说清楚 AI Agent、Prompt、Token、Context、Pre-training、Post-training、Inference 等重要名词，也补上从数据到 Agent 的模型生命周期图。
-    en: Clarified AI Agent, Prompt, Token, Context, Pre-training, Post-training, Inference, and other core terms, with a model-lifecycle diagram from data to agent.
-    links:
-      - https://github.com/WenyuChiou/awesome-agentic-ai-zh/blob/main/resources/glossary.md
-      - https://github.com/WenyuChiou/awesome-agentic-ai-zh/blob/main/stages/01-llm-basics.md
-  - id: rag-memory-and-agent-engineering
-    category: advanced-learning
-    zh-TW: 將進階 RAG 與 Agent Memory 拆成可單獨閱讀的指南，並釐清 Prompt、Context、Harness、Loop、Graph 等工程層次。
-    zh-Hans: 将进阶 RAG 与 Agent Memory 拆成可单独阅读的指南，并理清 Prompt、Context、Harness、Loop、Graph 等工程层次。
-    en: Split Advanced RAG and Agent Memory into standalone guides and clarified the Prompt, Context, Harness, Loop, and Graph engineering layers.
-    links:
-      - https://github.com/WenyuChiou/awesome-agentic-ai-zh/blob/main/resources/advanced-rag.md
-      - https://github.com/WenyuChiou/awesome-agentic-ai-zh/blob/main/resources/agent-memory.md
-  - id: eval-and-safe-execution
-    category: production
-    zh-TW: 把 Stage 7 與 Paper Summary Bot 接到 Eval、可觀測性、人工批准、Checkpoint、Resume 與失敗恢復，讓「能跑」和「能安全交付」分得清楚。
-    zh-Hans: 把 Stage 7 与 Paper Summary Bot 接到 Eval、可观测性、人工批准、Checkpoint、Resume 与失败恢复，让“能跑”和“能安全交付”分得清楚。
-    en: Connected Stage 7 and the Paper Summary Bot to evals, observability, human approval, checkpoints, resume, and recovery so “it runs” is distinct from “it is safe to deliver.”
-    links:
-      - https://github.com/WenyuChiou/awesome-agentic-ai-zh/blob/main/stages/07-multi-agent-production.md
-      - https://github.com/WenyuChiou/awesome-agentic-ai-zh/blob/main/walkthroughs/build-first-agent-in-7-steps.md
-  - id: roles-resources-and-freshness
-    category: resources
-    zh-TW: 重整五條角色路線、Cookbook、課程與資源入口；保留五星推薦度，並用官方資料檢查連結、專案狀態與易變資訊。
-    zh-Hans: 重整五条角色路线、Cookbook、课程与资源入口；保留五星推荐度，并用官方资料检查链接、项目状态与易变信息。
-    en: Reworked the five role paths, Cookbook, courses, and resource hub. Five-star editorial ratings remain visible, while official data checks links, repository state, and volatile facts.
-    links:
-      - https://github.com/WenyuChiou/awesome-agentic-ai-zh/tree/main/branches
-      - https://github.com/WenyuChiou/awesome-agentic-ai-zh/tree/main/resources
-  - id: trilingual-site-and-governance
-    category: delivery
-    zh-TW: 補強三語鏡像、手機表格、圖片載入、線上文件與必要 PR gate；Release 現在由同一份頁面清單產生繁中、簡中、英文 PDF。
-    zh-Hans: 补强三语镜像、手机表格、图片加载、在线文档与必要 PR gate；Release 现在由同一份页面清单生成繁中、简中、英文 PDF。
-    en: Strengthened locale mirrors, mobile tables, image delivery, the live docs site, and the required PR gate. Releases now build zh-TW, zh-Hans, and English PDFs from one page manifest.
-    links:
-      - https://wenyuchiou.github.io/awesome-agentic-ai-zh/
-      - https://github.com/WenyuChiou/awesome-agentic-ai-zh/actions
+      - https://www.anthropic.com/claude-fable-and-mythos-5-1
+      - https://platform.claude.com/docs/en/models/fable-5-1/overview
+      - https://platform.claude.com/docs/en/models/mythos-5-1/overview

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -104,16 +104,16 @@ python scripts/check-2026-freshness.py
 ## `build-pdf.sh` — 從同一份清單建立三語 PDF
 
 ```bash
-RELEASE_VERSION=v2026.08.31 LANG_VARIANT=zh-TW bash scripts/build-pdf.sh
-RELEASE_VERSION=v2026.08.31 LANG_VARIANT=zh-Hans bash scripts/build-pdf.sh
-RELEASE_VERSION=v2026.08.31 LANG_VARIANT=en bash scripts/build-pdf.sh
+RELEASE_VERSION=v2026.09.01 LANG_VARIANT=zh-TW bash scripts/build-pdf.sh
+RELEASE_VERSION=v2026.09.01 LANG_VARIANT=zh-Hans bash scripts/build-pdf.sh
+RELEASE_VERSION=v2026.09.01 LANG_VARIANT=en bash scripts/build-pdf.sh
 ```
 
 輸出檔名固定為：
 
-- `dist/awesome-agentic-ai-zh-v2026.08.31-zh-TW.pdf`
-- `dist/awesome-agentic-ai-zh-v2026.08.31-zh-Hans.pdf`
-- `dist/awesome-agentic-ai-zh-v2026.08.31-en.pdf`
+- `dist/awesome-agentic-ai-zh-v2026.09.01-zh-TW.pdf`
+- `dist/awesome-agentic-ai-zh-v2026.09.01-zh-Hans.pdf`
+- `dist/awesome-agentic-ai-zh-v2026.09.01-en.pdf`
 
 頁面順序只寫在 [`release/pages.yml`](../release/pages.yml) 一次；工具會從同一列推導繁中、簡中、英文檔名，並阻擋缺頁、順序漂移和外部 URL 漂移。Stage 0–8、Stage 7.5、A1–A3、五條角色路線、walkthrough、Capstone、Setup、Glossary、Resources、Advanced RAG、Agent Memory、CLI 與模型訓練選修都在這份清單裡。正文裡預設收合的補充內容會在 PDF 中展開。
 
@@ -128,7 +128,7 @@ sudo apt-get install pandoc weasyprint poppler-utils \
 
 ```bash
 python scripts/release_manifest.py validate-pdfs \
-  --version v2026.08.31 --dist dist --json dist/pdf-validation.json
+  --version v2026.09.01 --dist dist --json dist/pdf-validation.json
 ```
 
 [`release/notes.yml`](../release/notes.yml) 也只寫一次。`release_manifest.py render-notes` 會用相同 change ID、順序和共用連結產生三個語言段落。

--- a/scripts/freshness-models.yml
+++ b/scripts/freshness-models.yml
@@ -11,12 +11,12 @@
 
 stage01_fact_pack:
   canonical: 'stages/01-llm-basics.md'
-  verified_on: '2026-08-31'
+  verified_on: '2026-09-01'
   scope: ['models', 'pricing', 'availability', 'deprecations', 'model-lifecycle']
   official_sources:
     openai_model_development: 'https://openai.com/policies/how-chatgpt-and-our-foundation-models-are-developed/'
     google_llm_tuning: 'https://developers.google.com/machine-learning/crash-course/llm/tuning'
-    claude: 'https://platform.claude.com/docs/en/models/overview'
+    claude: 'https://platform.claude.com/docs/en/models/fable-5-1/overview'
     gpt: 'https://developers.openai.com/api/docs/models'
     gemini: 'https://ai.google.dev/gemini-api/docs/models'
     deepseek: 'https://api-docs.deepseek.com/quick_start/pricing/'
@@ -477,10 +477,11 @@ verified_pages:
     max_age_days: 90
 
 current_frontier_models:
-  # Verified 2026-08-27 from provider docs / official model cards.
+  # Verified 2026-09-01 from provider docs / official model cards.
   # This list documents what maintainers checked; stale_patterns below are the gate.
   anthropic:
-    - "Fable 5"
+    - "Fable 5.1"
+    - "Mythos 5.1"   # same model; limited to vetted cyber and life-science users
     - "Opus 5"
     - "Sonnet 5"
     - "Haiku 4.5"
@@ -525,6 +526,11 @@ current_frontier_models:
 # scanned — a qualifier written as "baseline" in zh-TW/en often becomes "基线" in
 # the zh-Hans mirror, and the gate must recognize all three (2026-07 gap).
 stale_patterns:
+  - pattern: 'Fable 5(?!\.1)|Mythos 5(?!\.1)'
+    include_files: ['stages/01-llm-basics.md']
+    qualifier_terms: ['前身', '歷史', '舊版', 'predecessor', 'historical', 'legacy', '前代', '历史', '旧版']
+    note: 'Fable 5.1 and Mythos 5.1 superseded the 5.0 model recommendations on 2026-09-01'
+
   # The setup guide is a copy/run entry point. It must use current native
   # installation paths and avoid freezing account-specific prices or credits.
   - pattern: 'npm install -g @anthropic-ai/claude-code|Node\.js\s*(?:v?18|18\+)'

--- a/scripts/test_model_lifecycle_content.py
+++ b/scripts/test_model_lifecycle_content.py
@@ -133,7 +133,7 @@ def test_freshness_markers_share_one_date_and_canonical_scope() -> None:
 
     assert len(set(stage_markers)) == 1
     assert len(set(guide_markers)) == 1
-    assert "verified_on=2026-08-31" in stage_markers[0]
+    assert "verified_on=2026-09-01" in stage_markers[0]
     assert "scope=models,pricing,availability,deprecations,model-lifecycle" in stage_markers[0]
     assert "canonical=resources/model-training-guide.md" in guide_markers[0]
     assert "verified_on=2026-08-31" in guide_markers[0]

--- a/scripts/test_release_manifest.py
+++ b/scripts/test_release_manifest.py
@@ -44,9 +44,9 @@ def test_page_manifest_has_one_ordered_trilingual_source() -> None:
 
 
 def test_release_notes_are_trilingual_mirrors() -> None:
-    manifest = rm.validate_notes_manifest(expected_version="v2026.08.31")
+    manifest = rm.validate_notes_manifest(expected_version="v2026.09.01")
     rendered = rm.render_notes(
-        "v2026.08.31", sha="0123456789abcdef0123456789abcdef01234567"
+        "v2026.09.01", sha="0123456789abcdef0123456789abcdef01234567"
     )
     assert rendered.index("## 繁體中文") < rendered.index("## 简体中文") < rendered.index("## English")
     assert rendered.count("- `") == len(manifest["changes"]) * 3

--- a/scripts/test_stage01_models.py
+++ b/scripts/test_stage01_models.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PAGES = (
+    (ROOT / "stages" / "01-llm-basics.md", "Fable 5.1：正式可用", "Mythos 5.1：限核准使用者"),
+    (ROOT / "stages" / "01-llm-basics.zh-Hans.md", "Fable 5.1：正式可用", "Mythos 5.1：限核准用户"),
+    (ROOT / "stages" / "01-llm-basics.en.md", "Fable 5.1: generally available", "Mythos 5.1: vetted access only"),
+)
+
+
+@pytest.mark.parametrize(("page", "fable_status", "mythos_status"), PAGES)
+def test_stage01_uses_current_fable_and_mythos_models(
+    page: Path, fable_status: str, mythos_status: str
+) -> None:
+    text = page.read_text(encoding="utf-8")
+    row = next(line for line in text.splitlines() if line.startswith("| Claude |"))
+    cells = [cell.strip() for cell in row.strip("|").split("|")]
+
+    assert len(cells) == 8
+    assert "Fable 5.1" in cells[1]
+    assert "Mythos 5.1" in cells[1]
+    assert "claude-fable-5-1" in cells[1]
+    assert "claude-mythos-5-1" in cells[1]
+    assert fable_status in cells[2]
+    assert mythos_status in cells[2]
+    assert "1M" in cells[3]
+    assert "128K" in cells[3]
+    assert "$10/$50" in cells[4]
+    assert "$0.25" in cells[4]
+    assert "https://platform.claude.com/docs/en/models/fable-5-1/overview" in cells[7]
+    assert "https://platform.claude.com/docs/en/models/mythos-5-1/overview" in cells[7]
+    assert "claude-fable-5-1" in text
+    assert "claude-mythos-5-1" in text
+    assert not re.search(r"claude-(?:fable|mythos)-5(?!-1)", text)
+    assert "verified_on=2026-09-01" in text

--- a/stages/01-llm-basics.en.md
+++ b/stages/01-llm-basics.en.md
@@ -4,7 +4,7 @@
 
 > Purpose: first see how a model moves from data to an Agent, then use a repeatable local-to-cloud path to call an LLM through an API (application programming interface). You will understand **Token**, **Context Window**, and **Temperature**, and explain model choices using cost and latency.
 
-<!-- freshness: canonical=stages/01-llm-basics.md; verified_on=2026-08-31; scope=models,pricing,availability,deprecations,model-lifecycle; max_age_days=90 -->
+<!-- freshness: canonical=stages/01-llm-basics.md; verified_on=2026-09-01; scope=models,pricing,availability,deprecations,model-lifecycle; max_age_days=90 -->
 
 ## 📌 Learning Goals
 
@@ -307,7 +307,7 @@ PRICING = {
     "claude-haiku-4-5":   {"input": 1.00, "output":  5.00},
     "claude-sonnet-5":    {"input": 2.00, "output": 10.00},
     "claude-opus-5":      {"input": 5.00, "output": 25.00},
-    "claude-fable-5":     {"input": 10.00, "output": 50.00},
+    "claude-fable-5-1":   {"input": 10.00, "output": 50.00},
 }
 
 client = anthropic.Anthropic()
@@ -478,7 +478,7 @@ If an official source gives no reliable public number, the table says “Not pub
 
 | Family | Current recommended models | Status | Context | Price or license | Good for | Limitations | Official source |
 |---|---|---|---|---|---|---|---|
-| Claude | Fable 5; Opus 5; Sonnet 5; Haiku 4.5 | Generally available | 1M (Haiku 200K) | API: Fable $10/$50, Opus $5/$25, Sonnet $2/$10, Haiku $1/$5 (input/output) | Long-form, coding, agent workflows | Fable is generally available, not invitation-only; model IDs differ by platform, so confirm platform and region support before use | [Anthropic model overview](https://platform.claude.com/docs/en/models/overview) |
+| Claude | Fable 5.1 (`claude-fable-5-1`); Mythos 5.1 (`claude-mythos-5-1`); Opus 5; Sonnet 5; Haiku 4.5 | Fable 5.1: generally available; Mythos 5.1: vetted access only | 1M context / 128K max output (Haiku 200K / 64K) | API: Fable/Mythos $10/$50, Opus $5/$25, Sonnet $2/$10, Haiku $1/$5 (input/output); Fable/Mythos cache reads $0.25 | Long-form, coding, long-running agent workflows | Mythos 5.1 is the same model as Fable 5.1 but is limited to vetted cybersecurity and life-science users | [Fable 5.1](https://platform.claude.com/docs/en/models/fable-5-1/overview) · [Mythos 5.1](https://platform.claude.com/docs/en/models/mythos-5-1/overview) |
 | GPT | GPT-5.6 Sol / Terra / Luna | Generally available | 1.05M | API: $4/$20, $2/$12, $0.20/$1.20 (input/output) | General chat, tool use, existing SDK integration | Price and limits vary by model and API plan | [OpenAI API models](https://developers.openai.com/api/docs/models) |
 | Gemini | Gemini 3.7 Flash | Generally available | 1M | Through 2026-12-31, introductory $0.75/$3.75 (input/output) | Long documents, multimodal tasks, Google integration | Gemini 3.1 Pro is Preview; introductory pricing has an end date | [Gemini models](https://ai.google.dev/gemini-api/docs/models) · [Gemini API pricing](https://ai.google.dev/gemini-api/docs/pricing) |
 | DeepSeek | `deepseek-v4-flash` / `deepseek-v4-pro` | Generally available | 1M | Cache-miss: Flash $0.14/$0.28, Pro $0.435/$0.87 (input/output) | Reasoning, coding, high-token workloads | Legacy `deepseek-chat` / `deepseek-reasoner` aliases were deprecated 2026-07-24 | [DeepSeek pricing](https://api-docs.deepseek.com/quick_start/pricing/) |

--- a/stages/01-llm-basics.md
+++ b/stages/01-llm-basics.md
@@ -4,7 +4,7 @@
 
 > 本章目的：先看懂模型怎麼從資料走到 Agent，再用一條可重複的本機到雲端路徑呼叫 LLM。你會讀懂 **Token（詞元）**、**Context Window（上下文視窗）** 與 **Temperature（溫度）**，也會用成本與延遲解釋模型選擇。
 
-<!-- freshness: canonical=stages/01-llm-basics.md; verified_on=2026-08-31; scope=models,pricing,availability,deprecations,model-lifecycle; max_age_days=90 -->
+<!-- freshness: canonical=stages/01-llm-basics.md; verified_on=2026-09-01; scope=models,pricing,availability,deprecations,model-lifecycle; max_age_days=90 -->
 
 ## 📌 學習目標
 
@@ -307,7 +307,7 @@ PRICING = {
     "claude-haiku-4-5":   {"input": 1.00, "output":  5.00},
     "claude-sonnet-5":    {"input": 2.00, "output": 10.00},
     "claude-opus-5":      {"input": 5.00, "output": 25.00},
-    "claude-fable-5":     {"input": 10.00, "output": 50.00},
+    "claude-fable-5-1":   {"input": 10.00, "output": 50.00},
 }
 
 client = anthropic.Anthropic()
@@ -478,7 +478,7 @@ print(f"💡 跑這次完全沒花錢（除了你的電力）")
 
 | 家族 | 目前推薦型號 | 狀態 | Context | 價格或授權 | 適合做什麼 | 限制 | 官方來源 |
 |---|---|---|---|---|---|---|---|
-| Claude | Fable 5；Opus 5；Sonnet 5；Haiku 4.5 | 正式可用 | 1M（Haiku 200K） | API：Fable $10/$50、Opus $5/$25、Sonnet $2/$10、Haiku $1/$5（輸入／輸出） | 長文、程式、agent 工作流 | Fable 已正式開放，不是邀請限定；各平台的 model ID 不同，使用前確認平台與區域支援 | [Anthropic 模型總覽](https://platform.claude.com/docs/en/models/overview) |
+| Claude | Fable 5.1（`claude-fable-5-1`）；Mythos 5.1（`claude-mythos-5-1`）；Opus 5；Sonnet 5；Haiku 4.5 | Fable 5.1：正式可用；Mythos 5.1：限核准使用者 | 1M context／128K 最大輸出（Haiku 200K／64K） | API：Fable／Mythos $10/$50、Opus $5/$25、Sonnet $2/$10、Haiku $1/$5（輸入／輸出）；Fable／Mythos cache read $0.25 | 長文、程式、長時間 agent 工作流 | Mythos 5.1 是與 Fable 5.1 相同的模型，但只提供給通過審核的資安與生命科學使用者 | [Fable 5.1](https://platform.claude.com/docs/en/models/fable-5-1/overview) · [Mythos 5.1](https://platform.claude.com/docs/en/models/mythos-5-1/overview) |
 | GPT | GPT-5.6 Sol／Terra／Luna | 正式可用 | 1.05M | API：$4/$20、$2/$12、$0.20/$1.20（輸入／輸出） | 通用對話、工具呼叫、既有 SDK 整合 | 價格與限制依型號及 API 方案 | [OpenAI API 模型](https://developers.openai.com/api/docs/models) |
 | Gemini | Gemini 3.7 Flash | 正式可用 | 1M | 2026-12-31 前介紹價 $0.75/$3.75（輸入／輸出） | 長文件、多模態與 Google 生態整合 | Gemini 3.1 Pro 為 Preview；介紹價有期限 | [Gemini 模型文件](https://ai.google.dev/gemini-api/docs/models) · [Gemini API 定價](https://ai.google.dev/gemini-api/docs/pricing) |
 | DeepSeek | `deepseek-v4-flash`／`deepseek-v4-pro` | 正式可用 | 1M | Cache-miss：Flash $0.14/$0.28、Pro $0.435/$0.87（輸入／輸出） | 推理、程式、大量 token 任務 | 舊 `deepseek-chat`／`deepseek-reasoner` alias 已於 2026-07-24 棄用 | [DeepSeek 定價](https://api-docs.deepseek.com/quick_start/pricing/) |

--- a/stages/01-llm-basics.zh-Hans.md
+++ b/stages/01-llm-basics.zh-Hans.md
@@ -4,7 +4,7 @@
 
 > 本章目的：先看懂模型如何从数据走到 Agent，再通过一条可重复的本地到云端路径调用 LLM。你会理解 **Token（词元）**、**Context Window（上下文窗口）** 和 **Temperature（温度）**，也会用成本与延迟解释模型选择。
 
-<!-- freshness: canonical=stages/01-llm-basics.md; verified_on=2026-08-31; scope=models,pricing,availability,deprecations,model-lifecycle; max_age_days=90 -->
+<!-- freshness: canonical=stages/01-llm-basics.md; verified_on=2026-09-01; scope=models,pricing,availability,deprecations,model-lifecycle; max_age_days=90 -->
 
 ## 📌 学习目标
 
@@ -307,7 +307,7 @@ PRICING = {
     "claude-haiku-4-5":   {"input": 1.00, "output":  5.00},
     "claude-sonnet-5":    {"input": 2.00, "output": 10.00},
     "claude-opus-5":      {"input": 5.00, "output": 25.00},
-    "claude-fable-5":     {"input": 10.00, "output": 50.00},
+    "claude-fable-5-1":   {"input": 10.00, "output": 50.00},
 }
 
 client = anthropic.Anthropic()
@@ -478,7 +478,7 @@ print("💡 本次调用为 $0（不含电费）")
 
 | 家族 | 当前推荐型号 | 状态 | Context | 价格或授权 | 适合做什么 | 限制 | 官方来源 |
 |---|---|---|---|---|---|---|---|
-| Claude | Fable 5；Opus 5；Sonnet 5；Haiku 4.5 | 正式可用 | 1M（Haiku 200K） | API：Fable $10/$50、Opus $5/$25、Sonnet $2/$10、Haiku $1/$5（输入／输出） | 长文、编程、agent 工作流 | Fable 已正式开放，不是仅限邀请；各平台的 model ID 不同，使用前确认平台和区域支持 | [Anthropic 模型总览](https://platform.claude.com/docs/en/models/overview) |
+| Claude | Fable 5.1（`claude-fable-5-1`）；Mythos 5.1（`claude-mythos-5-1`）；Opus 5；Sonnet 5；Haiku 4.5 | Fable 5.1：正式可用；Mythos 5.1：限核准用户 | 1M context／128K 最大输出（Haiku 200K／64K） | API：Fable／Mythos $10/$50、Opus $5/$25、Sonnet $2/$10、Haiku $1/$5（输入／输出）；Fable／Mythos cache read $0.25 | 长文、编程、长时间 agent 工作流 | Mythos 5.1 是与 Fable 5.1 相同的模型，但只提供给通过审核的网络安全与生命科学用户 | [Fable 5.1](https://platform.claude.com/docs/en/models/fable-5-1/overview) · [Mythos 5.1](https://platform.claude.com/docs/en/models/mythos-5-1/overview) |
 | GPT | GPT-5.6 Sol／Terra／Luna | 正式可用 | 1.05M | API：$4/$20、$2/$12、$0.20/$1.20（输入／输出） | 通用对话、工具调用、已有 SDK 集成 | 价格与限制按型号及 API 方案变化 | [OpenAI API 模型](https://developers.openai.com/api/docs/models) |
 | Gemini | Gemini 3.7 Flash | 正式可用 | 1M | 2026-12-31 前介绍价 $0.75/$3.75（输入／输出） | 长文档、多模态与 Google 生态整合 | Gemini 3.1 Pro 为 Preview；介绍价有期限 | [Gemini 模型文档](https://ai.google.dev/gemini-api/docs/models) · [Gemini API 定价](https://ai.google.dev/gemini-api/docs/pricing) |
 | DeepSeek | `deepseek-v4-flash`／`deepseek-v4-pro` | 正式可用 | 1M | Cache-miss：Flash $0.14/$0.28、Pro $0.435/$0.87（输入／输出） | 推理、编程、大量 token 任务 | 旧 `deepseek-chat`／`deepseek-reasoner` alias 已于 2026-07-24 弃用 | [DeepSeek 定价](https://api-docs.deepseek.com/quick_start/pricing/) |


### PR DESCRIPTION
## Summary
- update the trilingual Stage 1 Claude roster to Fable 5.1 and Mythos 5.1
- document both official model IDs, 1M context, 128K max output, \/\ pricing, \.25 cache reads, and model-specific access
- refresh freshness policy, release notes, citation metadata, and regression tests

## Official sources
- https://www.anthropic.com/claude-fable-and-mythos-5-1
- https://platform.claude.com/docs/en/models/fable-5-1/overview
- https://platform.claude.com/docs/en/models/mythos-5-1/overview

## Verification
- 1085 passed, 1 skipped
- strict anchors, mirror parity, locale links, zh-Hans, reader UX, freshness
- trilingual MkDocs build and rendered-site audit
- release manifest: 28 pages × 3 locales
- independent code-reviewer: APPROVE