### PR TITLE
release: prepare v2026.09.04 trilingual notes

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,8 +16,8 @@ abstract: >-
   ecosystem, memory/RAG, and multi-agent production, organized as
   staged tracks and audience-specific branches.
 license: MIT
-version: "2026.09.01"
-date-released: "2026-09-01"
+version: "2026.09.04"
+date-released: "2026-09-04"
 keywords:
   - agentic-ai
   - ai-agents

--- a/release/notes.yml
+++ b/release/notes.yml
@@ -1,15 +1,26 @@
 schema_version: 1
-release_version: v2026.09.01
+release_version: v2026.09.04
 
 # One ordered list produces all three language sections in the GitHub Release.
 # Links are shared so the three summaries cannot silently point to different pages.
 changes:
-  - id: claude-fable-mythos-5-1
-    category: models
-    zh-TW: 依 2026-09-01 官方公告，主流模型表更新為 Claude Fable 5.1 與 Claude Mythos 5.1。兩者皆有 1M context、128K 最大輸出與 $10/$50 輸入／輸出價格，cache read 為 $0.25；Fable 5.1 一般可用，Mythos 5.1 只提供給通過審核的資安與生命科學使用者。
-    zh-Hans: 根据 2026-09-01 官方公告，主流模型表更新为 Claude Fable 5.1 与 Claude Mythos 5.1。两者都有 1M context、128K 最大输出和 $10/$50 输入／输出价格，cache read 为 $0.25；Fable 5.1 普遍可用，Mythos 5.1 只提供给通过审核的网络安全与生命科学用户。
-    en: Updated the model guide for the September 1, 2026 release of Claude Fable 5.1 and Claude Mythos 5.1. Both have a 1M context window, 128K maximum output, $10/$50 input/output pricing, and $0.25 cache reads. Fable 5.1 is generally available; Mythos 5.1 is limited to vetted cybersecurity and life-science users.
+  - id: bifrost-stage4-gateway
+    category: infrastructure
+    zh-TW: Stage 4 加入 Bifrost，讓讀者和 LiteLLM 並排學習 AI gateway。教材清楚說明 gateway 負責統一連接模型、routing、fallback 與 load balancing，不是替 Agent 決定下一步的 Agent framework；也分開標示開源功能與 enterprise 功能。
+    zh-Hans: Stage 4 加入 Bifrost，让读者和 LiteLLM 并排学习 AI gateway。教材清楚说明 gateway 负责统一连接模型、routing、fallback 和 load balancing，不是替 Agent 决定下一步的 Agent framework；也分开标示开源功能和 enterprise 功能。
+    en: Stage 4 adds Bifrost beside LiteLLM as an AI gateway learning resource. It explains that a gateway connects model providers and handles routing, fallbacks, and load balancing; it is not the Agent framework that decides the next step. Open-source and enterprise features are also separated.
     links:
-      - https://www.anthropic.com/claude-fable-and-mythos-5-1
-      - https://platform.claude.com/docs/en/models/fable-5-1/overview
-      - https://platform.claude.com/docs/en/models/mythos-5-1/overview
+      - https://github.com/maximhq/bifrost
+      - https://docs.getbifrost.ai
+
+  - id: gpt6-stage1-model-refresh
+    category: models
+    zh-TW: Stage 1 重新查核 15 個模型家族。GPT 欄更新為 GPT-6 Astra 與 GPT-5.6 Terra／Luna，並說明 Astra 正在分批開放、1.05M context、128K 最大輸出、$10/$50 價格，以及超過 272K 輸入後的費率變化。Gemini 更新為 3.8 Flash；DeepSeek V4、Hunyuan Hy3 與 MiniMax M3 的價格、輸出、狀態、來源或授權也依官方資料修正。
+    zh-Hans: Stage 1 重新核查 15 个模型家族。GPT 栏更新为 GPT-6 Astra 与 GPT-5.6 Terra／Luna，并说明 Astra 正在分批开放、1.05M context、128K 最大输出、$10/$50 价格，以及超过 272K 输入后的费率变化。Gemini 更新为 3.8 Flash；DeepSeek V4、Hunyuan Hy3 与 MiniMax M3 的价格、输出、状态、来源或授权也根据官方资料修正。
+    en: Stage 1 rechecks all 15 model families. The GPT entry now lists GPT-6 Astra with GPT-5.6 Terra and Luna, and explains Astra's rollout, 1.05M context, 128K maximum output, $10/$50 pricing, and the rate change above 272K input. Gemini moves to 3.8 Flash, while official sources correct the pricing, output, status, source, or license details for DeepSeek V4, Hunyuan Hy3, and MiniMax M3.
+    links:
+      - https://developers.openai.com/api/docs/models/gpt-6-astra
+      - https://ai.google.dev/gemini-api/docs/models/gemini-3.8-flash
+      - https://api-docs.deepseek.com/quick_start/pricing/
+      - https://cloud.tencent.com/document/product/1823/130051
+      - https://huggingface.co/MiniMaxAI/MiniMax-M3

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -104,16 +104,16 @@ python scripts/check-2026-freshness.py
 ## `build-pdf.sh` — 從同一份清單建立三語 PDF
 
 ```bash
-RELEASE_VERSION=v2026.09.01 LANG_VARIANT=zh-TW bash scripts/build-pdf.sh
-RELEASE_VERSION=v2026.09.01 LANG_VARIANT=zh-Hans bash scripts/build-pdf.sh
-RELEASE_VERSION=v2026.09.01 LANG_VARIANT=en bash scripts/build-pdf.sh
+RELEASE_VERSION=v2026.09.04 LANG_VARIANT=zh-TW bash scripts/build-pdf.sh
+RELEASE_VERSION=v2026.09.04 LANG_VARIANT=zh-Hans bash scripts/build-pdf.sh
+RELEASE_VERSION=v2026.09.04 LANG_VARIANT=en bash scripts/build-pdf.sh
 ```
 
 輸出檔名固定為：
 
-- `dist/awesome-agentic-ai-zh-v2026.09.01-zh-TW.pdf`
-- `dist/awesome-agentic-ai-zh-v2026.09.01-zh-Hans.pdf`
-- `dist/awesome-agentic-ai-zh-v2026.09.01-en.pdf`
+- `dist/awesome-agentic-ai-zh-v2026.09.04-zh-TW.pdf`
+- `dist/awesome-agentic-ai-zh-v2026.09.04-zh-Hans.pdf`
+- `dist/awesome-agentic-ai-zh-v2026.09.04-en.pdf`
 
 頁面順序只寫在 [`release/pages.yml`](../release/pages.yml) 一次；工具會從同一列推導繁中、簡中、英文檔名，並阻擋缺頁、順序漂移和外部 URL 漂移。Stage 0–8、Stage 7.5、A1–A3、五條角色路線、walkthrough、Capstone、Setup、Glossary、Resources、Advanced RAG、Agent Memory、CLI 與模型訓練選修都在這份清單裡。正文裡預設收合的補充內容會在 PDF 中展開。
 
@@ -128,7 +128,7 @@ sudo apt-get install pandoc weasyprint poppler-utils \
 
 ```bash
 python scripts/release_manifest.py validate-pdfs \
-  --version v2026.09.01 --dist dist --json dist/pdf-validation.json
+  --version v2026.09.04 --dist dist --json dist/pdf-validation.json
 ```
 
 [`release/notes.yml`](../release/notes.yml) 也只寫一次。`release_manifest.py render-notes` 會用相同 change ID、順序和共用連結產生三個語言段落。

--- a/scripts/test_release_manifest.py
+++ b/scripts/test_release_manifest.py
@@ -44,9 +44,9 @@ def test_page_manifest_has_one_ordered_trilingual_source() -> None:
 
 
 def test_release_notes_are_trilingual_mirrors() -> None:
-    manifest = rm.validate_notes_manifest(expected_version="v2026.09.01")
+    manifest = rm.validate_notes_manifest(expected_version="v2026.09.04")
     rendered = rm.render_notes(
-        "v2026.09.01", sha="0123456789abcdef0123456789abcdef01234567"
+        "v2026.09.04", sha="0123456789abcdef0123456789abcdef01234567"
     )
     assert rendered.index("## 繁體中文") < rendered.index("## 简体中文") < rendered.index("## English")
     assert rendered.count("- `") == len(manifest["changes"]) * 3


### PR DESCRIPTION
## Summary
- publish one trilingual release-note manifest for the Bifrost and Stage 1 model updates already on `main`
- align `CITATION.cff`, PDF command examples, and release-manifest tests on `v2026.09.04`

## Verification
- `python scripts/release_manifest.py validate --strict-urls --version v2026.09.04`
- `python -m pytest scripts -q -p no:cacheprovider` → 1093 passed, 1 skipped
- independent code-reviewer: APPROVE, P0–P3 none

## Maintainer gate
The release workflow still performs full content, PDF, and publication checks before publishing.