### PR TITLE
docs(resources): mark Graphthulhu as archived

### DIFF
--- a/release/notes.yml
+++ b/release/notes.yml
@@ -24,3 +24,11 @@ changes:
       - https://api-docs.deepseek.com/quick_start/pricing/
       - https://cloud.tencent.com/document/product/1823/130051
       - https://huggingface.co/MiniMaxAI/MiniMax-M3
+
+  - id: graphthulhu-archived-resource
+    category: resources
+    zh-TW: MCP 資源表將已封存的 Graphthulhu 改列為歷史學習範例。原有 ⭐⭐⭐ 編輯推薦度保留，但清楚提醒新專案應選擇仍在維護的替代方案。
+    zh-Hans: MCP 资源表将已归档的 Graphthulhu 改列为历史学习范例。原有 ⭐⭐⭐ 编辑推荐度保留，但清楚提醒新项目应选择仍在维护的替代方案。
+    en: The MCP catalog now marks the archived Graphthulhu project as a historical learning example. Its ⭐⭐⭐ editorial rating remains visible, with a clear note that new projects should choose a maintained alternative.
+    links:
+      - https://github.com/skridlevsky/graphthulhu

--- a/resources/mcp-skills-catalog.en.md
+++ b/resources/mcp-skills-catalog.en.md
@@ -115,16 +115,16 @@ Installation and testing belong in [Stage 5](../stages/05-claude-code-ecosystem.
 **Audience**: Logseq users automating daily journals, cross-page links, backlink queries.
 **Notes**: enable Logseq's HTTP API (Settings → Features → HTTP API).
 
-### [skridlevsky/graphthulhu](https://github.com/skridlevsky/graphthulhu) ⭐⭐⭐
+### [skridlevsky/graphthulhu](https://github.com/skridlevsky/graphthulhu) ⭐⭐⭐ (archived / historical example)
 
 | Field | Value |
 |---|---|
 | License | MIT |
-| Rating | ⭐⭐⭐ (covers both Logseq + Obsidian) |
+| Rating | ⭐⭐⭐ (historical learning value; archived, so new projects should not start with it) |
 
 **What it does**: a broad tool set across navigation, search, analysis, writing, journals, flashcards, whiteboards.
-**Audience**: people using both Logseq and Obsidian who don't want two MCP servers.
-**Notes**: community project; broad tool surface but each tool is relatively basic.
+**Audience**: people studying early Logseq + Obsidian MCP design; new projects should choose a maintained alternative.
+**Notes**: this GitHub project is archived and is useful as historical reference; do not use it as the starting point for a new project.
 
 ### [ankimcp/anki-mcp-server](https://github.com/ankimcp/anki-mcp-server) ⭐⭐⭐
 

--- a/resources/mcp-skills-catalog.md
+++ b/resources/mcp-skills-catalog.md
@@ -116,16 +116,16 @@
 **適合誰**：Logseq 使用者要自動化 daily journal、跨頁 link、查詢 backlinks。
 **備註**：需要 Logseq 開啟 HTTP API（Settings → Features → HTTP API）。
 
-### [skridlevsky/graphthulhu](https://github.com/skridlevsky/graphthulhu) ⭐⭐⭐
+### [skridlevsky/graphthulhu](https://github.com/skridlevsky/graphthulhu) ⭐⭐⭐（已封存／歷史範例）
 
 | 欄位 | 內容 |
 |---|---|
 | License | MIT |
-| 推薦度 | ⭐⭐⭐（同時支援 Logseq + Obsidian） |
+| 推薦度 | ⭐⭐⭐（歷史學習價值；已封存，新專案不建議從它開始） |
 
 **教什麼**：把 navigation、search、analysis、writing、journals、flashcards 與 whiteboards 等操作包成工具。
-**適合誰**：同時用 Logseq 跟 Obsidian、不想裝兩套 MCP server 的人。
-**備註**：community project，工具數多但每個工具相對基本。
+**適合誰**：想研究早期 Logseq + Obsidian MCP 設計的人；新專案應改找仍在維護的替代方案。
+**備註**：此 GitHub 專案已封存，適合當歷史參考；不要用它作為新專案的起點。
 
 ### [ankimcp/anki-mcp-server](https://github.com/ankimcp/anki-mcp-server) ⭐⭐⭐
 

--- a/resources/mcp-skills-catalog.zh-Hans.md
+++ b/resources/mcp-skills-catalog.zh-Hans.md
@@ -114,16 +114,16 @@
 **适合谁**：Logseq 用户要自动化 daily journal、跨页 link、查询 backlinks。
 **备注**：需要 Logseq 开启 HTTP API（Settings → Features → HTTP API）。
 
-### [skridlevsky/graphthulhu](https://github.com/skridlevsky/graphthulhu) ⭐⭐⭐
+### [skridlevsky/graphthulhu](https://github.com/skridlevsky/graphthulhu) ⭐⭐⭐（已归档／历史范例）
 
 | 栏位 | 内容 |
 |---|---|
 | License | MIT |
-| 推荐度 | ⭐⭐⭐（同时支持 Logseq + Obsidian） |
+| 推荐度 | ⭐⭐⭐（历史学习价值；已归档，新项目不建议从它开始） |
 
 **教什么**：一组 tool，覆盖 navigation、search、analysis、writing、journals、flashcards、whiteboards。
-**适合谁**：同时用 Logseq 跟 Obsidian、不想装两套 MCP server 的人。
-**备注**：community project，工具数多但每个工具相对基本。
+**适合谁**：想研究早期 Logseq + Obsidian MCP 设计的人；新项目应改找仍在维护的替代方案。
+**备注**：此 GitHub 项目已归档，适合当历史参考；不要用它作为新项目的起点。
 
 ### [ankimcp/anki-mcp-server](https://github.com/ankimcp/anki-mcp-server) ⭐⭐⭐
 


### PR DESCRIPTION
## Summary
- mark archived Graphthulhu as a historical MCP learning example in all three languages
- preserve the ⭐⭐⭐ editorial rating while warning new projects to choose maintained alternatives
- add the correction to the `v2026.09.04` trilingual release notes

## Why
The release Content Health gate correctly blocked publication because GitHub now marks this repository archived while two locale pages still described it as current.

## Verification
- GitHub API: `archived=true`
- full repository scan: Graphthulhu hard failures reduced from 2 to 0
- mirror parity and zh-Hans residue checks passed
- `python -m pytest scripts -q -p no:cacheprovider` → 1093 passed, 1 skipped
- `python -m mkdocs build` passed
- independent code-reviewer: APPROVE, P0–P3 none