### PR TITLE
docs: add Awesome WorkBuddy directory

### DIFF
--- a/RESOURCES.en.md
+++ b/RESOURCES.en.md
@@ -91,6 +91,7 @@ The table below shows selected projects and official entry points directly. Star
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers): browse community Servers by category; review before installing.
 - [hesreallyhim/awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code): Claude Code community resources.
 - [travisvn/awesome-claude-skills](https://github.com/travisvn/awesome-claude-skills): Agent Skills community list.
+- [Awesome WorkBuddy](https://github.com/sandbaseai/awesome-workbuddy): a CC0 bilingual WorkBuddy resource directory covering Skills, MCP, workflows, and harness references with license, provenance, permission, and data-flow notes; each indexed project still requires its own review.
 - [Canva MCP](https://www.canva.dev/docs/mcp/): official remote MCP; features, plans, and permissions depend on the account, so no fixed tool count is stated.
 - [Course list](resources/courses.en.md): choose courses by learning goal; a certificate is not a degree.
 - [Agent paradigms](resources/agent-paradigms.en.md): compare common Agent shapes with diagrams.

--- a/RESOURCES.md
+++ b/RESOURCES.md
@@ -91,6 +91,7 @@
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers)：依分類瀏覽社群 Server；安裝前自行審查。
 - [hesreallyhim/awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code)：Claude Code 社群資源。
 - [travisvn/awesome-claude-skills](https://github.com/travisvn/awesome-claude-skills)：Agent Skills 社群清單。
+- [Awesome WorkBuddy](https://github.com/sandbaseai/awesome-workbuddy)：CC0 雙語 WorkBuddy 資源目錄，按許可、來源、權限與資料流補充 Skills、MCP、工作流和 harness 參考；各外部專案仍需自行審查。
 - [Canva MCP](https://www.canva.dev/docs/mcp/)：官方 remote MCP；功能、方案與權限依帳號而異，不先記固定工具數。
 - [課程清單](resources/courses.md)：按學習目標挑課程，不把證書當成學位。
 - [Agent paradigms](resources/agent-paradigms.md)：用圖比較常見 Agent 形狀。


### PR DESCRIPTION
## Summary
- add the CC0 bilingual Awesome WorkBuddy directory to the related resource lists
- describe its WorkBuddy-specific Skills, MCP, workflows, and harness references
- retain the independent-project and per-resource review caveat

This follows issue #248 and the repository contribution guide.

## Verification
- git diff --check
- focused repository checks: 79 passed
- full pytest collection is not available in this environment because optional example dependencies (anthropic, crewai, smolagents) are not installed and several example modules share test names; this PR only changes Markdown resource lists.
